### PR TITLE
Publish data source packages for python 3.7

### DIFF
--- a/soda/athena/setup.py
+++ b/soda/athena/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-athena"

--- a/soda/bigquery/setup.py
+++ b/soda/bigquery/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-bigquery"

--- a/soda/core/setup.py
+++ b/soda/core/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda Core requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core"
@@ -47,5 +47,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.7",
 )

--- a/soda/db2/setup.py
+++ b/soda/db2/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-db2"

--- a/soda/postgres/setup.py
+++ b/soda/postgres/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-postgres"

--- a/soda/redshift/setup.py
+++ b/soda/redshift/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-redshift"

--- a/soda/snowflake/setup.py
+++ b/soda/snowflake/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda SQL requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-snowflake"

--- a/soda/spark_df/setup.py
+++ b/soda/spark_df/setup.py
@@ -3,9 +3,9 @@ import sys
 
 from setuptools import find_namespace_packages, setup
 
-if sys.version_info < (3, 8):
-    print("Error: Soda Core requires at least Python 3.8")
-    print("Error: Please upgrade your Python version to 3.8 or later")
+if sys.version_info < (3, 7):
+    print("Error: Soda SQL requires at least Python 3.7")
+    print("Error: Please upgrade your Python version to 3.7 or later")
     sys.exit(1)
 
 package_name = "soda-core-spark-df"


### PR DESCRIPTION
This turned out to be much less than ideal:
1) Running tests for 37 would get clunky because of inability of tox to override deps. We could exclude scientific packages from requirements.txt and then install in explicitly for "standard" test suite etc but its clunky
2) even if we did 1) we cannot really get the whole test suite to be green anyway as scientific package is required in a few of the core tests 
3) This is temporary anyway

We could deal with 1) and run a subset of tests but that seems unnecessary imho.