### PR TITLE
Downgrade markupsafe dependency

### DIFF
--- a/soda/core/setup.py
+++ b/soda/core/setup.py
@@ -16,7 +16,7 @@ description = "Soda Core"
 # long_description = (pathlib.Path(__file__).parent.parent / "README.md").read_text()
 
 requires = [
-    "markupsafe~=2.1",
+    "markupsafe~=2.0",
     "Jinja2~=3.0",
     "click~=8.0",
     "ruamel.yaml~=0.17.21",


### PR DESCRIPTION
markupsafe 2.1 was giving some users dependency lock issues on some environments (e.g. gcp composer), there is no particular reason to force >=2.1 so we can relax the requirement. FYI @vijaykiran 