### PR TITLE
Databricks SQL Warehouse support

### DIFF
--- a/soda/spark/setup.py
+++ b/soda/spark/setup.py
@@ -21,6 +21,7 @@ extras = {
     "odbc": [
         "pyodbc",
     ],
+    "databricks": ["databricks-sql-connector"],
 }
 # TODO Fix the params
 setup(

--- a/soda/spark/tests/spark_data_source_fixture.py
+++ b/soda/spark/tests/spark_data_source_fixture.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from helpers.data_source_fixture import DataSourceFixture
+
+logger = logging.getLogger(__name__)
+
+
+class SparkDataSourceFixture(DataSourceFixture):
+    def __init__(self, test_data_source: str):
+        super().__init__(test_data_source)
+
+    def _build_configuration_dict(self, schema_name: str | None = None) -> dict:
+        return {
+            "data_source spark": {
+                "type": "spark",
+                "host": os.getenv("DATABRICKS_HOST"),
+                "method": os.getenv("SPARK_METHOD"),
+                "http_path": os.getenv("DATABRICKS_HTTP_PATH"),
+                "token": os.getenv("DATABRICKS_TOKEN"),
+                "database": os.getenv("DATABRICKS_DATABASE")
+
+            }
+        }
+
+    def _create_schema_if_not_exists_sql(self) -> str:
+        return f"CREATE SCHEMA IF NOT EXISTS {self.schema_name}"
+
+    def _use_schema_sql(self) -> str | None:
+        return None
+
+    def _drop_schema_if_exists_sql(self):
+        return f"DROP SCHEMA IF EXISTS {self.schema_name} CASCADE"

--- a/soda/spark/tests/spark_data_source_fixture.py
+++ b/soda/spark/tests/spark_data_source_fixture.py
@@ -20,8 +20,7 @@ class SparkDataSourceFixture(DataSourceFixture):
                 "method": os.getenv("SPARK_METHOD"),
                 "http_path": os.getenv("DATABRICKS_HTTP_PATH"),
                 "token": os.getenv("DATABRICKS_TOKEN"),
-                "database": os.getenv("DATABRICKS_DATABASE")
-
+                "database": os.getenv("DATABRICKS_DATABASE"),
             }
         }
 


### PR DESCRIPTION
To connect to databricks SQL Warehouse, first install the package using:
`pip install soda-core-spark[databricks]` and use the following as configuration.yml

```yaml
data_source abc:
  type: spark
  catalog: samples
  schema: nyctaxi
  method: databricks
  host: **hostname from SQL Warehouse settings**
  http_path: **http_path from SQL Warehouse Settings**
  token: **access_token**
```