### PR TITLE
Fix utc timezone handling

### DIFF
--- a/soda/core/soda/common/log.py
+++ b/soda/core/soda/common/log.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from textwrap import indent
 
@@ -49,7 +49,7 @@ class Log:
         self.location: Location | None = location
         self.doc: str | None = doc
         self.exception: BaseException | None = exception
-        self.timestamp: datetime = timestamp if isinstance(timestamp, datetime) else datetime.utcnow()
+        self.timestamp: datetime = timestamp if isinstance(timestamp, datetime) else datetime.now(tz=timezone.utc)
         self.index = self.get_next_index()
 
     __index = 0

--- a/soda/core/soda/sampler/sample_context.py
+++ b/soda/core/soda/sampler/sample_context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from soda.common.logs import Logs
@@ -23,7 +23,7 @@ class SampleContext:
         parts = [
             self.scan._scan_definition_name,
             self.scan._data_timestamp.strftime("%Y%m%d%H%M%S"),
-            datetime.utcnow().strftime("%Y%m%d%H%M%S"),
+            datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S"),
         ]
         return "_".join([part for part in parts if part])
 

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -454,7 +454,7 @@ class Scan:
             if error_count > 0:
                 Log.log_errors(self.get_error_logs())
 
-            self._scan_end_timestamp = datetime.utcnow()
+            self._scan_end_timestamp = datetime.now(tz=timezone.utc)
             if self._configuration.soda_cloud:
                 self._logs.info("Sending results to Soda Cloud")
                 self._configuration.soda_cloud.send_scan_results(self)

--- a/soda/core/soda/soda_cloud/soda_cloud.py
+++ b/soda/core/soda/soda_cloud/soda_cloud.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import requests
@@ -108,7 +108,7 @@ class SodaCloud:
             scan_folder_name = (
                 f"{self._fileify(scan_definition_name)}"
                 f'_{scan_data_timestamp.strftime("%Y%m%d%H%M%S")}'
-                f'_{datetime.utcnow().strftime("%Y%m%d%H%M%S")}'
+                f'_{datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")}'
             )
 
             with tempfile.TemporaryFile() as temp_file:

--- a/soda/core/tests/helpers/mock_soda_cloud.py
+++ b/soda/core/tests/helpers/mock_soda_cloud.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from requests import Response
 from soda.common.json_helper import JsonHelper
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class TimeGenerator:
     def __init__(
         self,
-        timestamp: datetime = datetime.utcnow(),
+        timestamp: datetime = datetime.now(tz=timezone.utc),
         timedelta: timedelta = timedelta(days=-1),
     ):
         self.timestamp = timestamp


### PR DESCRIPTION
Only one usage was fixed in the previous PR, this fixes all remaining `datetime.utcnow()`