### PR TITLE
feat: Add `samples limit` to failed rows checks

### DIFF
--- a/soda/core/soda/execution/query.py
+++ b/soda/core/soda/execution/query.py
@@ -19,6 +19,7 @@ class Query:
         sql: str | None = None,
         sample_name: str = "failed_rows",
         location: Location | None = None,
+        samples_limit: int | None = 100,
     ):
         self.logs = data_source_scan.scan._logs
         self.data_source_scan = data_source_scan
@@ -30,6 +31,7 @@ class Query:
         self.partition: Partition | None = partition
         self.column: Column | None = column
         self.location: Location | None = location
+        self.samples_limit: int | None = samples_limit
 
         # The SQL query that is used _fetchone or _fetchall or _store
         # This field can also be initialized in the execute method before any of _fetchone,
@@ -158,6 +160,7 @@ class Query:
                     column=self.column,
                     scan=self.data_source_scan.scan,
                     logs=self.data_source_scan.scan._logs,
+                    samples_limit=self.samples_limit,
                 )
 
                 self.sample_ref = sampler.store_sample(sample_context)

--- a/soda/core/soda/execution/user_defined_failed_rows_expression_check.py
+++ b/soda/core/soda/execution/user_defined_failed_rows_expression_check.py
@@ -53,6 +53,7 @@ class UserDefinedFailedRowsExpressionCheck(Check):
                 data_source_scan=self.data_source_scan,
                 check_name=self.check_cfg.source_line,
                 sql=failed_rows_sql,
+                samples_limit=self.check_cfg.samples_limit,
             )
             failed_rows_query.execute()
             if failed_rows_query.sample_ref and failed_rows_query.sample_ref.is_persisted():

--- a/soda/core/soda/execution/user_defined_failed_rows_expression_query.py
+++ b/soda/core/soda/execution/user_defined_failed_rows_expression_query.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 from soda.execution.query import Query
 
 
 class UserDefinedFailedRowsExpressionQuery(Query):
-    def __init__(self, data_source_scan: "DataSourceScan", check_name: str, sql: str):
+    def __init__(self, data_source_scan: DataSourceScan, check_name: str, sql: str, samples_limit: int | None = 100):
         super().__init__(
             data_source_scan=data_source_scan,
             unqualified_query_name=f"user_defined_failed_rows_expression_query[{check_name}]",
         )
         self.sql: str = sql
+        self.samples_limit = samples_limit
 
     def execute(self):
         self.store()

--- a/soda/core/soda/execution/user_defined_failed_rows_metric.py
+++ b/soda/core/soda/execution/user_defined_failed_rows_metric.py
@@ -34,5 +34,10 @@ class UserDefinedFailedRowsMetric(QueryMetric):
         check = next(iter(self.checks), None)
         location = check.check_cfg.location if check else None
         self.data_source_scan.queries.append(
-            UserDefinedFailedRowsQuery(data_source_scan=self.data_source_scan, metric=self, location=location)
+            UserDefinedFailedRowsQuery(
+                data_source_scan=self.data_source_scan,
+                metric=self,
+                location=location,
+                samples_limit=check.check_cfg.samples_limit,
+            )
         )

--- a/soda/core/soda/execution/user_defined_failed_rows_query.py
+++ b/soda/core/soda/execution/user_defined_failed_rows_query.py
@@ -5,10 +5,17 @@ from soda.execution.query import Query
 
 class UserDefinedFailedRowsQuery(Query):
     def __init__(
-        self, data_source_scan: DataSourceScan, metric: FailedRowsQueryMetric, location: Location | None = None
+        self,
+        data_source_scan: DataSourceScan,
+        metric: FailedRowsQueryMetric,
+        location: Location | None = None,
+        samples_limit: int | None = 100,
     ):
         super().__init__(
-            data_source_scan=data_source_scan, unqualified_query_name=f"failed_rows[{metric.name}]", location=location
+            data_source_scan=data_source_scan,
+            unqualified_query_name=f"failed_rows[{metric.name}]",
+            location=location,
+            samples_limit=samples_limit,
         )
         self.sql = metric.query
         self.metric = metric

--- a/soda/core/soda/sampler/sample_context.py
+++ b/soda/core/soda/sampler/sample_context.py
@@ -17,6 +17,7 @@ class SampleContext:
     column: Optional["Column"]
     scan: "Scan"
     logs: "Logs"
