### PR TITLE
Send check attributes to cloud

### DIFF
--- a/soda/core/soda/common/attributes_handler.py
+++ b/soda/core/soda/common/attributes_handler.py
@@ -109,7 +109,7 @@ class AttributeHandler:
 
     def _log_unrecognized_value(self, key: str, value: any, allowed_values: list[any]) -> None:
         self.logs.error(
-            f"Soda Cloud does not recognize '{key}': '{value}' attribute value. Valid attribute values: {allowed_values}."
+            f"Soda Cloud does not recognize '{key}': '{value}' attribute value. Valid attribute value(s): {allowed_values}."
         )
 
     def _log_unrecognized_type(self, key: str, value: any, type: str, expected_types: list(str)) -> None:

--- a/soda/core/soda/soda_cloud/soda_cloud.py
+++ b/soda/core/soda/soda_cloud/soda_cloud.py
@@ -204,7 +204,7 @@ class SodaCloud:
     def is_samples_disabled(self) -> bool:
         return self.organization_configuration.get(self.ORG_CONFIG_KEY_DISABLE_COLLECTING_WH_DATA, True)
 
-    def get_check_attributes_schema(self) -> dict:
+    def get_check_attributes_schema(self) -> list(dict):
         return self.organization_configuration.get(self.ORG_CONFIG_KEY_CHECK_ATTRIBUTES, {})
 
     def _get_historic_changes_over_time(self, hd: HistoricChangeOverTimeDescriptor):


### PR DESCRIPTION
This iterates all checks before running any queries and:
- if there is no cloud it just takes attributes from check cfg and attaches them to check as-is
- if there is cloud it validates them and removes any check that has invalid attributes, such check is removed from execution completely, the only trace of it then is an error log from the attribute formatter.