### PR TITLE
Refactored to actual table and actual column names

### DIFF
--- a/soda/athena/soda/data_sources/athena_data_source.py
+++ b/soda/athena/soda/data_sources/athena_data_source.py
@@ -99,7 +99,7 @@ class DataSourceImpl(DataSource):
         return "table_schema"
 
     @staticmethod
-    def format_column_default(identifier: str) -> str:
+    def actual_column_name(identifier: str) -> str:
         return identifier.lower()
 
     def get_metric_sql_aggregation_expression(self, metric_name: str, metric_args: list[object] | None, expr: str):

--- a/soda/bigquery/soda/data_sources/bigquery_data_source.py
+++ b/soda/bigquery/soda/data_sources/bigquery_data_source.py
@@ -185,7 +185,7 @@ class DataSourceImpl(DataSource):
         return f"{self.project_id}.{self.dataset_name}.INFORMATION_SCHEMA.TABLES"
 
     @staticmethod
-    def format_type_default(identifier: str) -> str:
+    def actual_type_name(identifier: str) -> str:
         return identifier.upper()
 
     def safe_connection_data(self):

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -654,12 +654,17 @@ class DataSource:
         return self.data_source_scan
 
     @staticmethod
-    def format_column_default(identifier: str) -> str:
+    def actual_table_name(identifier: str) -> str:
+        """Formats table identifier to e.g. a default case for a given data source."""
+        return identifier
+
+    @staticmethod
+    def actual_column_name(identifier: str) -> str:
         """Formats column identifier to e.g. a default case for a given data source."""
         return identifier
 
     @staticmethod
-    def format_type_default(identifier: str) -> str:
+    def actual_type_name(identifier: str) -> str:
         """Formats type identifier to e.g. a default case for a given data source."""
         return identifier
 

--- a/soda/core/tests/cli/test_cli_update_distribution_file.py
+++ b/soda/core/tests/cli/test_cli_update_distribution_file.py
@@ -8,7 +8,7 @@ from tests.helpers.scanner import Scanner
 
 
 # TODO: add some tests that can assert the generated query
-@pytest.mark.skip("test takes too long")
+# @pytest.mark.skip("test takes too long")
 def test_cli_update_distribution_file(scanner: Scanner, mock_file_system: MockFileSystem, data_source_config_str: str):
     table_name = scanner.ensure_test_table(customers_test_table)
 

--- a/soda/core/tests/data_source/test_schema_column_types.py
+++ b/soda/core/tests/data_source/test_schema_column_types.py
@@ -36,14 +36,12 @@ def test_columns_types_fail(scanner: Scanner):
         indent=15,
         data_source=scanner.data_source,
     )
-    table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
-    format_type_default = scanner.data_source.format_type_default
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             fail:
               when wrong column type:
@@ -55,10 +53,10 @@ def test_columns_types_fail(scanner: Scanner):
     check = scan._checks[0]
 
     assert check.outcome == CheckOutcome.FAIL
-    assert check.schema_missing_column_names == [format_column_default("does_not_exist")]
+    assert check.schema_missing_column_names == [scanner.actual_column_name("does_not_exist")]
     assert check.schema_column_type_mismatches == {
-        format_column_default("id"): {
-            "expected_type": format_type_default("integer"),
+        scanner.actual_column_name("id"): {
+            "expected_type": scanner.actual_type_name("integer"),
             "actual_type": scanner.data_source.get_sql_type_for_schema_check(DataType.TEXT),
         }
     }
@@ -70,14 +68,12 @@ def test_columns_types_warn(scanner: Scanner):
         indent=15,
         data_source=scanner.data_source,
     )
-    format_column_default = scanner.data_source.format_column_default
-    format_type_default = scanner.data_source.format_type_default
-    table_name = scanner.ensure_test_table(customers_test_table)
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             warn:
               when wrong column type:
@@ -89,10 +85,10 @@ def test_columns_types_warn(scanner: Scanner):
     check = scan._checks[0]
 
     assert check.outcome == CheckOutcome.WARN
