### PR TITLE
feat: skip row count query during column profiling

### DIFF
--- a/soda/core/soda/execution/check/profile_columns_run.py
+++ b/soda/core/soda/execution/check/profile_columns_run.py
@@ -73,12 +73,11 @@ class ProfileColumnsRun:
             self.profile_columns_cfg.exclude_columns
         )
 
-        self.logs.info(f"Profiling columns for the following tables:")
+        self.logs.info("Profiling columns for the following tables:")
         for table_name in table_names:
             self.logs.info(f"  - {table_name}")
-            measured_row_count = self.data_source.get_table_row_count(table_name)
             profile_columns_result_table = profile_columns_result.create_table(
-                table_name, self.data_source.data_source_name, measured_row_count
+                table_name, self.data_source.data_source_name, row_count=None
             )
             included_columns, excluded_columns = self.build_column_inclusion_exclusion_lists(
                 table_name, parsed_included_tables_and_columns, parsed_excluded_tables_and_columns

--- a/soda/core/soda/profiling/profile_columns_result.py
+++ b/soda/core/soda/profiling/profile_columns_result.py
@@ -47,10 +47,10 @@ class ProfileColumnsResultColumn:
 
 
 class ProfileColumnsResultTable:
-    def __init__(self, table_name: str, data_source: str, row_count: int):
+    def __init__(self, table_name: str, data_source: str, row_count: int | None = None):
         self.table_name: str = table_name
         self.data_source: str = data_source
-        self.row_count: int = row_count
+        self.row_count: int | None = row_count
         self.result_columns: list[ProfileColumnsResultColumn] = []
 
     def create_column(self, column_name: str, column_type: str) -> ProfileColumnsResultColumn:
@@ -72,7 +72,9 @@ class ProfileColumnsResult:
         self.profile_columns_cfg: ProfileColumnsCfg = profile_columns_cfg
         self.tables: list[ProfileColumnsResultTable] = []
 
-    def create_table(self, table_name: str, data_source_name: str, row_count: int) -> ProfileColumnsResultTable:
+    def create_table(
+        self, table_name: str, data_source_name: str, row_count: int | None = None
+    ) -> ProfileColumnsResultTable:
         table = ProfileColumnsResultTable(table_name, data_source_name, row_count)
         self.tables.append(table)
         return table


### PR DESCRIPTION
Column profiling isn't really supposed to take care of deriving row counts for a dataset because `discover datasets` does it. However, we were deriving this row count anyway in order to satisfy the `create_table` contract. 

This contract has now been relaxed to allow for `row_count` to be null.

I also tested sending a `profile columns` result to cloud which did not have a row count and cloud accepts it.