### PR TITLE
Async Docker image building through Actions and dispatch

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,71 @@
+name: Build Docker image for Soda Core
+
+on:
+  repository_dispatch:
+    types: [started-from-version-tag]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: check if a version tag
+        id: check-version-tag
+        run: |
+          if [[ ${{ github.event.client_payload.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      - 
+        name: Sleep for 900s
+        if: steps.check-version-tag.outputs.match == 'true'
+        uses: juliangruber/sleep-action@v1
+        with:
+          time: 900s
+      - 
+        name: check if a version tag in ref
+        if: steps.check-version-tag.outputs.match == 'true'
+        id: get-version-tag-in-ref
+        run: |
+          if [[ ${{ github.event.client_payload.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=versiontag::$(echo "${{github.event.client_payload.ref}}" | cut -d / -f 3)
+          fi
+      -
+        name: Checkout
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+      -
+        name: Docker meta
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            sodadata/soda-core
+          tags: |
+            type=raw,value=${{ github.event.client_payload.tag }}
+      -
+        name: Set up QEMU
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -219,3 +219,25 @@ jobs:
             echo "There was an error, check the logs please."
             exit 1
           fi
+  trigger-docker-build:
+    name: Trigger Docker build workflow
+    needs: [ publish-pypi ]
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    if: contains(github.ref, 'refs/tags/')
+    steps:
+      - name: check if a version tag
+        id: check-version-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+              echo ::set-output name=versiontag::$(echo $GITHUB_REF | cut -d / -f 3)
+          fi
+      - name: Repository Dispatch
+        if: steps.check-version-tag.outputs.match == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN_DISPATCH }}
+          repository: sodadata/soda-core
+          event-type: started-from-version-tag
+          client-payload: '{"tag": "${{ steps.check-version-tag.outputs.versiontag }}", "ref": "${{ github.ref }}"}'


### PR DESCRIPTION
Docker image building through Github Actions, with a final step in main flow to dispatch an event in case of a version tag.

The triggered workflow will then sleep for 900sec, then build and push the Docker image.

Closes [CLOUD-423]