### PR TITLE
Variables everywhere

### DIFF
--- a/soda/core/soda/cli/cli.py
+++ b/soda/core/soda/cli/cli.py
@@ -168,12 +168,7 @@ def scan(
 
     __load_configuration(scan, configuration)
 
-    if sodacl_paths:
-        for sodacl_path_element in sodacl_paths:
-            scan.add_sodacl_yaml_files(sodacl_path_element)
-    else:
-        scan._logs.warning("No checks file specified")
-
+    # Add variables before adding files so that they can be immediately applied.
     if variable:
         variables_dict = {}
         for v in variable:
@@ -182,6 +177,12 @@ def scan(
             if variable_key and variable_value:
                 variables_dict[variable_key] = variable_value
         scan.add_variables(variables_dict)
+
+    if sodacl_paths:
+        for sodacl_path_element in sodacl_paths:
+            scan.add_sodacl_yaml_files(sodacl_path_element)
+    else:
+        scan._logs.warning("No checks file specified")
 
     if isinstance(scan_results_file, str):
         scan.set_scan_results_file(scan_results_file)

--- a/soda/core/soda/common/jinja.py
+++ b/soda/core/soda/common/jinja.py
@@ -14,7 +14,10 @@ class OsContext(Context):
             return self.vars[key]
         elif key == "env_var":
             return Jinja.env_var
-        return Context.resolve_or_missing(self, key)
+        if key in self.parent:
+            return self.parent[key]
+        # Ignore keys with no value, return as is.
+        return f"${{{key}}}"
 
 
 def create_os_environment():

--- a/soda/core/soda/execution/check/check.py
+++ b/soda/core/soda/execution/check/check.py
@@ -131,9 +131,8 @@ class Check(ABC):
 
         Uses user provided name if available or generates one from the check definition and thresholds.
         """
-        jinja_resolve = self.data_source_scan.scan.jinja_resolve
         if self.check_cfg.name:
-            return jinja_resolve(self.check_cfg.name)
+            return self.check_cfg.name
 
         name = self.check_cfg.source_line
 
@@ -146,7 +145,7 @@ class Check(ABC):
             if source_cfg.get("fail"):
                 name += f" fail {source_cfg['fail']}"
 
-        return jinja_resolve(name)
+        return name
 
     def create_definition(self) -> str:
         check_cfg: CheckCfg = self.check_cfg

--- a/soda/core/soda/execution/check/distribution_check.py
+++ b/soda/core/soda/execution/check/distribution_check.py
@@ -118,8 +118,6 @@ class DistributionCheck(Check):
 
     def sql_column_values_query(self, distribution_check_cfg: DistributionCheckCfg) -> str:
         column_name = distribution_check_cfg.column_name
-        scan = self.data_source_scan.scan
-
         partition_filter = self.partition.sql_partition_filter
         distribution_check_filter = distribution_check_cfg.filter
         sample_clause = distribution_check_cfg.sample_clause

--- a/soda/core/soda/execution/check/distribution_check.py
+++ b/soda/core/soda/execution/check/distribution_check.py
@@ -120,9 +120,9 @@ class DistributionCheck(Check):
         column_name = distribution_check_cfg.column_name
         scan = self.data_source_scan.scan
 
-        partition_filter = scan.jinja_resolve(self.partition.sql_partition_filter)
-        distribution_check_filter = scan.jinja_resolve(distribution_check_cfg.filter)
-        sample_clause = scan.jinja_resolve(distribution_check_cfg.sample_clause)
+        partition_filter = self.partition.sql_partition_filter
+        distribution_check_filter = distribution_check_cfg.filter
+        sample_clause = distribution_check_cfg.sample_clause
 
         filters = []
         filters.append(partition_filter)

--- a/soda/core/soda/execution/check/metric_check.py
+++ b/soda/core/soda/execution/check/metric_check.py
@@ -103,6 +103,7 @@ class MetricCheck(Check):
     def set_outcome_based_on_check_value(self):
         metric_check_cfg: MetricCheckCfg = self.check_cfg
         if self.check_value is not None and metric_check_cfg.has_threshold():
+            # TODO What is this jinja resolve doing ?!?!
             metric_check_cfg.resolve_thresholds(self.data_source_scan.scan.jinja_resolve)
             if isinstance(self.check_value, Number):
                 if metric_check_cfg.fail_threshold_cfg and metric_check_cfg.fail_threshold_cfg.is_bad(self.check_value):

--- a/soda/core/soda/execution/check/user_defined_failed_rows_expression_check.py
+++ b/soda/core/soda/execution/check/user_defined_failed_rows_expression_check.py
@@ -71,8 +71,7 @@ class UserDefinedFailedRowsExpressionCheck(Check):
         )
         partition_filter = self.partition.sql_partition_filter
         if partition_filter:
-            scan = self.data_source_scan.scan
-            condition = scan.jinja_resolve(definition=partition_filter, location=self.check_cfg.location)
+            condition = partition_filter
             sql += f"\n      AND ({condition})"
         return sql
 

--- a/soda/core/soda/execution/metric/numeric_query_metric.py
+++ b/soda/core/soda/execution/metric/numeric_query_metric.py
@@ -243,7 +243,7 @@ class NumericQueryMetric(QueryMetric):
             passing_where_clauses = []
             partition_filter = self.partition.sql_partition_filter
             if partition_filter:
-                resolved_filter = self.data_source_scan.scan.jinja_resolve(definition=partition_filter)
+                resolved_filter = partition_filter
                 where_clauses.append(resolved_filter)
                 passing_where_clauses.append(resolved_filter)
 

--- a/soda/core/soda/execution/query/aggregation_query.py
+++ b/soda/core/soda/execution/query/aggregation_query.py
@@ -21,15 +21,12 @@ class AggregationQuery(Query):
         self.metrics.append(metric)
 
     def execute(self):
-        scan = self.data_source_scan.scan
         select_expression_sql = f",\n  ".join(self.select_expressions)
         self.sql = f"SELECT \n" f"  {select_expression_sql} \n" f"FROM {self.partition.table.qualified_table_name}"
 
         partition_filter = self.partition.sql_partition_filter
         if partition_filter:
-            resolved_filter = scan.jinja_resolve(definition=partition_filter)
-            self.sql += f"\nWHERE {resolved_filter}"
-        self.sql = self.data_source_scan.scan.jinja_resolve(self.sql)
+            self.sql += f"\nWHERE {partition_filter}"
         self.fetchone()
         if self.row:
             for i in range(0, len(self.row)):

--- a/soda/core/soda/execution/query/query.py
+++ b/soda/core/soda/execution/query/query.py
@@ -39,7 +39,7 @@ class Query:
         # The SQL query that is used _fetchone or _fetchall or _store
         # This field can also be initialized in the execute method before any of _fetchone,
         # _fetchall or _store are called
-        self.sql: str = data_source_scan.scan.jinja_resolve(sql)
+        self.sql: str = sql
 
         # The SQL query that is the opposite of a failed rows query if applicable.
         self.passing_sql: str | None = passing_sql

--- a/soda/core/soda/execution/query/reference_query.py
+++ b/soda/core/soda/execution/query/reference_query.py
@@ -69,13 +69,13 @@ class ReferenceQuery(Query):
             ]
         )
 
-        self.sql = self.data_source_scan.scan.jinja_resolve(
+        self.sql = (
             f"SELECT {source_diagnostic_column_fields} \n"
             f"FROM {source_table_name}  SOURCE \n"
             f"     LEFT JOIN {target_table_name}  TARGET on {join_condition} \n"
             f"WHERE {where_condition}"
         )
-        self.passing_sql = self.data_source_scan.scan.jinja_resolve(
+        self.passing_sql = (
             f"SELECT {source_diagnostic_column_fields} \n"
             f"FROM {source_table_name}  SOURCE \n"
             f"     LEFT JOIN {target_table_name}  TARGET on {join_condition} \n"

--- a/soda/core/soda/execution/query/schema_query.py
+++ b/soda/core/soda/execution/query/schema_query.py
@@ -23,7 +23,6 @@ class TableColumnsQuery(Query):
         """
         data_source = self.data_source_scan.data_source
         self.sql = data_source.sql_get_table_columns(self.table.table_name)
-        self.sql = self.data_source_scan.scan.jinja_resolve(self.sql)
         self.fetchall()
 
     def _propagate_column_rows_to_metric_value(self):

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -282,6 +282,9 @@ class Scan:
     def _parse_sodacl_yaml_str(self, sodacl_yaml_str: str, file_path: str = None):
         from soda.sodacl.sodacl_parser import SodaCLParser
 
+        # First round of template resolve right when loading a sodacl string.
+        sodacl_yaml_str = self.jinja_resolve(sodacl_yaml_str)
+
         sodacl_parser = SodaCLParser(
             sodacl_cfg=self._sodacl_cfg,
             logs=self._logs,

--- a/soda/core/tests/data_source/test_vars.py
+++ b/soda/core/tests/data_source/test_vars.py
@@ -1,37 +1,43 @@
 from helpers.common_test_tables import customers_test_table
 from helpers.data_source_fixture import DataSourceFixture
+from helpers.fixtures import test_data_source
 from helpers.utils import execute_scan_and_get_scan_result
 
 
-def test_vars_in_name(data_source_fixture: DataSourceFixture):
+def test_vars_in_checks(data_source_fixture: DataSourceFixture):
     table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    date_expr = "" if test_data_source == "sqlserver" else "DATE"
 
     scan_result = execute_scan_and_get_scan_result(
         data_source_fixture,
         f"""
-          checks for {table_name}:
-            - row_count > 0:
-                name: testing name ${{NAME}}
+          filter ${{TABLE_NAME}} [${{PARTITION}}]:
+              ${{FILTER_KEY}}: ${{FILTER_COLUMN}} = {date_expr} '${{DATE}}'
+          checks for ${{TABLE_NAME}}:
+            - ${{CHECK}}:
+                name: Row count in ${{TABLE_NAME}} must be ${{NAME_OUTCOME}}
+
+          for each dataset ${{TABLE_ALIAS}}:
+            datasets:
+                - include ${{TABLE_NAME}}
+            checks:
+                - ${{CHECK}}:
+                    name: Row count in ${{D}} must be ${{NAME_OUTCOME}}
         """,
         variables={
-            "NAME": "something",
+            "TABLE_ALIAS": "D",
+            "TABLE_NAME": table_name,
+            "PARTITION": "daily",
+            "FILTER_KEY": "where",
+            "DATE": "2020-06-23",
+            "FILTER_COLUMN": "date_updated",
+            "FILTER_COLUMN": "cat",
+            "FILTER_VALUE": "'HIGH'",
+            "CHECK": "row_count > 0",
+            "NAME_OUTCOME": "positive",
         },
     )
-    assert scan_result["checks"][0]["name"] == "testing name something"
-
-
-def test_vars_in_foreach_name(data_source_fixture: DataSourceFixture):
-    table_name = data_source_fixture.ensure_test_table(customers_test_table)
-
-    scan_result = execute_scan_and_get_scan_result(
-        data_source_fixture,
-        f"""
-          for each dataset D:
-            datasets:
-                - include {table_name}
-            checks:
-                - row_count > 1:
-                    name: Row count in ${{D}} must be positive
-        """,
-    )
-    assert scan_result["checks"][0]["name"].lower() == f"Row count in {table_name} must be positive".lower()
+    for check in scan_result["checks"]:
+        assert check["name"].lower() == f"Row count in {table_name} must be positive".lower()
+        assert check["table"].lower() == table_name.lower()

--- a/soda/core/tests/data_source/test_vars.py
+++ b/soda/core/tests/data_source/test_vars.py
@@ -1,39 +1,68 @@
+import pytest
 from helpers.common_test_tables import customers_test_table
 from helpers.data_source_fixture import DataSourceFixture
 from helpers.fixtures import test_data_source
 from helpers.utils import execute_scan_and_get_scan_result
 
 
-def test_vars_in_checks(data_source_fixture: DataSourceFixture):
+@pytest.mark.parametrize(
+    "checks",
+    [
+        pytest.param(
+            """
+            filter ${TABLE_NAME} [${PARTITION}]:
+                ${FILTER_KEY}: ${FILTER_COLUMN_DATE} = {date_expr} '${some_time}'
+            checks for ${TABLE_NAME}:
+                - ${CHECK}:
+                    name: Row count in ${TABLE_NAME} must be ${NAME_OUTCOME}
+            variables:
+                some_time: '${DATE}'""",
+            id="partition filter",
+        ),
+        pytest.param(
+            """
+            checks for ${TABLE_NAME}:
+                - row_count > 0:
+                    filter: ${FILTER_COLUMN} = ${FILTER_VALUE}
+                    name: Row count in ${TABLE_NAME} must be ${NAME_OUTCOME}
+            variables:
+                some_time: '${DATE}'""",
+            id="in check filter",
+        ),
+        pytest.param(
+            """
+            for each dataset ${TABLE_ALIAS}:
+                datasets:
+                    - include ${TABLE_NAME}
+                checks:
+                    - ${CHECK}:
+                        name: Row count in ${TABLE_NAME} must be ${NAME_OUTCOME}
+            variables:
+                some_time: '${DATE}'""",
+            id="foreach",
+        ),
+    ],
+)
+def test_vars_in_checks(checks: str, data_source_fixture: DataSourceFixture):
     table_name = data_source_fixture.ensure_test_table(customers_test_table)
 
     date_expr = "" if test_data_source == "sqlserver" else "DATE"
+    checks = checks.replace("{date_expr}", date_expr)
 
     scan_result = execute_scan_and_get_scan_result(
         data_source_fixture,
-        f"""
-          filter ${{TABLE_NAME}} [${{PARTITION}}]:
-              ${{FILTER_KEY}}: ${{FILTER_COLUMN}} = {date_expr} '${{DATE}}'
-          checks for ${{TABLE_NAME}}:
-            - ${{CHECK}}:
-                name: Row count in ${{TABLE_NAME}} must be ${{NAME_OUTCOME}}
-
-          for each dataset ${{TABLE_ALIAS}}:
-            datasets:
-                - include ${{TABLE_NAME}}
-            checks:
-                - ${{CHECK}}:
-                    name: Row count in ${{D}} must be ${{NAME_OUTCOME}}
-        """,
+        checks,
         variables={
             "TABLE_ALIAS": "D",
             "TABLE_NAME": table_name,
             "PARTITION": "daily",
             "FILTER_KEY": "where",
+            # Date passed in as string, but this is replaced by jinja without quotes, yaml would consider it a datetime when loaded,
+            # so quotes can be added either here or in the variable definition in the SodaCL variables section.
             "DATE": "2020-06-23",
-            "FILTER_COLUMN": "date_updated",
-            "FILTER_COLUMN": "cat",
-            "FILTER_VALUE": "'HIGH'",
+            "FILTER_COLUMN_DATE": "date_updated",
+            "FILTER_COLUMN": "cst_size",
+            "FILTER_VALUE": "1",
             "CHECK": "row_count > 0",
             "NAME_OUTCOME": "positive",
         },
@@ -41,3 +70,5 @@ def test_vars_in_checks(data_source_fixture: DataSourceFixture):
     for check in scan_result["checks"]:
         assert check["name"].lower() == f"Row count in {table_name} must be positive".lower()
         assert check["table"].lower() == table_name.lower()
+        assert "{" not in check["definition"]
+        assert "}" not in check["definition"]

--- a/soda/core/tests/unit/test_variables.py
+++ b/soda/core/tests/unit/test_variables.py
@@ -3,7 +3,7 @@ from soda.scan import Scan
 
 def test_variables():
     scan = Scan()
-    scan.add_variables({"now": "2022-10-22 11:12:13"})
+    scan.add_variables({"now": "'2022-10-22 11:12:13'"})
     scan.add_sodacl_yaml_str(
         f"""
           variables:


### PR DESCRIPTION
I felt courageous and tried to solve this once and for all during the phase of parsing the file. We had reservations against doing that, but I think all have been resolved here. The only downside I see is that we need to be more careful about passing non-string variables without quotes, e.g. a datetime in some scenarios would be considered a datetime object by the yaml parser itself - see the changed test_variables unit test. I am not sure if this is an issue. If it is we can still solve that one.