### PR TITLE
build: require strict prophet v1.0.0 in scientific library

### DIFF
--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -21,7 +21,7 @@ requires = [
     "PyYAML>=5.4.1,<6.0.0",
     "cython>=0.22",
     "pystan==2.19.1.1",
-    "prophet>=1.0.0"
+    "prophet==1.0.0"
     # Uncomment & recreate .venv to make scientific tests work
     # "prophet @ git+https://github.com/facebook/prophet.git#egg=prophet&subdirectory=python",
 ]


### PR DESCRIPTION
Fixes prophet to `v1.0.0` as it is causing issues in our docker images build and we will have to take some time to investigate ugrades to the new version of prophet.

In theory that new tag, should make installation easier but it looks like that's not exactly the case.

`v1.1.0` of prophet was released a few days ago: https://github.com/facebook/prophet/releases/tag/v1.1