### PR TITLE
Update trino_data_source.py

### DIFF
--- a/soda/trino/soda/data_sources/trino_data_source.py
+++ b/soda/trino/soda/data_sources/trino_data_source.py
@@ -71,9 +71,9 @@ class TrinoDataSource(DataSource):
 
     def connect(self):
         # Default to BasicAuthentication so we don't break current users.
-        if self.authType == 'BasicAuthentication':
+        if self.authType == "BasicAuthentication":
             self.auth = trino.auth.BasicAuthentication(self.username, self.password)
-        elif self.authType == 'NoAuthentication':
+        elif self.authType == "NoAuthentication":
             # No auth typically should use http. If your connection fails, try 'http_scheme: http' in your data source confguration.
             self.auth = None
         # Add other auth types here as needed
@@ -85,14 +85,14 @@ class TrinoDataSource(DataSource):
         self.connection = trino.dbapi.connect(
             # experimental_python_types is required to recieve values in appropriate python data types
             # https://github.com/trinodb/trino-python-client#improved-python-types
-            experimental_python_types = True,
-            host = self.host,
-            port = self.port,
-            catalog = self.catalog,
-            schema = self.schema,
-            user = self.username,
-            http_scheme = self.http_scheme,
-            auth = self.auth
+            experimental_python_types=True,
+            host=self.host,
+            port=self.port,
+            catalog=self.catalog,
+            schema=self.schema,
+            user=self.username,
+            http_scheme=self.http_scheme,
+            auth=self.auth,
         )
 
     def regex_replace_flags(self) -> str:


### PR DESCRIPTION
Added no auth without breaking existing users.

The following properties need to be added to the connection for no auth.  Setting the http_scheme to http is likely needed as no auth is unencrypted and undocumented.
```
    auth_type: NoAuthentication
    http_scheme: http
```

Also, password is optional/not needed with NoAuthentication.