### PR TITLE
Reduce the Docker image size to acceptable levels again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,10 @@ RUN pip install --upgrade pip
 
 COPY . .
 
-RUN pip install "$(cat dev-requirements.in | grep pip-tools)" && \
-    pip install -r dev-requirements.txt
+RUN pip --no-cache-dir install "$(cat dev-requirements.in | grep pip-tools)" && \
+    pip --no-cache-dir install -r dev-requirements.txt
 
-RUN cat requirements.txt | while read requirement || [[ -n $requirement ]]; do pip install $requirement; done
+RUN cat requirements.txt | while read requirement || [[ -n $requirement ]]; do pip --no-cache-dir install $requirement; done
 
 RUN apt-get purge -y build-essential git curl && \
     apt-get clean -qq -y && \


### PR DESCRIPTION
Reduce the Docker image size to a reasonable level again by better applying the --no-cache-dir flag.