### PR TITLE
deprecation: remove row-count derivation from dataset discovery

### DIFF
--- a/soda/core/soda/execution/check/discover_tables_run.py
+++ b/soda/core/soda/execution/check/discover_tables_run.py
@@ -42,7 +42,7 @@ class DiscoverTablesRun:
             self.logs.info(f"  - {table_name}")
             measured_row_count = self.data_source.get_table_row_count(table_name)
             discover_tables_result_table = discover_tables_result.create_table(
-                table_name, self.data_source.data_source_name, measured_row_count
+                table_name, self.data_source.data_source_name
             )
             # get columns & metadata for current table
             columns_metadata_result = self.data_source.get_table_columns(

--- a/soda/core/soda/profiling/discover_table_result_table.py
+++ b/soda/core/soda/profiling/discover_table_result_table.py
@@ -1,14 +1,13 @@
-from typing import List
+from __future__ import annotations
 
 from soda.profiling.discover_tables_result_column import DiscoverTablesResultColumn
 
 
 class DiscoverTablesResultTable:
-    def __init__(self, table_name: str, data_source: str, row_count: int):
+    def __init__(self, table_name: str, data_source: str):
         self.table_name: str = table_name
         self.data_source: str = data_source
-        self.row_count: int = row_count
-        self.result_columns: List[DiscoverTablesResultColumn] = []
+        self.result_columns: list[DiscoverTablesResultColumn] = []
 
     def create_column(self, column_name: str, column_type: str) -> DiscoverTablesResultColumn:
         column = DiscoverTablesResultColumn(column_name, column_type)
@@ -19,7 +18,6 @@ class DiscoverTablesResultTable:
         cloud_dict = {
             "table": self.table_name,
             "dataSource": self.data_source,
-            "rowCount": self.row_count,
             "schema": [result_column.get_cloud_dict() for result_column in self.result_columns],
         }
         return cloud_dict
@@ -28,6 +26,5 @@ class DiscoverTablesResultTable:
         return {
             "table": self.table_name,
             "dataSource": self.data_source,
-            "rowCount": self.row_count,
             "schema": [result_column.get_dict() for result_column in self.result_columns],
         }

--- a/soda/core/soda/profiling/discover_tables_result.py
+++ b/soda/core/soda/profiling/discover_tables_result.py
@@ -9,7 +9,7 @@ class DiscoverTablesResult:
         self.data_source_check_cfg: DataSourceCheckCfg = data_source_check_cfg
         self.tables: List[DiscoverTablesResultTable] = []
 
-    def create_table(self, table_name: str, data_source_name: str, row_count: int) -> DiscoverTablesResultTable:
-        table = DiscoverTablesResultTable(table_name, data_source_name, row_count)
+    def create_table(self, table_name: str, data_source_name: str) -> DiscoverTablesResultTable:
+        table = DiscoverTablesResultTable(table_name, data_source_name)
         self.tables.append(table)
         return table

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -77,7 +77,6 @@ class Scan:
             profile_table.get_dict()
             for profile_table in self._profile_columns_result_tables + self._sample_tables_result_tables
         ]
-
         return JsonHelper.to_jsonnable(  # type: ignore
             {
                 "definitionName": self._scan_definition_name,


### PR DESCRIPTION
As per: https://sodadata.atlassian.net/browse/CLOUD-2211

Plans to re-introduce row count derivation are unspecified at the moment. Product will come back to us with an answer. For now, they are aware of and desire to just disable it for now.