-    assert check.schema_missing_column_names == [format_column_default("does_not_exist")]
+    assert check.schema_missing_column_names == [scanner.actual_column_name("does_not_exist")]
     assert check.schema_column_type_mismatches == {
-        format_column_default("id"): {
-            "expected_type": format_type_default("integer"),
+        scanner.actual_column_name("id"): {
+            "expected_type": scanner.actual_type_name("integer"),
             "actual_type": scanner.data_source.get_sql_type_for_schema_check(DataType.TEXT),
         }
     }

--- a/soda/core/tests/data_source/test_schema_forbidden_columns.py
+++ b/soda/core/tests/data_source/test_schema_forbidden_columns.py
@@ -4,16 +4,16 @@ from tests.helpers.scanner import Scanner
 
 
 def test_forbidden_columns_pass(scanner: Scanner):
-    table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
+    actual_column_name = scanner.actual_column_name
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             fail:
-              when forbidden column present: [{format_column_default('non_existing_column_one')}, {format_column_default('"%non_existing%"')}]
+              when forbidden column present: [{actual_column_name('non_existing_column_one')}, {actual_column_name('"%non_existing%"')}]
     """
     )
     scan.execute()
@@ -22,38 +22,38 @@ def test_forbidden_columns_pass(scanner: Scanner):
 
 
 def test_forbidden_columns_fail(scanner: Scanner):
-    table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
+    actual_column_name = scanner.actual_column_name
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             fail:
-              when forbidden column present: [{format_column_default('id')}, {format_column_default('non_existing_column_one')}, {format_column_default('"%non_existing%"')}]
+              when forbidden column present: [{actual_column_name('id')}, {actual_column_name('non_existing_column_one')}, {actual_column_name('"%non_existing%"')}]
     """
     )
     scan.execute()
 
     scan.assert_all_checks_fail()
     check: SchemaCheck = scan._checks[0]
-    assert sorted(check.schema_present_column_names) == sorted([format_column_default("id")])
+    assert sorted(check.schema_present_column_names) == sorted([actual_column_name("id")])
 
 
 def test_forbidden_columns_fail_matching_wildcard(scanner: Scanner):
-    table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
+    actual_column_name = scanner.actual_column_name
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             fail:
               when forbidden column present:
-               - {format_column_default('size*')}
-               - {format_column_default('non_existing_column_two')}
+               - {actual_column_name('size*')}
+               - {actual_column_name('non_existing_column_two')}
     """
     )
     scan.execute()
@@ -61,25 +61,25 @@ def test_forbidden_columns_fail_matching_wildcard(scanner: Scanner):
     scan.assert_all_checks_fail()
     check: SchemaCheck = scan._checks[0]
     assert sorted(check.schema_present_column_names) == sorted(
-        [format_column_default("size"), format_column_default("sizeTxt")]
+        [actual_column_name("size"), actual_column_name("sizeTxt")]
     )
 
 
 def test_forbidden_columns_warn(scanner: Scanner):
-    table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_table_name = scanner.ensure_test_table(customers_test_table)
+    actual_column_name = scanner.data_source.actual_column_name
 
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
-      checks for {table_name}:
+      checks for {actual_table_name}:
         - schema:
             warn:
-              when forbidden column present: [{format_column_default('id')}, {format_column_default('non_existing_column_one')}, {format_column_default('"%non_existing%"')}]
+              when forbidden column present: [{actual_column_name('id')}, {actual_column_name('non_existing_column_one')}, {actual_column_name('"%non_existing%"')}]
     """
     )
     scan.execute()
 
     scan.assert_all_checks_warn()
     check: SchemaCheck = scan._checks[0]
-    assert sorted(check.schema_present_column_names) == sorted([format_column_default("id")])
+    assert sorted(check.schema_present_column_names) == sorted([actual_column_name("id")])

