### PR TITLE
Feat/add new distr checks

### DIFF
--- a/soda/core/soda/cli/cli.py
+++ b/soda/core/soda/cli/cli.py
@@ -225,16 +225,16 @@ def update(
     if not column_name:
         logging.error(f"Missing key 'column' in distribution reference file {distribution_reference_file}")
 
-    method = distribution_dict.get("method")
-    if not method:
-        logging.error(f"Missing key 'method' in distribution reference file {distribution_reference_file}")
+    dtype = distribution_dict.get("dtype")
+    if not dtype:
+        logging.error(f"Missing key 'dtype' in distribution reference file {distribution_reference_file}")
 
     filter = distribution_dict.get("filter")
     filter_clause = ""
     if filter is not None:
         filter_clause = f"WHERE {filter}"
 
-    if table_name and column_name and method:
+    if table_name and column_name and dtype:
         query = f"SELECT {column_name} FROM {table_name} {filter_clause}"
         logging.info(f"Querying column values to build distribution reference:\n{query}")
 
@@ -249,7 +249,7 @@ def update(
         from soda.scientific.distribution.comparison import RefDataCfg
         from soda.scientific.distribution.generate_dro import DROGenerator
 
-        dro = DROGenerator(RefDataCfg(method=method), column_values).generate()
+        dro = DROGenerator(RefDataCfg(dtype = dtype), column_values).generate()
         distribution_dict["distribution reference"] = dro.dict()
 
         new_file_content = to_yaml_str(distribution_dict)

--- a/soda/core/soda/execution/distribution_check.py
+++ b/soda/core/soda/execution/distribution_check.py
@@ -43,8 +43,8 @@ class DistributionCheck(Check):
         if self.query.exception is None and self.query.rows is not None:
             test_data = [row[0] for row in self.query.rows]
 
-            _, p_value = DistributionChecker(distribution_check_cfg, test_data).run()
-            self.check_value = p_value
+            distr_check_results = DistributionChecker(distribution_check_cfg, test_data).run()
+            self.check_value = distr_check_results['check_value'] 
 
             self.set_outcome_based_on_check_value()
 

--- a/soda/core/soda/sodacl/distribution_check_cfg.py
+++ b/soda/core/soda/sodacl/distribution_check_cfg.py
@@ -19,6 +19,7 @@ class DistributionCheckCfg(CheckCfg):
         reference_file_path: str,
         fail_threshold_cfg: ThresholdCfg | None,
         warn_threshold_cfg: ThresholdCfg | None,
+        method: str
     ):
         super().__init__(
             source_header=source_header,
@@ -33,6 +34,7 @@ class DistributionCheckCfg(CheckCfg):
         self.reference_file_path = reference_file_path
         self.fail_threshold_cfg = fail_threshold_cfg
         self.warn_threshold_cfg = warn_threshold_cfg
+        self.method = method
 
     def get_column_name(self) -> str | None:
         return self.column_name

--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -476,6 +476,7 @@ class SodaCLParser(Parser):
         # Parse the nested check configuration details
         name = None
         filter = None
+        method = None
         missing_and_valid_cfg = None
         condition = None
         metric_expression = None
@@ -491,6 +492,8 @@ class SodaCLParser(Parser):
                     filter = configuration_value.strip()
                 elif "condition" == configuration_key:
                     condition = configuration_value.strip()
+                elif "method" == configuration_key:
+                    method = configuration_value.strip()
                 elif configuration_key.endswith("expression"):
                     metric_expression = configuration_value.strip()
                     configuration_metric_name = (
@@ -637,6 +640,7 @@ class SodaCLParser(Parser):
                 column_name=column_name,
                 distribution_name=distribution_name,
                 filter=None,
+                method = method,
                 reference_file_path=reference_file_path,
                 fail_threshold_cfg=fail_threshold_cfg,
                 warn_threshold_cfg=warn_threshold_cfg,

--- a/soda/core/tests/data_source/test_distribution_check.py
+++ b/soda/core/tests/data_source/test_distribution_check.py
@@ -22,6 +22,7 @@ def test_distribution_check(scanner: Scanner, mock_file_system):
                 checks for {table_name}:
                   - distribution_difference(size, my_happy_ml_model_distribution) >= 0.05:
                       distribution reference file: ./customers_size_distribution_reference.yml
+                      method: ks
             """
         ).strip(),
     }
@@ -32,7 +33,7 @@ def test_distribution_check(scanner: Scanner, mock_file_system):
         reference_table = f"""
             table: {table_name}
             column: size
-            method: continuous
+            dtype: continuous
             distribution reference:
                 bins: [1, 2, 3]
                 weights: [0.5, 0.2, 0.3]
@@ -67,6 +68,7 @@ def test_distribution_sql(scanner: Scanner, mock_file_system, table, expectation
                 checks for {table_name}:
                   - distribution_difference(size, my_happy_ml_model_distribution) >= 0.05:
                       distribution reference file: ./customers_size_distribution_reference.yml
+                      method: ks
             """
         ).strip(),
     }
@@ -76,7 +78,7 @@ def test_distribution_sql(scanner: Scanner, mock_file_system, table, expectation
         reference_table = f"""
             table: {table_name}
             column: size
-            method: continuous
+            dtype: continuous
             distribution reference:
                 bins: [1, 2, 3]
                 weights: [0.5, 0.2, 0.3]

--- a/soda/scientific/soda/scientific/distribution/generate_dro.py
+++ b/soda/scientific/soda/scientific/distribution/generate_dro.py
@@ -22,7 +22,7 @@ def normalize(data: np.ndarray):
 
 class DROGenerator:
     def __init__(self, cfg: RefDataCfg, data: list) -> None:
-        self.method = cfg.method
+        self.dtype = cfg.dtype
         self.data = data
 
     def generate_continuous_dro(self) -> DRO:
@@ -54,13 +54,7 @@ class DROGenerator:
         return DRO(weights=weights.tolist(), bins=labels.tolist())
 
     def generate(self) -> DRO:
-        distribution_type_mapping = {
-            "continuous": "continuous",
-            "ks": "continuous",
-            "categorical": "categorical",
-            "chi_square": "categorical",
-        }
-        if distribution_type_mapping[self.method] == "continuous":
+        if self.dtype == "continuous":
             return self.generate_continuous_dro()
         else:
             return self.generate_categorical_dro()

--- a/soda/scientific/soda/scientific/distribution/utils.py
+++ b/soda/scientific/soda/scientific/distribution/utils.py
@@ -17,7 +17,7 @@ class RefDataCfg(BaseModel):
     bins: Optional[List]
     weights: Optional[List[float]]
     labels: Optional[List]
-    method: str
+    dtype: str
 
     @validator("weights")
     def check_weights_sum(cls, v):
@@ -27,9 +27,9 @@ class RefDataCfg(BaseModel):
         )
         return v
 
-    @validator("method")
-    def check_accepted_values_method(cls, v):
-        valid_distribution_methods = ["categorical", "continuous", "ks", "chi_square"]
+    @validator("dtype")
+    def check_accepted_values_dtype(cls, v):
+        valid_distribution_methods = ["categorical", "continuous"]
         assert (
             v in valid_distribution_methods
         ), f"Method must be one of {valid_distribution_methods}, but '{v}' was provided."
@@ -70,3 +70,14 @@ def distribution_is_all_null(distribution: pd.Series) -> bool:
         return True
     else:
         return False
+
+def generate_ref_data(cfg: RefDataCfg, sample_size: int, rng: np.random.Generator) -> pd.Series:
+    if cfg.dtype == "continuous":
+        sample_data = rng.random((1, sample_size))[0]
+        xp = np.cumsum(cfg.weights)
+        yp = cfg.bins
+        ref_data = np.interp(sample_data, xp, yp)
+        return ref_data
+    else: 
+        return pd.Series(rng.choice(cfg.bins, p=cfg.weights, size=sample_size))
+

--- a/soda/scientific/tests/assets/dist_ref_categorical.yml
+++ b/soda/scientific/tests/assets/dist_ref_categorical.yml
@@ -1,6 +1,6 @@
 table: ex_table
 column: size
-method: categorical
+dtype: categorical
 distribution reference:
     bins: [1, 2, 3]
     weights: [0.4, 0.3, 0.3]

--- a/soda/scientific/tests/assets/dist_ref_categorical_no_bins.yml
+++ b/soda/scientific/tests/assets/dist_ref_categorical_no_bins.yml
@@ -1,3 +1,3 @@
 table: ex_table
 column: size
-method: categorical
+dtype: categorical

--- a/soda/scientific/tests/assets/dist_ref_continuous.yml
+++ b/soda/scientific/tests/assets/dist_ref_continuous.yml
@@ -1,6 +1,6 @@
 table: ex_table
 column: size
-method: continuous
+dtype: continuous
 distribution reference:
     bins: [
         -3.34034354,

--- a/soda/scientific/tests/assets/dist_ref_continuous_no_bins.yml
+++ b/soda/scientific/tests/assets/dist_ref_continuous_no_bins.yml
@@ -1,3 +1,3 @@
 table: ex_table
 column: size
-method: continuous
+dtype: continuous

--- a/soda/scientific/tests/distribution_comparison_test.py
+++ b/soda/scientific/tests/distribution_comparison_test.py
@@ -1,3 +1,4 @@
+from cmath import nan
 import numpy as np
 import pandas as pd
 import pytest
@@ -6,30 +7,27 @@ from numpy.random import default_rng
 from soda.scientific.distribution.comparison import (
     DistributionRefKeyException,
     DistributionRefParsingException,
+    SWDAlgorithm,
 )
 from soda.scientific.distribution.utils import DistCfg, RefDataCfg
 
 
 @pytest.mark.parametrize(
-    "method",
+    "dtype",
     [
-        pytest.param("continuous", id="valid method continuous"),
-        pytest.param("categorical", id="valid method categorical"),
-        pytest.param("ks", id="valid method ks"),
-        pytest.param("chi_square", id="valid method chi_square"),
-        pytest.param("trabzonspor", id="invalid method"),
+        pytest.param("continuous", id="valid dtype continuous"),
+        pytest.param("categorical", id="valid dtype categorical"),
     ],
 )
-def test_config_method(method):
+def test_config_dtype(dtype):
     from pydantic.error_wrappers import ValidationError
 
     try:
         bins = [1, 2, 3]
         weights = [0.1, 0.8, 0.1]
-        RefDataCfg(bins=bins, weights=weights, labels=None, method=method)
+        RefDataCfg(bins=bins, weights=weights, labels=None, dtype=dtype)
     except ValidationError:
         pass
-
 
 @pytest.mark.parametrize(
     "weights",
@@ -44,7 +42,7 @@ def test_config_weights(weights):
 
     try:
         bins = [1, 2, 3]
-        method = "continuous"
+        method = "ks"
         RefDataCfg(bins=bins, weights=weights, labels=None, method=method)
     except ValidationError:
         pass
@@ -67,53 +65,59 @@ def test_ref_file_path(reference_file_path):
 
 
 @pytest.mark.parametrize(
-    "reference_file_path, test_data, expected_stat, expected_p",
+    "method, reference_file_path, test_data, expected_stat, expected_p",
     [
         pytest.param(
+            "ks",
             "soda/scientific/tests/assets/dist_ref_continuous.yml",
             list(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)),
             0.036,
             0.5545835690881001,
-            id="Similar continuous distribution",
+            id="Similar continuous distribution with ks",
         ),
         pytest.param(
+            "ks",
             "soda/scientific/tests/assets/dist_ref_continuous.yml",
             list(default_rng(61).normal(loc=1.5, scale=1.0, size=1000)),
             0.2115,
             8.845435165401255e-20,
-            id="Different continuous distribution",
+            id="Different continuous distribution with ks",
         ),
         pytest.param(
+            "ks",
             "soda/scientific/tests/assets/dist_ref_continuous_no_bins.yml",
             list(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)),
             0.0245,
             0.9211961644657093,
-            id="Similar continuous distribution without bins and weights",
+            id="Similar continuous distribution without bins and weights using ks",
         ),
         pytest.param(
+            "chi_square",
             "soda/scientific/tests/assets/dist_ref_categorical_no_bins.yml",
             ["peace", "at", "home", "peace", "in", "the", "world"] * 1000,
             2.849628571261552,
             0.7222714008190096,
-            id="Similar categorical distribution without bins and weights",
+            id="Similar categorical distribution without bins and weights with chi-square",
         ),
         pytest.param(
+            "chi_square",
             "soda/scientific/tests/assets/dist_ref_categorical.yml",
             [1, 1, 2, 3] * 1000,
             156.32764391336602,
             1.960998922048572e-34,
-            id="Different categorical distribution",
+            id="Different categorical distribution with chi-square",
         ),
     ],
 )
-def test_distribution_checker(reference_file_path, test_data, expected_stat, expected_p):
+def test_distribution_checker(method, reference_file_path, test_data, expected_stat, expected_p):
     from soda.scientific.distribution.comparison import DistributionChecker
 
     test_dist_cfg = DistCfg(reference_file_path=reference_file_path)
+    DistCfg.method = method
     check = DistributionChecker(test_dist_cfg, test_data)
-    stat_val, p_val = check.run()
-    assert stat_val == pytest.approx(expected_stat, abs=1e-3)
-    assert p_val == pytest.approx(expected_p, abs=1e-3)
+    check_results = check.run()
+    assert check_results['stat_value'] == pytest.approx(expected_stat, abs=1e-3)
+    assert check_results['check_value'] == pytest.approx(expected_p, abs=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -141,9 +145,10 @@ def test_ref_config_file_exceptions(reference_file_path, exception):
 
 
 @pytest.mark.parametrize(
-    "reference_file_path, expected_stat, expected_p",
+    "method, reference_file_path, expected_stat, expected_p",
     [
         pytest.param(
+            "ks",
             "soda/scientific/tests/assets/dist_ref_continuous_no_bins.yml",
             0.0245,
             0.9211961644657093,
@@ -151,14 +156,15 @@ def test_ref_config_file_exceptions(reference_file_path, exception):
         ),
     ],
 )
-def test_with_no_bins_and_weights(reference_file_path, expected_stat, expected_p):
+def test_with_no_bins_and_weights(method, reference_file_path, expected_stat, expected_p):
     from soda.scientific.distribution.comparison import DistributionChecker
 
     test_dist_cfg = DistCfg(reference_file_path=reference_file_path)
+    DistCfg.method = method
     test_data = list(default_rng(61).normal(loc=1.0, scale=1.0, size=1000))
-    stat_val, p_val = DistributionChecker(test_dist_cfg, test_data).run()
-    assert stat_val == pytest.approx(expected_stat, abs=1e-3)
-    assert p_val == pytest.approx(expected_p, abs=1e-3)
+    check_results = DistributionChecker(test_dist_cfg, test_data).run()
+    assert check_results['stat_value'] == pytest.approx(expected_stat, abs=1e-3)
+    assert check_results['check_value'] == pytest.approx(expected_p, abs=1e-3)
 
 
 # The following bins and weights are generated based on
@@ -237,12 +243,13 @@ TEST_CONFIG_CONT_1 = RefDataCfg(
         0.003,
     ],
     labels=None,
-    method="continuous",
+    method="ks",
+    dtype="continuous"
 )
 
 
 @pytest.mark.parametrize(
-    "test_data, expectated_stat_val, expected_p_val",
+    "test_data, expected_stat_val, expected_p_val",
     [
         pytest.param(
             pd.Series(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)),
@@ -276,21 +283,21 @@ TEST_CONFIG_CONT_1 = RefDataCfg(
         ),
     ],
 )
-def test_continuous_comparison(test_data, expectated_stat_val, expected_p_val):
+def test_ks_comparison(test_data, expected_stat_val, expected_p_val):
     from soda.scientific.distribution.comparison import KSAlgorithm
 
-    stat_val, p_val = KSAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
-    assert expectated_stat_val == pytest.approx(stat_val, abs=1e-3)
-    assert expected_p_val == pytest.approx(p_val, abs=1e-3)
+    check_results = KSAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
+    assert expected_stat_val == pytest.approx(check_results['stat_value'], abs=1e-3)
+    assert expected_p_val == pytest.approx(check_results['check_value'], abs=1e-3)
 
 
 # The following bins and weights are generated based on
 # default_rng().normal(loc=1.0, scale=1.0, size=1000)
-TEST_CONFIG_CATEGORIC_1 = RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, method="categorical")
+TEST_CONFIG_CATEGORIC_1 = RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, dtype = "categorical")
 
 
 @pytest.mark.parametrize(
-    "test_data, expectated_stat_val, expected_p_val, error_expected",
+    "test_data, expected_stat_val, expected_p_val, error_expected",
     [
         pytest.param(
             pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
@@ -322,16 +329,16 @@ TEST_CONFIG_CATEGORIC_1 = RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], la
         ),
     ],
 )
