### PR TITLE
feat(profiling): add support for extra numeric and text datatypes

### DIFF
--- a/soda/bigquery/soda/data_sources/bigquery_data_source.py
+++ b/soda/bigquery/soda/data_sources/bigquery_data_source.py
@@ -46,7 +46,19 @@ class BigQueryDataSource(DataSource):
         DataType.BOOLEAN: "BOOL",
     }
 
-    NUMERIC_TYPES_FOR_PROFILING = ["NUMERIC", "INT64"]
+    NUMERIC_TYPES_FOR_PROFILING = [
+        "NUMERIC",
+        "INT64",
+        "INT",
+        "SMALLINT",
+        "INTEGER",
+        "BIGINT",
+        "TINYINT",
+        "DECIMAL",
+        "BIGNUMERIC",
+        "BIGDECIMAL",
+        "FLOAT64",
+    ]
     TEXT_TYPES_FOR_PROFILING = ["STRING"]
 
     def __init__(self, logs: Logs, data_source_name: str, data_source_properties: dict):
@@ -117,7 +129,10 @@ class BigQueryDataSource(DataSource):
             raise DataSourceConnectionError(self.TYPE, e)
 
     def sql_get_table_columns(
-        self, table_name: str, included_columns: list[str] | None = None, excluded_columns: list[str] | None = None
+        self,
+        table_name: str,
+        included_columns: list[str] | None = None,
+        excluded_columns: list[str] | None = None,
     ):
         included_columns_filter = ""
         excluded_columns_filter = ""

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -142,7 +142,19 @@ class DataSource:
         DataType.BOOLEAN: "boolean",
     }
 
-    NUMERIC_TYPES_FOR_PROFILING = ["integer", "double precision", "double"]
+    NUMERIC_TYPES_FOR_PROFILING = [
+        "integer",
+        "double precision",
+        "double",
+        "smallint",
+        "bigint",
+        "decimal",
+        "numeric",
+        "real",
+        "smallserial",
+        "serial",
+        "bigserial",
+    ]
     TEXT_TYPES_FOR_PROFILING = ["character varying", "varchar", "text"]
 
     DEFAULT_FORMATS: dict[str, str] = FormatHelper.build_default_formats()

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -155,7 +155,7 @@ class DataSource:
         "serial",
         "bigserial",
     ]
-    TEXT_TYPES_FOR_PROFILING = ["character varying", "varchar", "text"]
+    TEXT_TYPES_FOR_PROFILING = ["character varying", "varchar", "text", "character", "char"]
 
     DEFAULT_FORMATS: dict[str, str] = FormatHelper.build_default_formats()
 

--- a/soda/db2/soda/data_sources/db2_data_source.py
+++ b/soda/db2/soda/data_sources/db2_data_source.py
@@ -44,8 +44,18 @@ class Db2DataSource(DataSource):
         DataType.BOOLEAN: "BOOLEAN",
     }
 
-    NUMERIC_TYPES_FOR_PROFILING = ["INT", "DOUBLE"]
-    TEXT_TYPES_FOR_PROFILING = ["VARCHAR"]
+    NUMERIC_TYPES_FOR_PROFILING = [
+        "INT",
+        "DOUBLE",
+        "SMALLINT",
+        "INTEGER",
+        "BIGINT",
+        "DECIMAL",
+        "NUMERIC",
+        "REAL",
+        "DECFLOAT",
+    ]
+    TEXT_TYPES_FOR_PROFILING = ["VARCHAR", "CHARACTER"]
 
     def __init__(self, logs: Logs, data_source_name: str, data_source_properties: dict):
         super().__init__(logs, data_source_name, data_source_properties)
@@ -147,7 +157,11 @@ class Db2DataSource(DataSource):
         schema_column_name: str = "table_schema",
     ) -> str:
         return super().sql_find_table_names(
-            filter, include_tables, exclude_tables, table_column_name="TABNAME", schema_column_name="TABSCHEMA"
+            filter,
+            include_tables,
+            exclude_tables,
+            table_column_name="TABNAME",
+            schema_column_name="TABSCHEMA",
         )
 
     def literal_datetime(self, datetime: datetime):

--- a/soda/snowflake/soda/data_sources/snowflake_data_source.py
+++ b/soda/snowflake/soda/data_sources/snowflake_data_source.py
@@ -46,7 +46,20 @@ class SnowflakeDataSource(DataSource):
         DataType.BOOLEAN: "BOOLEAN",
     }
 
-    NUMERIC_TYPES_FOR_PROFILING = ["FLOAT", "NUMBER", "INT"]
+    NUMERIC_TYPES_FOR_PROFILING = [
+        "FLOAT",
+        "NUMBER",
+        "INT",
+        "DECIMAL",
+        "NUMERIC",
+        "INTEGER",
+        "BIGINT",
+        "SMALLINT",
+        "TINYINT",
+        "FLOAT4",
+        "FLOAT8",
+        "REAL",
+    ]
     TEXT_TYPES_FOR_PROFILING = ["TEXT"]
 
     def __init__(self, logs: Logs, data_source_name: str, data_source_properties: dict):

--- a/soda/snowflake/soda/data_sources/snowflake_data_source.py
+++ b/soda/snowflake/soda/data_sources/snowflake_data_source.py
@@ -60,7 +60,18 @@ class SnowflakeDataSource(DataSource):
         "FLOAT8",
         "REAL",
     ]
-    TEXT_TYPES_FOR_PROFILING = ["TEXT"]
+    TEXT_TYPES_FOR_PROFILING = [
+        "TEXT",
+        "VARCHAR",
+        "CHAR",
+        "CHARACTER",
+        "NCHAR",
+        "STRING",
+        "NVARCHAR",
+        "NVARCHAR2",
+        "CHAR VARYING",
+        "NCHAR VARYING",
+    ]
 
     def __init__(self, logs: Logs, data_source_name: str, data_source_properties: dict):
         super().__init__(logs, data_source_name, data_source_properties)


### PR DESCRIPTION
I recently realised that we were only considering the most common data types in column profiling for most dbs.

I've now added support to pretty much all numeric and text types for the following databases:
- postgres (base) & therefore redshift
- snowflake
- bigquery
- db2

I've left out:
- athena because it seems like types for profiling were commented out (not sure why), see: https://github.com/sodadata/soda-core/blob/main/soda/athena/soda/data_sources/athena_data_source.py#L84-L85
- sqlserver (all types seem to be already there from a previous implementation)
- MySQL (all types seem to be already there from a previous implementation)
