### PR TITLE
Introduce http sampler

### DIFF
--- a/soda/core/soda/configuration/configuration_parser.py
+++ b/soda/core/soda/configuration/configuration_parser.py
@@ -7,6 +7,7 @@ from soda.cloud.dbt_config import DbtCloudConfig
 from soda.common.logs import Logs
 from soda.common.parser import Parser
 from soda.configuration.configuration import Configuration
+from soda.sampler.http_sampler import HTTPSampler
 from soda.sampler.soda_cloud_sampler import SodaCloudSampler
 from soda.soda_cloud.soda_cloud import SodaCloud
 
@@ -75,10 +76,19 @@ class ConfigurationParser(Parser):
                                     location=self.location,
                                 )
 
-                        custom_storage = sampler_configuration.get("custom_storage")
-                        if custom_storage:
-                            # TODO: deal with custom sampler storage config.
-                            pass
+                        storage = sampler_configuration.get("storage")
+                        if storage:
+                            storage_type = storage.get("type")
+                            if storage_type in ["http", "s3"]:
+                                if storage_type == "http":
+                                    url = storage.get("url")
+                                    self.configuration.sampler = HTTPSampler(url)
+                            else:
+                                self.logs.error(
+                                    f"Invalid storage type: {storage_type} specified, must be one of ['http', 's3']",
+                                    location=self.location,
+                                )
+
                     else:
                         self.logs.error(
                             "'sampler' configuration must be a dict",

--- a/soda/core/soda/execution/query/query.py
+++ b/soda/core/soda/execution/query/query.py
@@ -168,9 +168,9 @@ class Query:
                 self.description = cursor.description
 
                 # Check if query does not contain forbidden columns and only create sample if it does not.
-                # Query still needs to execute in such situation because some of the queries create both a metric
+                # Query still needs to execute in such situation because some queries create both a metric
                 # for a check and get the samples.
-                # This has a limitation - some of the metrics (e.g. duplicate_count) are set when storing the sample,
+                # This has a limitation - some metrics (e.g. duplicate_count) are set when storing the sample,
                 # so those need a workaround - see below.
                 allow_samples = True
                 offending_columns = []

--- a/soda/core/soda/sampler/http_sampler.py
+++ b/soda/core/soda/sampler/http_sampler.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+
+import requests
+from soda.sampler.sample_context import SampleContext
+from soda.sampler.sample_ref import SampleRef
+from soda.sampler.sampler import Sampler
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPSampler(Sampler):
+    def __init__(self, url: str, format: str = "json"):
+        self.url = url
+        self.format = format
+
+    def store_sample(self, sample_context: SampleContext) -> SampleRef | None:
+
+        logger.info(f"Sending failed row samples to {self.url}")
+        sample_rows = sample_context.sample.get_rows()
+        row_count = len(sample_rows)
+        sample_schema = sample_context.sample.get_schema()
+
+        result_dict = {"schema": sample_schema.get_dict(), "count": row_count, "rows": sample_rows}
+
+        response = requests.post(self.url, json=result_dict)
+
+        if response.status_code != 200:
+            logger.error(f"Unable to upload failed rows to {self.url} -  {response.text}")
+        else:
+            logger.info(f"Uploaded {row_count} failed rows to {self.url}")
+
+        if sample_context.samples_limit is not None:
+            stored_row_count = row_count if row_count < sample_context.samples_limit else sample_context.samples_limit
+        else:
+            stored_row_count = row_count
+
+        return SampleRef(
+            name=sample_context.sample_name,
+            schema=sample_schema,
+            total_row_count=row_count,
+            stored_row_count=stored_row_count,
+            type="http",
+        )

--- a/soda/core/soda/sampler/sample_schema.py
+++ b/soda/core/soda/sampler/sample_schema.py
@@ -31,3 +31,6 @@ class SampleColumn:
 @dataclass
 class SampleSchema:
     columns: list[SampleColumn]
+
+    def get_dict(self):
+        return [x.get_dict() for x in self.columns]

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -358,7 +358,7 @@ class Scan:
                     if self._configuration.soda_cloud.is_samples_disabled():
                         self._configuration.sampler = DefaultSampler()
 
-            # Override the sampler, if it is configured
+            # Override the sampler, if it is configured programmatically
             if self.sampler is not None:
                 self._configuration.sampler = self.sampler
 


### PR DESCRIPTION
Sampler can be configured in data_source configuration:

```yaml
  sampler:
    storage:
      type: http
      url: http://localhost:8000
```

This will send the failed rows in as json to configured url e.g.:

```json
{
   "count":1,
   "schema":[
      {
         "name":"account_key",
         "type":"int4"
      }
   ],
   "rows":[
      [
         1,
         null,
         1,
         null,
         "~",
         null,
         "Currency",
         null
      ]
   ]
}
```