-def test_categorical_comparison(test_data, expectated_stat_val, expected_p_val, error_expected):
+def test_chi_square_comparison(test_data, expected_stat_val, expected_p_val, error_expected):
     from soda.scientific.distribution.comparison import (
         ChiSqAlgorithm,
         NotEnoughSamplesException,
     )
 
     try:
-        stat_val, p_val = ChiSqAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
-        assert expectated_stat_val == pytest.approx(stat_val, abs=1e-3)
-        assert expected_p_val == pytest.approx(p_val, abs=1e-3)
+        check_results = ChiSqAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
+        assert expected_stat_val == pytest.approx(check_results['stat_value'], abs=1e-3)
+        assert expected_p_val == pytest.approx(check_results['check_value'], abs=1e-3)
         assert not error_expected
     except NotEnoughSamplesException:
         assert error_expected
@@ -342,17 +349,17 @@ def test_categorical_comparison(test_data, expectated_stat_val, expected_p_val, 
     [
         pytest.param(
             pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
-            RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, method="categorical"),
+            RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, dtype="categorical"),
             id="category missing in reference data",
         ),
         pytest.param(
             pd.Series(default_rng(61).choice([0, 1], p=[0.1, 0.9], size=1000)),
-            RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, method="categorical"),
+            RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, dtype="categorical"),
             id="category missing in test data",
         ),
         pytest.param(
             pd.Series(default_rng(61).choice([None, None, 1], p=[0.2, 0.3, 0.5], size=1000)),
-            RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, method="categorical"),
+            RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, dtype="categorical"),
             id="one of the distributions is fully none",
         ),
     ],
