### PR TITLE
fix: Suppress `prophet`'s `pandas: frame.append` deprecation warning

### DIFF
--- a/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
@@ -5,7 +5,8 @@ import os
 import sys
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
-
+import warnings 
+warnings.filterwarnings('ignore', '.*The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.*')
 import numpy as np
 import pandas as pd
 from soda.common.logs import Logs

--- a/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
@@ -3,10 +3,14 @@
 import multiprocessing
 import os
 import sys
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
-import warnings 
-warnings.filterwarnings('ignore', '.*The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.*')
+
+warnings.filterwarnings(
+    "ignore",
+    ".*The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.*",
+)
 import numpy as np
 import pandas as pd
 from soda.common.logs import Logs


### PR DESCRIPTION
The change in this PR ensures that the pandas `frame.append` method deprecation warning is suppressed. This warning is caused by the `prophet` package that is used for anomaly detection.

Resolves the following issue: [Check pandas warnings in automated monitoring](https://sodadata.atlassian.net/browse/CLOUD-278)