### PR TITLE
Use "connection" instead of "warehouse"

### DIFF
--- a/docs/warehouse.md
+++ b/docs/warehouse.md
@@ -42,7 +42,7 @@ version control.
 For example:
 ```yaml
 name: my_project_postgres
-warehouse:
+connection:
   type: postgres
   host: localhost
   username: env_var(POSTGRES_USERNAME)

--- a/docs/warehouse_types.md
+++ b/docs/warehouse_types.md
@@ -36,7 +36,7 @@ Example
 
 ```yaml
 name: my_athena_project
-warehouse:
+connection:
     type: athena
     database: sodalite_test
     access_key_id: env_var(AWS_ACCESS_KEY_ID)
@@ -51,7 +51,7 @@ warehouse:
 
 ```yaml
 name: my_bigquery_project
-warehouse:
+connection:
     type: bigquery
     account_info: <PATH TO YOUR BIGQUERY ACCOUNT INFO JSON FILE>
     dataset: sodasql
@@ -62,7 +62,7 @@ warehouse:
 
 ```yaml
 name: my_postgres_project
-warehouse:
+connection:
     type: postgres
     host: localhost
     username: sodasql
@@ -76,7 +76,7 @@ warehouse:
 
 ```yaml
 name: my_redshift_project
-warehouse:
+connection:
     type: redshift
     host: <YOUR AWS REDSHIFT HOSTNAME>
     username: soda


### PR DESCRIPTION
Soda SQL doesn't work when you provide "warehouse" instead of "connection" as key to the warehouse.yml file.