@@ -373,17 +380,17 @@ def test_chi_sq_2_samples_comparison_missing_cat(test_data, config):
     [
         pytest.param(
             pd.Series([None, None] * 10),
-            RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, method="categorical"),
+            RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, dtype="categorical"),
             id="test data is all none",
         ),
         pytest.param(
             pd.Series(default_rng(61).choice([0, 1], p=[0.1, 0.9], size=1000)),
-            RefDataCfg(bins=[None], weights=[1], labels=None, method="categorical"),
+            RefDataCfg(bins=[None], weights=[1], labels=None, dtype = "categorical"),
             id="ref data is all none",
         ),
         pytest.param(
             pd.Series([None, None] * 10),
-            RefDataCfg(bins=[None], weights=[1], labels=None, method="categorical"),
+            RefDataCfg(bins=[None], weights=[1], labels=None, dtype="categorical"),
             id="both distributions are null",
         ),
     ],
@@ -401,7 +408,7 @@ def test_chi_sq_2_samples_comparison_one_or_more_null_distros(test_data, config)
     [
         pytest.param(
             pd.Series(default_rng(61).choice([1, 2], p=[0.5, 0.5], size=2)),
-            RefDataCfg(bins=[1, 2], weights=[0.5, 0.5], labels=None, method="categorical"),
+            RefDataCfg(bins=[1, 2], weights=[0.5, 0.5], labels=None, dtype="categorical"),
             id="not enough samples",
         ),
     ],
