### PR TITLE
Failed rows configurable sample size for duplicate_count check

### DIFF
--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -476,6 +476,23 @@ class DataSource:
     def sql_analyze_table(self, table: str) -> str | None:
         return None
 
+    def sql_get_duplicates(
+        self, column_names: str, table_name: str, filter: str, limit: str | None = None
+    ) -> str | None:
+        sql = f"""WITH frequencies AS (
+              SELECT {column_names}, COUNT(*) AS frequency
+              FROM {table_name}
+              WHERE {filter}
+              GROUP BY {column_names})
+            SELECT *
+            FROM frequencies
+            WHERE frequency > 1"""
+
+        if limit:
+            sql += f"\n LIMIT {limit}"
+
+        return sql
+
     def cast_to_text(self, expr: str) -> str:
         return f"CAST({expr} AS VARCHAR)"
 

--- a/soda/core/tests/data_source/test_samples.py
+++ b/soda/core/tests/data_source/test_samples.py
@@ -167,6 +167,8 @@ def test_sample_limit_configuration(data_source_fixture: DataSourceFixture):
             samples limit: 2
         - values in (size) must exist in {another_table_name} (size):
             samples limit: 2
+        - duplicate_count(zip) = 0:
+            samples limit: 2
     """
     )
     scan.execute()
@@ -175,3 +177,4 @@ def test_sample_limit_configuration(data_source_fixture: DataSourceFixture):
 
     assert mock_soda_cloud.find_failed_rows_line_count(0) == 2
     assert mock_soda_cloud.find_failed_rows_line_count(1) == 2
+    assert mock_soda_cloud.find_failed_rows_line_count(2) == 2

--- a/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
+++ b/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
@@ -288,3 +288,22 @@ class SQLServerDataSource(DataSource):
 
     def expr_false_condition(self):
         return "1 = 0"
+
+    def sql_get_duplicates(
+        self, column_names: str, table_name: str, filter: str, limit: str | None = None
+    ) -> str | None:
+        limit_sql = ""
+
+        if limit:
+            limit_sql = f" TOP {limit} "
+
+        sql = f"""WITH frequencies AS (
+              SELECT {column_names}, COUNT(*) AS frequency
+              FROM {table_name}
+              WHERE {filter}
+              GROUP BY {column_names})
+            SELECT {limit_sql} *
+            FROM frequencies
+            WHERE frequency > 1"""
+
+        return sql


### PR DESCRIPTION
duplicate_count check did not correctly support the sample limit config, this fixes the issue. Minor refactor of duplicate query is included as well to remove creating of the actual duplicate query sql from query and leave it as data source responsibility. Added limit support as well (not used at the moment)