### PR TITLE
chore: pin prophet to >=1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN ln -s /usr/bin/python3.9 /usr/bin/python && \
 # extra dependencies for soda-scientific
 RUN pip --no-cache-dir install "numpy>=1.15.4" \
                                "Cython>=0.22"
-RUN pip --no-cache-dir install -r "https://raw.githubusercontent.com/facebook/prophet/v1.0/python/requirements.txt"
-
 RUN mkdir /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 ENV ACCEPT_EULA=Y
 RUN apt-get update && apt-get install -y curl gnupg2
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN curl https://packages.microsoft.com/config/ubuntu/21.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 # install dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -21,8 +21,7 @@ requires = [
     "httpx>=0.18.1,<2.0.0",
     "PyYAML>=5.4.1,<6.0.0",
     "cython>=0.22",
-    "pystan==2.19.1.1",
-    "prophet==1.0.0"  # Pinned 1.0.0 until 1.1 (and above) installation issues are resolved. https://sodadata.atlassian.net/browse/CLOUD-446
+    "prophet>=1.1.0,<2.0.0"  # Pinned 1.0.0 until 1.1 (and above) installation issues are resolved. https://sodadata.atlassian.net/browse/CLOUD-446
     # Uncomment & recreate .venv to make scientific tests work
     # "prophet @ git+https://github.com/facebook/prophet.git#egg=prophet&subdirectory=python",
 ]

--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -21,9 +21,7 @@ requires = [
     "httpx>=0.18.1,<2.0.0",
     "PyYAML>=5.4.1,<6.0.0",
     "cython>=0.22",
-    "prophet>=1.1.0,<2.0.0"  # Pinned 1.0.0 until 1.1 (and above) installation issues are resolved. https://sodadata.atlassian.net/browse/CLOUD-446
-    # Uncomment & recreate .venv to make scientific tests work
-    # "prophet @ git+https://github.com/facebook/prophet.git#egg=prophet&subdirectory=python",
+    "prophet>=1.1.0,<2.0.0",
 ]
 
 # TODO Fix the params


### PR DESCRIPTION
When tested locally I am able to install the scientific library without issues but I used to never have any issues.

@jmarien and I were able to build the docker image locally as well

This is an attempt to not having to install `pystan` anymore which causes known issues with some of our customers.