@@ -415,3 +422,157 @@ def test_chi_sq_2_samples_comparison_not_enough_samples(test_data, config):
     checker = ChiSqAlgorithm(config, test_data)
     with pytest.raises(NotEnoughSamplesException):
         checker.evaluate()
+
+
+@pytest.mark.parametrize(
+    "test_data, expected_swd",
+    [
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)),
+            0.09541381487225127,
+            id="distributions are same",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=1.0, scale=0.9, size=1000)),
+            0.10607140143389837,
+            id="distributions are different_1",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=0.9, scale=1.0, size=1000)),
+            0.19193533134279744,
+            id="distributions are different_2",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=10, scale=10, size=1000)),
+            1.2438664038653537,
+            id="distributions are extremely different",
+        ),
+    ],
+)
+def test_swd_continuous(test_data, expected_swd):
+    from soda.scientific.distribution.comparison import SWDAlgorithm
+
+    check_results = SWDAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
+    assert check_results['check_value'] == expected_swd
+
+@pytest.mark.parametrize(
+    "test_data, expected_swd",
+    [
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            0,
+            id="distributions are same",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.2, 0.3, 0.5], size=1000)),
+            0.130034992111961,
+            id="distributions are different",
+        )
+    ],
+)
+def test_swd_categorical(test_data, expected_swd):
+    from soda.scientific.distribution.comparison import (
+        SWDAlgorithm
+    )
+    
+    check_results = SWDAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
+    assert check_results['check_value'] == expected_swd
+
+
+@pytest.mark.parametrize("test_data", [pd.Series(100 * [np.nan])])
+def test_swd_comparison_null(test_data):
+    from soda.scientific.distribution.comparison import SWDAlgorithm
+
+    check_results = SWDAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
+    assert np.isnan(check_results['check_value'])
+
+
+@pytest.mark.parametrize(
+    "test_data, expected_psi",
+    [
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)),
+            0.040699470804929805,
+            id="distributions are same",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=1.0, scale=0.9, size=1000)),
+            0.08448405985073384,
+            id="distributions are different_1",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=0.9, scale=1.0, size=1000)),
+            0.06596002459912605,
+            id="distributions are different_2",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).normal(loc=10, scale=10, size=1000)),
+            8.478605750455749,
+            id="distributions are extremely different",
+        ),
+    ],
+)
+def test_psi_continuous(test_data, expected_psi):
+    from soda.scientific.distribution.comparison import PSIAlgorithm
+
+    check_results = PSIAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
+    assert check_results['check_value'] == expected_psi
+
+
+
+@pytest.mark.parametrize(
+    "test_data, expected_psi",
+    [
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            0,
+            id="distributions are same",
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.2, 0.3, 0.5], size=1000)),
+            0.09000613400978587,
+            id="distributions are different",
+        )
+    ],
+)
+def test_psi_categorical(test_data, expected_psi):
+    from soda.scientific.distribution.comparison import (
+        PSIAlgorithm
+    )
+    
+    check_results = PSIAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
+    assert check_results['check_value'] == expected_psi
+
+
+@pytest.mark.parametrize("test_data, expected_psi", [(pd.Series(100 * [np.nan]), 11.51281033571558)])
+def test_psi_comparison_null(test_data, expected_psi):
+    from soda.scientific.distribution.comparison import PSIAlgorithm
+
+    check_results = PSIAlgorithm(TEST_CONFIG_CONT_1, test_data).evaluate()
+    assert check_results['check_value'] == expected_psi
+
+@pytest.mark.parametrize("test_data, reference_file_path, method",
+    [
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            "soda/scientific/tests/assets/dist_ref_categorical.yml",
+            "ks",
+            id = "ks method with dtype categorical"
+        ),
+        pytest.param(
+            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            "soda/scientific/tests/assets/dist_ref_continuous.yml",
+            "chi_square",
+            id = "chi_square method with dtype continuous"
+        )
+    ]
+)
+def test_ref_config_incompatible(test_data, reference_file_path, method):
+    from soda.scientific.distribution.comparison import (
+        DistributionChecker,
+        DistributionRefIncompatibleException,
+    )
+    test_dist_cfg = DistCfg(reference_file_path=reference_file_path)
+    DistCfg.method = method
+    with pytest.raises(DistributionRefIncompatibleException):
+        DistributionChecker(test_dist_cfg, test_data)

