### PR TITLE
SODA-914: add context authentication and impersonation for BigQuery

### DIFF
--- a/soda/bigquery/soda/data_sources/bigquery_data_source.py
+++ b/soda/bigquery/soda/data_sources/bigquery_data_source.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 
+from google.auth import default, impersonated_credentials
 from google.cloud import bigquery
 from google.cloud.bigquery import dbapi
 from google.oauth2.service_account import Credentials
@@ -88,16 +89,28 @@ class BigQueryDataSource(DataSource):
         self.auth_scopes = data_source_properties.get("auth_scopes", default_auth_scopes)
 
         self.credentials = None
+        self.project_id = None
+
         if self.account_info_dict:
             self.credentials = Credentials.from_service_account_info(
                 self.account_info_dict,
                 scopes=self.auth_scopes,
             )
+            self.project_id = self.account_info_dict.get("project_id")
 
-        # All remaining parameters
-        # Usually the project_id comes from the self.account_info_dict
-        self.project_id = self.account_info_dict.get("project_id") if self.account_info_dict else None
-        # But users can optionally overwrite in the connection properties
+        if self.data_source_properties.get("use_context_auth") or self.account_info_dict is None:
+            self.logs.info("Using application default credentials.")
+            self.credentials, self.project_id = default()
+
+        if self.data_source_properties.get("impersonation_account"):
+            self.logs.info("Using impersonation of Service Account.")
+            self.credentials = impersonated_credentials.Credentials(
+                source_credentials=self.credentials,
+                target_principal=str(self.data_source_properties.get("impersonation_account")),
+                target_scopes=self.auth_scopes,
+            )
+
+        # Users can optionally overwrite in the connection properties
         self.project_id = data_source_properties.get("project_id", self.project_id)
 
         self.dataset = data_source_properties.get("dataset")
@@ -109,8 +122,6 @@ class BigQueryDataSource(DataSource):
         self.client_options = data_source_properties.get("client_options")
 
     def connect(self):
-        if not self.credentials:
-            self.logs.info("Using application default credentials.")
         try:
             self.client = bigquery.Client(
                 project=self.project_id,


### PR DESCRIPTION
With GCP/BigQuery one has the option to use different methods to authenticate.
The standard authentication methods are:

1. Use of Application Default Credentials
2. Use of Application Default Credentials with Service Account impersonation
3. Use of Service Account Key (already implemented)
4. Use of Service Account Key with Service Account Impersonation  


###  Usage in configuration.yml file:
1. Use of Application Default Credentials
```
data_source <SOURCE-NAME>:
  type: bigquery
  connection:
    use_context_auth: True
```
2. Use of Application Default Credentials with Service Account impersonation
```
data_source <SOURCE-NAME>:
  type: bigquery
  connection:
    use_context_auth: True
    impersonation_account: <SA_EMAIL>
```
3. Use of Service Account Key
...
4. Use of Service Account Key with Service Account Impersonation
```
data_source my_database_name:
  type: bigquery
  connection:
    account_info_json: '{
        "type": "service_account",
        "project_id": "...",
        "private_key_id": "...",
      ...}'
    impersonation_account: <SA_EMAIL>
```


@m1n0 
I have incorporated you requested changes regarding some duplicate lines. Thanks for the remark.


