### PR TITLE
Duplicate count workaround for complex types

### DIFF
--- a/soda/core/tests/unit/test_string_helper.py
+++ b/soda/core/tests/unit/test_string_helper.py
@@ -10,6 +10,7 @@ from soda.common.string_helper import string_matches_simple_pattern
         pytest.param("table_1", "*", True),
         pytest.param("table_1", "*_*", True),
         pytest.param("table-1", "*_*", False),
+        pytest.param("something-table-1", "table-1*", False),
     ],
 )
 def test_string_matches_simple_pattern(input: str, pattern: str, should_match: bool):

--- a/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
+++ b/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
@@ -323,8 +323,10 @@ class SQLServerDataSource(DataSource):
         filter: str,
         limit: str | None = None,
         invert_condition: bool = False,
+        exclude_patterns: list[str] | None = None,
     ) -> str | None:
         limit_sql = ""
+        main_query_columns = f"{column_names}, frequency" if exclude_patterns else "*"
 
         if limit:
             limit_sql = f"TOP {limit}"
@@ -336,7 +338,7 @@ class SQLServerDataSource(DataSource):
               FROM {table_name}
               WHERE {filter}
               GROUP BY {column_names})
-            SELECT {limit_sql} {column_names}, frequency
+            SELECT {limit_sql} {main_query_columns}
             FROM frequencies
             WHERE frequency {'<=' if invert_condition else '>'} 1
             ORDER BY frequency DESC"""


### PR DESCRIPTION
Use explicit list of columns only if exclude columns are present, use asterisk otherwise as a workaround for rudimentary complex types support