--- a/soda/scientific/tests/generate_dro_test.py
+++ b/soda/scientific/tests/generate_dro_test.py
@@ -12,7 +12,7 @@ rng = default_rng(1234)
     "cfg, data, expected_weights, expected_bins",
     [
         pytest.param(
-            RefDataCfg(method="continuous"),
+            RefDataCfg(dtype = "continuous"),
             list(rng.normal(loc=2, scale=1.0, size=1000)),
             np.array(
                 [0, 2, 4, 12, 15, 40, 49, 57, 58, 87, 112, 112, 98, 88, 74, 67, 40, 29, 27, 13, 6, 1, 7, 0, 0, 1, 1]
@@ -66,7 +66,7 @@ def test_generate_dro_continuous(cfg, data, expected_bins, expected_weights):
     "cfg, data, expected_weights, expected_bins",
     [
         pytest.param(
-            RefDataCfg(method="categorical"),
+            RefDataCfg(dtype = "categorical"),
             list(rng.choice(["hello", "world", "foo"], p=[0.1, 0.4, 0.5], size=1000)),  # type: ignore
             np.array([0.525, 0.392, 0.083]),
             np.array(["foo", "world", "hello"]),


### PR DESCRIPTION
@bastienboutonnet Hey this became a lot bigger than initially expected. Besides adding the new DistributionAlgorithms this PR implements [the following](https://sodadata.slack.com/archives/C033ZCE96TY/p1654169953739229). @baturayo  and I had a chat and thought it made sense that I move on and implement this. If you disagree with this approach I would obviously be happy to take a different route. 

This PR makes the following changes/additions:

- Change `soda update` so that it parses a `dtype` key from the DRO. This `dtype` key is necessary to resample from the DRO.
- Update the RefDataCfg so that it contains a `dtype` key and not a `method` key
- Changes the `__parse_metric_check` method so that it parses a `method` key if present and passes this to the `DistributionCheckCfg`
- Changes `DistributionCheckCfg` so that it contains a `method` attribute
- Changed the return value of `DistributionAlgorithm` so that it makes sense for non-statistical tests like wasserstein and psi
- Added wasserstein and psi algorithms
- Refactored the unit tests and added new ones that check whether wasserstein and psi work for both continuous and categoric data, and whether exceptions are thrown if the specified `method` is incompatible with the `dtype`

Resolves: [add wasserstein metric](https://sodadata.atlassian.net/browse/SODA-195) and [add psi](https://sodadata.atlassian.net/browse/SODA-196) 