--- a/soda/core/tests/data_source/test_schema_index.py
+++ b/soda/core/tests/data_source/test_schema_index.py
@@ -30,7 +30,7 @@ def test_required_columns_indexes_pass(scanner: Scanner):
 
 def test_required_columns_indexes_fail(scanner: Scanner):
     table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_column_name = scanner.data_source.actual_column_name
     checks_str = format_checks(
         [("id", "6"), ("sizeTxt", "3"), ("distance", "4")],
         indent=15,
@@ -52,19 +52,19 @@ def test_required_columns_indexes_fail(scanner: Scanner):
     scan.assert_all_checks_fail()
     check: SchemaCheck = scan._checks[0]
     assert check.schema_column_index_mismatches == {
-        format_column_default("distance"): {
+        actual_column_name("distance"): {
             "actual_index": 3,
-            "column_on_expected_index": format_column_default("pct"),
+            "column_on_expected_index": actual_column_name("pct"),
             "expected_index": 4,
         },
-        format_column_default("id"): {
+        actual_column_name("id"): {
             "actual_index": 0,
-            "column_on_expected_index": format_column_default("country"),
+            "column_on_expected_index": actual_column_name("country"),
             "expected_index": 6,
         },
-        format_column_default("sizeTxt"): {
+        actual_column_name("sizeTxt"): {
             "actual_index": 2,
-            "column_on_expected_index": format_column_default("distance"),
+            "column_on_expected_index": actual_column_name("distance"),
             "expected_index": 3,
         },
     }
@@ -72,7 +72,7 @@ def test_required_columns_indexes_fail(scanner: Scanner):
 
 def test_required_columns_indexes_warn(scanner: Scanner):
     table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_column_name = scanner.data_source.actual_column_name
     checks_str = format_checks(
         [("id", "6"), ("sizeTxt", "3"), ("distance", "4")],
         indent=15,
@@ -94,19 +94,19 @@ def test_required_columns_indexes_warn(scanner: Scanner):
     scan.assert_all_checks_warn()
     check: SchemaCheck = scan._checks[0]
     assert check.schema_column_index_mismatches == {
-        format_column_default("distance"): {
+        actual_column_name("distance"): {
             "actual_index": 3,
-            "column_on_expected_index": format_column_default("pct"),
+            "column_on_expected_index": actual_column_name("pct"),
             "expected_index": 4,
         },
-        format_column_default("id"): {
+        actual_column_name("id"): {
             "actual_index": 0,
-            "column_on_expected_index": format_column_default("country"),
+            "column_on_expected_index": actual_column_name("country"),
             "expected_index": 6,
         },
-        format_column_default("sizeTxt"): {
+        actual_column_name("sizeTxt"): {
             "actual_index": 2,
-            "column_on_expected_index": format_column_default("distance"),
+            "column_on_expected_index": actual_column_name("distance"),
             "expected_index": 3,
         },
     }

--- a/soda/core/tests/data_source/test_schema_required_columns.py
+++ b/soda/core/tests/data_source/test_schema_required_columns.py
@@ -7,14 +7,14 @@ from tests.helpers.utils import format_checks
 def test_required_columns_pass(scanner: Scanner):
     table_name = scanner.ensure_test_table(customers_test_table)
 
-    format_column_default = scanner.data_source.format_column_default
+    actual_column_name = scanner.data_source.actual_column_name
     scan = scanner.create_test_scan()
     scan.add_sodacl_yaml_str(
         f"""
       checks for {table_name}:
         - schema:
             fail:
-              when required column missing: [{format_column_default('id')}, {format_column_default('sizeTxt')}, {format_column_default('distance')}]
+              when required column missing: [{actual_column_name('id')}, {actual_column_name('sizeTxt')}, {actual_column_name('distance')}]
     """
     )
     scan.execute()
@@ -24,7 +24,7 @@ def test_required_columns_pass(scanner: Scanner):
 
 def test_required_columns_fail(scanner: Scanner):
     table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_column_name = scanner.data_source.actual_column_name
 
     scan = scanner.create_test_scan()
     checks_str = format_checks(
@@ -47,13 +47,13 @@ def test_required_columns_fail(scanner: Scanner):
     scan.assert_all_checks_fail()
     check: SchemaCheck = scan._checks[0]
     assert sorted(check.schema_missing_column_names) == sorted(
-        [format_column_default("non_existing_column"), format_column_default("name")]
+        [actual_column_name("non_existing_column"), actual_column_name("name")]
     )
 
 
 def test_required_columns_warn(scanner: Scanner):
     table_name = scanner.ensure_test_table(customers_test_table)
-    format_column_default = scanner.data_source.format_column_default
+    actual_column_name = scanner.data_source.actual_column_name
 
     scan = scanner.create_test_scan()
     checks_str = format_checks(
@@ -76,5 +76,5 @@ def test_required_columns_warn(scanner: Scanner):
     scan.assert_all_checks_warn()
     check: SchemaCheck = scan._checks[0]
     assert sorted(check.schema_missing_column_names) == sorted(
-        [format_column_default("non_existing_column"), format_column_default("name")]
+        [actual_column_name("non_existing_column"), actual_column_name("name")]
     )

--- a/soda/core/tests/helpers/common_test_tables.py
+++ b/soda/core/tests/helpers/common_test_tables.py
@@ -105,7 +105,7 @@ orders_test_table = TestTable(
 
 raw_customers_test_table = TestTable(
     name="RAWCUSTOMERS",
-    columns=customers_test_table.columns,
+    columns=customers_test_table.test_columns,
     values=customers_test_table.values,
 )
 

--- a/soda/core/tests/helpers/scanner.py
+++ b/soda/core/tests/helpers/scanner.py
@@ -194,3 +194,12 @@ class Scanner:
             return cursor.fetchone()
         finally:
             cursor.close()
+
+    def actual_table_name(self, identifier: str) -> str:
+        return self.data_source.actual_table_name(identifier)
+
+    def actual_column_name(self, identifier: str) -> str:
+        return self.data_source.actual_column_name(identifier)
+
+    def actual_type_name(self, identifier: str) -> str:
+        return self.data_source.actual_type_name(identifier)

--- a/soda/core/tests/helpers/test_column.py
+++ b/soda/core/tests/helpers/test_column.py
@@ -1,0 +1,19 @@
+from soda.execution.data_type import DataType
+
+
+class TestColumn:
+
+    def __init__(self, name: str, data_type: DataType):
+        self.name: str = name
+        self.data_type: DataType = data_type
+        # self.actual_name is the actual name in the data source and it is initialized in the TestTableManager.ensure_test_table
+        self.actual_name: str = None
+
+    def __hash__(self):
+        return
+
+    def to_hashable_json(self):
+        """
+        Used to create the unique hash part in the table name to determine if the table already exists.
+        """
+        return [self.name, self.data_type]

--- a/soda/core/tests/helpers/test_table.py
+++ b/soda/core/tests/helpers/test_table.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+from typing import List
 
 from soda.common.json_helper import JsonHelper
 from soda.execution.data_type import DataType
+from tests.helpers.test_column import TestColumn
 
 
 class TestTable:
@@ -19,7 +21,7 @@ class TestTable:
     def __init__(
         self,
         name: str,
-        columns: list[tuple[str, DataType]],
+        columns: list[tuple[str, DataType]] | list[TestColumn],
         values: list[tuple] = None,
         quote_names: bool = False,
     ):
@@ -34,16 +36,22 @@ class TestTable:
         TestTable.__names.append(name)
 
         self.name: str = name
-        self.columns: list[tuple[str, DataType]] = columns
+        if len(columns) == 0 or isinstance(columns[0], TestColumn):
+            self.test_columns: List[TestColumn] = columns
+        else:
+            self.test_columns: List[TestColumn] = [TestColumn(column[0], column[1]) for column in columns]
+
         self.values: list[tuple] = values
         self.quote_names: bool = quote_names
         self.unique_table_name = f"SODATEST_{name}_{self.__test_table_hash()}"
+        # self.actual_name is the actual name in the data source and it is initialized in the TestTableManager.ensure_test_table
+        self.actual_name = None
 
     def __test_table_hash(self):
         json_text = JsonHelper.to_json(
             [
                 self.name,
-                list(self.columns),
+                [test_column.to_hashable_json() for test_column in self.test_columns],
                 list(self.values) if self.values else None,
             ]
         )

--- a/soda/core/tests/helpers/test_table_manager.py
+++ b/soda/core/tests/helpers/test_table_manager.py
@@ -38,6 +38,11 @@ class TestTableManager:
 
             # Run analyze table so that metadata works if applicable.
             self.data_source.analyze_table(test_table.unique_table_name)
+
+        # initializing the actual namees
+        test_table.actual_name = self.data_source.actual_table_name(test_table.unique_table_name)
+        for test_column in test_table.test_columns:
+            test_column.actual_name = self.data_source.actual_column_name(test_column.name)
         return test_table.unique_table_name
 
     def _get_existing_test_table_names(self):
@@ -69,17 +74,17 @@ class TestTableManager:
             else test_table.unique_table_name
         )
         prefixed_table_name = self.data_source.prefix_table(quoted_table_name)
-        columns = test_table.columns
+        test_columns = test_table.test_columns
         if test_table.quote_names:
-            columns = [
+            test_columns = [
                 (
-                    self.data_source.quote_column_declaration(column[0]),
-                    column[1],
+                    self.data_source.quote_column_declaration(test_column.name),
+                    test_column.data_type,
                 )
-                for column in columns
+                for test_column in test_columns
             ]
         columns_sql = ",\n".join(
-            [f"  {column[0]} {self.data_source.get_sql_type_for_create_table(column[1])}" for column in columns]
+            [f"  {test_column.name} {self.data_source.get_sql_type_for_create_table(test_column.data_type)}" for test_column in test_columns]
         )
 
         sql = f"CREATE TABLE {prefixed_table_name} ( \n{columns_sql} \n)"

--- a/soda/core/tests/helpers/utils.py
+++ b/soda/core/tests/helpers/utils.py
@@ -8,11 +8,11 @@ def format_checks(checks: list, prefix: str = "", indent: int = 0, data_source: 
     checks_str = ""
     for check in checks:
         if isinstance(check, tuple):
-            identifier = data_source.format_column_default(check[0]) if data_source else check[0]
-            type = data_source.format_type_default(check[1]) if data_source else check[1]
+            identifier = data_source.actual_column_name(check[0]) if data_source else check[0]
+            type = data_source.actual_type_name(check[1]) if data_source else check[1]
             checks_str += f"{indent_str}{prefix} {identifier}: {type}\n"
         elif isinstance(check, str):
-            identifier = data_source.format_column_default(check) if data_source else check
+            identifier = data_source.actual_column_name(check) if data_source else check
             checks_str += f"{indent_str}{prefix} {identifier}\n"
 
     return checks_str
@@ -21,8 +21,8 @@ def format_checks(checks: list, prefix: str = "", indent: int = 0, data_source: 
 def derive_schema_metric_value_from_test_table(test_table, data_source: DataSource):
     return [
         {
-            "columnName": data_source.format_column_default(column[0]),
-            "sourceDataType": data_source.get_sql_type_for_schema_check(column[1]),
+            "columnName": data_source.actual_column_name(test_column.name),
+            "sourceDataType": data_source.get_sql_type_for_schema_check(test_column.data_type),
         }
-        for column in test_table.columns
+        for test_column in test_table.test_columns
     ]

--- a/soda/postgres/soda/data_sources/postgres_data_source.py
+++ b/soda/postgres/soda/data_sources/postgres_data_source.py
@@ -53,11 +53,11 @@ class DataSourceImpl(DataSource):
         return super().get_metric_sql_aggregation_expression(metric_name, metric_args, expr)
 
     @staticmethod
-    def format_column_default(identifier: str) -> str:
+    def actual_column_name(identifier: str) -> str:
         return identifier.lower()
 
     @staticmethod
-    def format_type_default(identifier: str) -> str:
+    def actual_type_name(identifier: str) -> str:
         return identifier.lower()
 
     def safe_connection_data(self):

--- a/soda/redshift/soda/data_sources/redshift_data_source.py
+++ b/soda/redshift/soda/data_sources/redshift_data_source.py
@@ -106,11 +106,11 @@ class DataSourceImpl(DataSource):
         return ""
 
     @staticmethod
-    def format_column_default(identifier: str) -> str:
+    def actual_column_name(identifier: str) -> str:
         return identifier.lower()
 
     @staticmethod
-    def format_type_default(identifier: str) -> str:
+    def actual_type_name(identifier: str) -> str:
         return identifier.lower()
 
     def safe_connection_data(self):

--- a/soda/snowflake/soda/data_sources/snowflake_data_source.py
+++ b/soda/snowflake/soda/data_sources/snowflake_data_source.py
@@ -123,11 +123,11 @@ class DataSourceImpl(DataSource):
         return f"SELECT table_name, row_count \n" f"FROM information_schema.tables" f"{where_clause}"
 
     @staticmethod
-    def format_column_default(identifier: str) -> str:
+    def actual_column_name(identifier: str) -> str:
         return identifier.upper()
 
     @staticmethod
-    def format_type_default(identifier: str) -> str:
+    def actual_type_name(identifier: str) -> str:
         return identifier.upper()
 
     def safe_connection_data(self):


### PR DESCRIPTION
1) Renamed the `format...` methods that handles data source specific case rules for table names, column names and type names to `actual...`

This renaming is an improvement imo because "format" has name clash with the soda validity formats and "actual" has a hint towards testing so that fits better imo.  So anything referring actual means the data source specific name taking the case defaults into account.

2) Introduced variables for the actual names in the TestTable data structure that are initialized in the `ensure_test_table` method.  
 * `TestTable.actual_name` the actual table name
 * `TestTable.test_column[x].actual_name` are the actual column names

3) added convenience methods to scanner to access the data_source.actual_*** methods