### PR TITLE
Cloud: timestamps use seconds resolution

### DIFF
--- a/soda/core/soda/common/json_helper.py
+++ b/soda/core/soda/common/json_helper.py
@@ -54,7 +54,7 @@ class JsonHelper:
         if isinstance(o, Decimal):
             return float(o)
         if isinstance(o, datetime.datetime):
-            return o.isoformat()
+            return o.isoformat(timespec="seconds")
         if isinstance(o, datetime.date):
             return o.strftime("%Y-%m-%d")
         if isinstance(o, datetime.time):


### PR DESCRIPTION
Note: Changes timestamp resolution to seconds on all json serialized datetime instances.

Fix #1298