### PR TITLE
Change: rename the `update` command to `update-dro` as it better describes what the command is used for

### DIFF
--- a/soda/core/soda/cli/cli.py
+++ b/soda/core/soda/cli/cli.py
@@ -162,7 +162,7 @@ def scan(
 
 
 @main.command(
-    short_help="updates a distribution reference file",
+    short_help="updates a DRO in the distribution reference file",
 )
 @click.option("-d", "--data-source", envvar="SODA_DATA_SOURCE", required=True, multiple=False, type=click.STRING)
 @click.option(
@@ -174,14 +174,14 @@ def scan(
 )
 @click.option("-V", "--verbose", is_flag=True)
 @click.argument("distribution_reference_file", type=click.STRING)
-def update(
+def update_dro(
     distribution_reference_file: str,
     data_source: str,
     configuration: str,
     verbose: Optional[bool],
 ):
     """
-    soda update will
+    soda update-dro will
       * Read the configuration and instantiate a connection to the data source
       * Read the definition properties in the distribution reference file
       * Update bins, labels and/or weights under key "reference distribution" in the distribution reference file
@@ -191,13 +191,14 @@ def update(
     option -c --configuration is the configuration file containing the data source definitions.  The default
     is ~/.soda/configuration.yml is used.
 
+
     option -V --verbose activates more verbose logging, including the queries that are executed.
 
     [DISTRIBUTION_REFERENCE_FILE] is a distribution reference file
 
     Example:
 
-    soda update -d snowflake_customer_data ./customers_size_distribution_reference.yml
+    soda update-dro -d snowflake_customer_data ./customers_size_distribution_reference.yml
     """
 
     configure_logging()

--- a/soda/core/tests/cli/test_cli_update_distribution_file.py
+++ b/soda/core/tests/cli/test_cli_update_distribution_file.py
@@ -30,7 +30,7 @@ def test_cli_update_distribution_file(data_source_fixture: DataSourceFixture, mo
 
     run_cli(
         [
-            "update",
+            "update-dro",
             "-c",
             "configuration.yml",
             "-d",

--- a/soda/core/tests/data_source/test_distribution_check.py
+++ b/soda/core/tests/data_source/test_distribution_check.py
@@ -121,7 +121,7 @@ def test_distribution_missing_bins_weights(data_source_fixture: DataSourceFixtur
     log_message = (
         'The DRO in your "/Users/johndoe/customers_size_distribution_reference.yml" distribution reference file does'
         ' not contain a "distribution_reference" key with weights and bins. Make sure that before running "soda scan" you'
-        ' create a DRO by running "soda update". For more information visit the docs:\nhttps://docs.soda.io/soda-cl/distribution.html#generate-a-distribution-reference-object-dro.'
+        ' create a DRO by running "soda update-dro". For more information visit the docs:\nhttps://docs.soda.io/soda-cl/distribution.html#generate-a-distribution-reference-object-dro.'
     )
 
     log = next(log for log in scan._logs.logs if isinstance(log.message, MissingBinsWeightsException))

--- a/soda/scientific/soda/scientific/distribution/comparison.py
+++ b/soda/scientific/soda/scientific/distribution/comparison.py
@@ -119,7 +119,7 @@ class DistributionChecker:
             else:
                 raise MissingBinsWeightsException(
                     f"""The DRO in your "{dist_ref_file_path}" distribution reference file does not contain a "distribution_reference" key with weights and bins."""
-                    f""" Make sure that before running "soda scan" you create a DRO by running "soda update". For more information visit the docs:\n"""
+                    f""" Make sure that before running "soda scan" you create a DRO by running "soda update-dro". For more information visit the docs:\n"""
                     f"""https://docs.soda.io/soda-cl/distribution.html#generate-a-distribution-reference-object-dro."""
                 )
 


### PR DESCRIPTION
This PR implements the following

* Use `soda update-dro` instead of `soda update` to update a DRO in the distribution reference file

This PR resolves the following: [Rename `soda update` to `soda update-dro`](https://sodadata.atlassian.net/browse/CLOUD-372)