### PR TITLE
Log and trace Soda Cloud trace IDs

### DIFF
--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -473,6 +473,12 @@ class Scan:
                     self._logs.info("Sending results to Soda Cloud")
                     self._configuration.soda_cloud.send_scan_results(self)
 
+                    if "send_scan_results" in self._configuration.soda_cloud.soda_cloud_trace_ids:
+                        cloud_trace_id = self._configuration.soda_cloud.soda_cloud_trace_ids["send_scan_results"]
+                        self._logs.info(f"Soda Cloud Trace: {cloud_trace_id}")
+                    else:
+                        self._logs.info("Soda Cloud Trace ID not available.")
+
             except Exception as e:
                 exit_value = 3
                 self._logs.error(f"Error occurred while sending scan results to soda cloud.", exception=e)
@@ -488,6 +494,10 @@ class Scan:
                 "metrics_count": len(self._metrics),
             }
         )
+        if self._configuration.soda_cloud:
+            for request_name, trace_id in self._configuration.soda_cloud.soda_cloud_trace_ids.items():
+                soda_telemetry.set_attribute(f"soda_cloud_trace_id__{request_name}", trace_id)
+
         return exit_value
 
     def run_data_source_scan(self):

--- a/soda/core/soda/telemetry/soda_telemetry.py
+++ b/soda/core/soda/telemetry/soda_telemetry.py
@@ -105,6 +105,10 @@ class SodaTelemetry:
 
         trace.set_tracer_provider(self.__provider)
 
+    def get_attribute(self, key: str, default_value=None) -> any:
+        """There is no obvious easy way to get attribute value from the current span."""
+        raise NotImplementedError()
+
     def set_attribute(self, key: str, value: str) -> None:
         """Set attribute value in the current span."""
         if self.__send:

--- a/soda/core/tests/helpers/mock_soda_cloud.py
+++ b/soda/core/tests/helpers/mock_soda_cloud.py
@@ -205,7 +205,7 @@ class MockSodaCloud(SodaCloud):
             kwargs["data"] = data.read().decode("utf-8")
         raise AssertionError(f"Unsupported request to mock soda cloud: {JsonHelper.to_json_pretty(kwargs)}")
 
-    def _mock_server_command(self, url, headers, json):
+    def _mock_server_command(self, url, headers, json, request_name):
         command_type = json.get("type")
         if command_type == "login":
             return self._mock_server_command_login(url, headers, json)
@@ -213,7 +213,7 @@ class MockSodaCloud(SodaCloud):
             return self._mock_server_command_sodaCoreInsertScanResults(url, headers, json)
         raise AssertionError(f"Unsupported command type {command_type}")
 
-    def _mock_server_query(self, url, headers, json):
+    def _mock_server_query(self, url, headers, json, request_name):
         query_type = json.get("type")
         if query_type == "sodaCoreCloudConfiguration":
             return self._mock_server_query_core_cfg(url, headers, json)


### PR DESCRIPTION
Produces:
```
...
1/1 check PASSED:
    sodatest_customers_b7580920 in soda_test
      correct name [PASSED]
        check_value: 10
All is good. No failures. No warnings. No errors.
Sending results to Soda Cloud
Soda Cloud Trace: 5665396938212519809
...
```
and in telemetry:
```
    },
    "attributes": {
        "user_cookie_id": "ecce720d-af39-4a12-89ae-b480fff7059d",
         ...
        "soda_cloud_trace_id__get_token": "1544882401638874526",
        "soda_cloud_trace_id__is_samples_disabled": "5195034207881313683",
        "soda_cloud_trace_id__send_scan_results": "5665396938212519809"
    },