### PR TITLE
refactor: remove darts dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-bullseye
+FROM python:3.9-bullseye
 
 # Remove after direct git reference to Prophet is removed.
 RUN apt-get update && apt-get -y install git

--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -15,6 +15,7 @@ requires = [
     f"soda-core=={package_version}",
     "wheel",
     "pydantic>=1.8.1,<2.0.0",
+    "scipy>=1.8.0",
     "inflection==0.5.1",
     "httpx>=0.18.1,<2.0.0",
     "PyYAML>=5.4.1,<6.0.0",

--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -14,7 +14,6 @@ description = "Soda Core Scientific Package"
 requires = [
     f"soda-core=={package_version}",
     "wheel",
-    "u8darts>=0.7.0,<1.0.0",
     "pydantic>=1.8.1,<2.0.0",
     "inflection==0.5.1",
     "httpx>=0.18.1,<2.0.0",


### PR DESCRIPTION
Removes the `darts` dependency which will make installing the scientific package a bit lighter and remove at least some potentially annoying-to-install dependencies. 

This addresses: https://sodadata.atlassian.net/browse/SODA-461 but only as a partial elimination of issues