+    samples_limit: Optional[int]
 
     def get_scan_folder_name(self):
         parts = [

--- a/soda/core/soda/sampler/soda_cloud_sampler.py
+++ b/soda/core/soda/sampler/soda_cloud_sampler.py
@@ -19,7 +19,10 @@ class SodaCloudSampler(Sampler):
             scan = sample_context.scan
             soda_cloud = scan._configuration.soda_cloud
             soda_cloud_file_id = soda_cloud.upload_sample(
-                scan=scan, sample_rows=sample_rows, sample_file_name=sample_context.get_sample_file_name()
+                scan=scan,
+                sample_rows=sample_rows,
+                sample_file_name=sample_context.get_sample_file_name(),
+                samples_limit=sample_context.samples_limit,
             )
 
         return SampleRef(

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -308,10 +308,6 @@ class Scan:
                         "scan.set_scan_definition_name(...) is not set and it is required to make the Soda Cloud integration work.  For this scan, Soda Cloud will be disabled."
                     )
                     self._configuration.soda_cloud = None
-                    from soda.sampler.soda_cloud_sampler import SodaCloudSampler
-
-                    if isinstance(self._configuration.sampler, SodaCloudSampler):
-                        self._configuration.sampler = DefaultSampler()
                 else:
                     if self._configuration.soda_cloud.is_samples_disabled():
                         self._configuration.sampler = DefaultSampler()

--- a/soda/core/soda/soda_cloud/soda_cloud.py
+++ b/soda/core/soda/soda_cloud/soda_cloud.py
@@ -94,7 +94,9 @@ class SodaCloud:
             return value
         return str(value)
 
-    def upload_sample(self, scan: Scan, sample_rows: tuple[tuple], sample_file_name: str) -> str:
+    def upload_sample(
+        self, scan: Scan, sample_rows: tuple[tuple], sample_file_name: str, samples_limit: int | None = 100
+    ) -> str:
         """
         :param sample_file_name: file name without extension
         :return: Soda Cloud file_id
@@ -110,7 +112,7 @@ class SodaCloud:
             )
 
             with tempfile.TemporaryFile() as temp_file:
-                for row in sample_rows:
+                for row in sample_rows[0:samples_limit]:
                     row = [self._serialize_file_upload_value(v) for v in row]
                     rows_json_str = json.dumps(row)
                     rows_json_bytes = bytearray(rows_json_str, "utf-8")

--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -39,13 +39,13 @@ from soda.sodacl.threshold_cfg import ThresholdCfg
 
 logger = logging.getLogger(__name__)
 
-
 WARN = "warn"
 FAIL = "fail"
 NAME = "name"
 IDENTITY = "identity"
 FAIL_CONDITION = "fail condition"
 FAIL_QUERY = "fail query"
+SAMPLES_LIMIT = "samples limit"
 WHEN_REQUIRED_COLUMN_MISSING = "when required column missing"
 WHEN_WRONG_COLUMN_TYPE = "when wrong column type"
 WHEN_WRONG_COLUMN_INDEX = "when wrong column index"
@@ -353,13 +353,16 @@ class SodaCLParser(Parser):
             try:
                 name = self._get_required(NAME, str)
                 for invalid_configuration_key in [
-                    key for key in check_configurations if key not in [NAME, WARN, FAIL, FAIL_CONDITION, FAIL_QUERY]
+                    key
+                    for key in check_configurations
+                    if key not in [NAME, WARN, FAIL, FAIL_CONDITION, FAIL_QUERY, SAMPLES_LIMIT]
                 ]:
                     self.logs.error(
                         f'Invalid user defined failed rows check configuration key "{invalid_configuration_key}"',
                         location=self.location,
                     )
                 fail_condition_sql_expr = self._get_optional(FAIL_CONDITION, str)
+                samples_limit = self._get_optional(SAMPLES_LIMIT, int)
                 if fail_condition_sql_expr:
                     return UserDefinedFailedRowsExpressionCheckCfg(
                         source_header=header_str,
@@ -368,6 +371,7 @@ class SodaCLParser(Parser):
                         location=self.location,
                         name=name,
                         fail_condition_sql_expr=fail_condition_sql_expr,
+                        samples_limit=samples_limit,
                     )
                 else:
                     fail_query = self._get_optional(FAIL_QUERY, str)
@@ -379,6 +383,7 @@ class SodaCLParser(Parser):
                             location=self.location,
                             name=name,
                             query=fail_query,
+                            samples_limit=samples_limit,
                         )
                     else:
                         self.logs.error(
@@ -434,6 +439,7 @@ class SodaCLParser(Parser):
             try:
                 name = self._get_optional(NAME, str)
                 query = self._get_required(FAIL_QUERY, str)
+                samples_limit = self._get_optional(SAMPLES_LIMIT, int)
                 return UserDefinedFailedRowsCheckCfg(
                     source_header=header_str,
                     source_line=check_str,
@@ -441,6 +447,7 @@ class SodaCLParser(Parser):
                     location=self.location,
                     name=name,
                     query=query,
+                    samples_limit=samples_limit,
                 )
             finally:
                 self._pop_path_element()

--- a/soda/core/soda/sodacl/user_defined_failed_rows_check_cfg.py
+++ b/soda/core/soda/sodacl/user_defined_failed_rows_check_cfg.py
@@ -13,6 +13,8 @@ class UserDefinedFailedRowsCheckCfg(CheckCfg):
         location: Location,
         name: Optional[str],
         query: Optional[str],
+        samples_limit: Optional[int] = 100,
     ):
         super().__init__(source_header, source_line, source_configurations, location, name)
         self.query: Optional[str] = query
+        self.samples_limit = samples_limit

--- a/soda/core/soda/sodacl/user_defined_failed_rows_expression_check_cfg.py
+++ b/soda/core/soda/sodacl/user_defined_failed_rows_expression_check_cfg.py
@@ -13,6 +13,8 @@ class UserDefinedFailedRowsExpressionCheckCfg(CheckCfg):
         location: Location,
         name: str,
         fail_condition_sql_expr: Optional[str],
+        samples_limit: Optional[int] = 100,
     ):
         super().__init__(source_header, source_line, source_configurations, location, name)
+        self.samples_limit = samples_limit
         self.fail_condition_sql_expr: Optional[str] = fail_condition_sql_expr


### PR DESCRIPTION
Failed rows have an additional configuration option `samples limit` that can be
used limit the number of rows that are uploaded to soda cloud.

```yaml
checks for customers:
  - failed rows:
      name: failed rows with limit
      samples limit: 10
      fail condition:  size > 0
```
samples limit is added to user defined expressions, data source queries, as well
as table queries

Note: Needs docs update @janet-can