### PR TITLE
fix(anomaly_check): only send outcomeReasons with severity "warn" or "error"

### DIFF
--- a/soda/core/soda/execution/check/anomaly_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_metric_check.py
@@ -129,7 +129,7 @@ class AnomalyMetricCheck(MetricCheck):
         self.check_value = diagnostics["anomalyProbability"]
         self.outcome = CheckOutcome(level)
         self.diagnostics = diagnostics
-        if diagnostics["anomalyErrorCode"]:
+        if diagnostics["anomalyErrorSeverity"] in ["warn", "error"]:
             self.add_outcome_reason(
                 outcome_type=diagnostics["anomalyErrorCode"],
                 message=diagnostics["anomalyErrorMessage"],

--- a/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
@@ -80,13 +80,13 @@ DETECTOR_MESSAGES: Dict[str, DetectorMessageComponent] = {
         error_code_str="",
     ),
     "coerced_daily": DetectorMessageComponent(
-        log_message="coerced to daily freq with last daily time point kept",
+        log_message="Coerced to daily frequency with last daily time point kept",
         severity="warn",
         error_code_int=2,
         error_code_str="made_daily_keeping_last_point_only",
     ),
     "last_four": DetectorMessageComponent(
-        log_message="frequency inferred from the last 4 stable data points",
+        log_message="Frequency inferred from the last 4 stable data points",
         severity="warn",
         error_code_int=3,
         error_code_str="frequency_from_last_4_points",


### PR DESCRIPTION
This PR resolves the following bug: [Anomaly Detection native frequency detected message is shown in Cloud UI](https://sodadata.atlassian.net/browse/CLOUD-1689)

@bastienboutonnet, I spoke with dirk and based on [this](https://github.com/sodadata/soda/blob/8811034e16c41942f8a19b41675989b4152b2713/soda-webapp/src/app/features/tests/components/outcome-reason-banner/outcome-reasons.ts#L19) and [this](https://github.com/sodadata/soda-core/blob/04938d26d8ee495a5592debc806bd66a3d9eb656/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py#L69) I think we should send `outcomeReasons` to cloud for messages with severity `warn` or `error`

It's possible that instead of using the list literal here we could use a class variable that defines for which severity levels we send to cloud, but I think this is more readable and more in line with the rest of the code style. Let me know if you disagree!

