### PR TITLE
fix: provide docker image with soda-scientific packaged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.8-bullseye
 
-
 # Remove after direct git reference to Prophet is removed.
 RUN apt-get update && apt-get -y install git
+
 RUN mkdir /app
 
 WORKDIR /app
 
+RUN pip install --upgrade pip
+
 COPY . .
+
 RUN pip install "$(cat dev-requirements.in | grep pip-tools)" && \
     pip install -r dev-requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM python:3.10-slim
+FROM python:3.8-bullseye
+
 
 # Remove after direct git reference to Prophet is removed.
 RUN apt-get update && apt-get -y install git
-
 RUN mkdir /app
 
 WORKDIR /app
 
-RUN pip install --upgrade pip
-
 COPY . .
-
 RUN pip install "$(cat dev-requirements.in | grep pip-tools)" && \
     pip install -r dev-requirements.txt
 


### PR DESCRIPTION
Should resolve: https://sodadata.atlassian.net/browse/SODA-154

This base image was advised by the `pystan` community that runs this package on docker containers. Forgot the links.

I tested that `Prophet` is importable and fits a model so I'm 99% sure that this should allow the agent to run a version of soda-core with the scientific library package.

This could also be something that we offer to users who want to run soda-core locally but are struggling with installing it in their systems. At least until a new version of `prophet` with changes in dependencies is shipped by the prophet devs.