### PR TITLE
Handle missing data source.

### DIFF
--- a/soda/core/soda/common/log.py
+++ b/soda/core/soda/common/log.py
@@ -63,10 +63,13 @@ class Log:
             exception_str = indent(text=exception_str, prefix="  | ")
             logger.log(python_log_level, exception_str)
             # Logging the stack trace
-            stacktrace = get_exception_stacktrace(self.exception)
-            indented_stacktrace = indent(text=stacktrace, prefix="  | ")
-            logger.log(python_log_level, f"  | Stacktrace:")
-            logger.log(python_log_level, indented_stacktrace)
+            from soda.scan import verbose
+
+            if verbose:
+                stacktrace = get_exception_stacktrace(self.exception)
+                indented_stacktrace = indent(text=stacktrace, prefix="  | ")
+                logger.log(python_log_level, f"  | Stacktrace:")
+                logger.log(python_log_level, indented_stacktrace)
         if self.level in [LogLevel.WARNING, LogLevel.ERROR] and self.location is not None:
             logger.log(python_log_level, f"  +-> {self.location}")
         if isinstance(self.doc, str):

--- a/soda/core/soda/execution/data_source_manager.py
+++ b/soda/core/soda/execution/data_source_manager.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+from soda.common.exceptions import DataSourceConnectionError
 from soda.execution.data_source import DataSource
 
 
@@ -52,8 +53,8 @@ class DataSourceManager:
                                     data_source = None
                         else:
                             self.logs.error(f'Data source "{data_source_name}" does not have a type')
-                    else:
-                        self.logs.error(f'Data source "{data_source_name}" not in the configuration')
+            else:
+                raise DataSourceConnectionError(f"Data source '{data_source_name}' not present in the configuration.")
 
         return data_source
 

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -20,6 +20,7 @@ from soda.sodacl.location import Location
 from soda.sodacl.sodacl_cfg import SodaCLCfg
 
 logger = logging.getLogger(__name__)
+verbose = False
 
 
 class Scan:
@@ -59,8 +60,10 @@ class Scan:
         """
         self._scan_definition_name = scan_definition_name
 
-    def set_verbose(self, verbose: bool = True):
-        self._logs.verbose = verbose
+    def set_verbose(self, verbose_var: bool = True):
+        self._logs.verbose = verbose_var
+        global verbose
+        verbose = verbose_var
 
     def add_configuration_yaml_file(self, file_path: str):
         """
@@ -417,7 +420,7 @@ class Scan:
                 self._configuration.soda_cloud.send_scan_results(self)
 
         except Exception as e:
-            self._logs.error(f"Unknown error while executing scan.", exception=e)
+            self._logs.error(f"Error occurred while executing scan.", exception=e)
         finally:
             self._close()
 


### PR DESCRIPTION
Introduces a global `verbose` variable in the scan file so that we can use verbosity level anywhere in the codebase.

Also changes the global behaviour of logging errors with exceptions, prints the stacktrace only in verbose mode (globally).

Fix #1169