### PR TITLE
Handle invalid data source type

### DIFF
--- a/soda/core/soda/common/exceptions.py
+++ b/soda/core/soda/common/exceptions.py
@@ -9,6 +9,12 @@ class SodaSqlError(Exception):
         self.original_exception = original_exception
 
 
+class DataSourceError(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)
+        self.error_code = ERROR_CODE_CONNECTION_FAILED
+
+
 class DataSourceConnectionError(SodaSqlError):
     def __init__(self, data_source_type, original_exception):
         super().__init__(

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -8,6 +8,7 @@ import re
 from datetime import date, datetime
 from numbers import Number
 
+from soda.common.exceptions import DataSourceError
 from soda.common.logs import Logs
 from soda.execution.data_type import DataType
 from soda.execution.partition_queries import PartitionQueries
@@ -78,8 +79,8 @@ class DataSource:
             if connection_type == "postgresql":
                 logs.error(f'Data source type "{connection_type}" not found. Did you mean postgres?')
             else:
-                logs.error(
-                    f'Data source type "{connection_type}" not found. Did you spell {connection_type} correct?  Did you install module soda-core-{connection_type}?'
+                raise DataSourceError(
+                    f'Data source type "{connection_type}" not found. Did you spell {connection_type} correct? Did you install module soda-core-{connection_type}?'
                 )
             return None
 

--- a/soda/core/soda/execution/data_source_manager.py
+++ b/soda/core/soda/execution/data_source_manager.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from soda.common.exceptions import DataSourceConnectionError
+from soda.common.exceptions import DataSourceError
 from soda.execution.data_source import DataSource
 
 
@@ -54,7 +54,7 @@ class DataSourceManager:
                         else:
                             self.logs.error(f'Data source "{data_source_name}" does not have a type')
             else:
-                raise DataSourceConnectionError(f"Data source '{data_source_name}' not present in the configuration.")
+                raise DataSourceError(f"Data source '{data_source_name}' not present in the configuration.")
 
         return data_source
 

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -633,7 +633,12 @@ class Scan:
             raise AssertionError(self.get_logs_text())
 
     def assert_has_error(self, expected_error_message: str):
-        if all([expected_error_message not in log.message for log in self.get_error_logs()]):
+        if all(
+            [
+                expected_error_message not in log.message and expected_error_message not in str(log.exception)
+                for log in self.get_error_logs()
+            ]
+        ):
             raise AssertionError(
                 f'Expected error message "{expected_error_message}" did not occur in the error logs:\n{self.get_logs_text()}'
             )


### PR DESCRIPTION
Switch from log to exception to halt the execution early.

Fix #1197