### PR TITLE
Restoring --scan-results-file CLI arg for scan

### DIFF
--- a/soda/core/soda/cli/cli.py
+++ b/soda/core/soda/cli/cli.py
@@ -58,6 +58,12 @@ if __name__ == "__main__":
     type=click.STRING,
 )
 @click.option("-V", "--verbose", is_flag=True)
+@click.option(
+    '-srf', '--scan-results-file',
+    required=False,
+    default=None,
+    help='Specify the file path where the scan results as json will be stored'
+)
 @click.argument("sodacl_paths", nargs=-1, type=click.STRING)
 @soda_trace
 def scan(
@@ -67,6 +73,7 @@ def scan(
     configuration: List[str],
     variable: List[str],
     verbose: Optional[bool],
+    scan_results_file: Optional[str] = None,
 ):
     """
     soda scan will
@@ -121,6 +128,7 @@ def scan(
                 "offline": False,  # TODO: change after offline mode is supported.
                 "non_interactive": False,  # TODO: change after non interactive mode is supported.
                 "verbose": verbose,
+                "scan_results_file": scan_results_file,
             },
         }
     )
@@ -158,6 +166,9 @@ def scan(
     if variable:
         variables_dict = dict([tuple(v.split("=")) for v in variable])
         scan.add_variables(variables_dict)
+
+    if isinstance(scan_results_file, str):
+        scan.set_scan_results_file(scan_results_file)
 
     sys.exit(scan.execute())
 

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -20,6 +20,7 @@ from soda.profiling.profile_columns_result import ProfileColumnsResultTable
 from soda.profiling.sample_tables_result import SampleTablesResultTable
 from soda.sampler.default_sampler import DefaultSampler
 from soda.soda_cloud.historic_descriptor import HistoricDescriptor
+from soda.soda_cloud.soda_cloud import SodaCloud
 from soda.sodacl.location import Location
 from soda.sodacl.sodacl_cfg import SodaCLCfg
 from soda.telemetry.soda_telemetry import SodaTelemetry
@@ -42,6 +43,7 @@ class Scan:
 
         self._logs = Logs(logger)
         self._scan_definition_name: str | None = None
+        self._scan_results_file: str | None = None
         self._data_source_name: str | None = None
         self._variables: dict[str, object] = {"NOW": now.isoformat()}
         self._configuration: Configuration = Configuration(scan=self)
@@ -77,6 +79,9 @@ class Scan:
         self._logs.verbose = verbose_var
         global verbose
         verbose = verbose_var
+
+    def set_scan_results_file(self, set_scan_results_file: str):
+        self._scan_results_file = set_scan_results_file
 
     def add_configuration_yaml_file(self, file_path: str):
         """
@@ -484,6 +489,11 @@ class Scan:
                 self._logs.error(f"Error occurred while sending scan results to soda cloud.", exception=e)
 
             self._close()
+
+        if self._scan_results_file is not None:
+            logger.info(f'Saving scan results to {self._scan_results_file}')
+            with open(self._scan_results_file, 'w') as f:
+                json.dump(SodaCloud.build_scan_results(self), f)
 
         # Telemetry data
         soda_telemetry.set_attributes(


### PR DESCRIPTION
#569 introduced a `--scan-results-file` argument for `scan` however this was later removed. It would be great to restore this functionality so the results of a scan can be used in downstream processes (for example [#122](https://github.com/sodadata/soda-sql/issues/122)).