### PR TITLE
Deprecate global data source 'disable_samples', use one from sampler

### DIFF
--- a/soda/core/soda/configuration/configuration_parser.py
+++ b/soda/core/soda/configuration/configuration_parser.py
@@ -64,9 +64,18 @@ class ConfigurationParser(Parser):
                         )
 
                 # Sampler configuration
+                disable_samples = None
+
+                if "disable_samples" in header_value.keys():
+                    disable_samples = header_value.get("disable_samples")
+                    self.logs.info(
+                        "Data source configuration key `disable_samples` will be removed in future versions of Soda Core. Use data_source.sampler.disable_samples instead."
+                    )
+
                 sampler_configuration = header_value.get("sampler")
                 if sampler_configuration:
                     if isinstance(sampler_configuration, dict):
+                        disable_samples = sampler_configuration.get("disable_samples", disable_samples)
                         exclude_columns = sampler_configuration.get("exclude_columns", {})
                         if exclude_columns:
                             if isinstance(exclude_columns, dict):
@@ -85,10 +94,8 @@ class ConfigurationParser(Parser):
                                     url = storage.get("url")
                                     message = storage.get("message") or f"Failed rows have been sent to {url}"
                                     self.configuration.sampler = HTTPSampler(url, message=message)
-                            elif self.configuration.soda_cloud and not header_value.get("disable_samples"):
+                            elif self.configuration.soda_cloud and not disable_samples:
                                 self.configuration.sampler = SodaCloudSampler()
-                            elif header_value.get("disable_samples"):
-                                self.configuration.sampler = DefaultSampler()
                             else:
                                 self.logs.error(
                                     f"Invalid storage type: {storage_type} specified, must be one of ['http', 's3'], using Soda Cloud as sampler",
@@ -100,6 +107,9 @@ class ConfigurationParser(Parser):
                             "'sampler' configuration must be a dict",
                             location=self.location,
                         )
+
+                if disable_samples:
+                    self.configuration.sampler = DefaultSampler()
 
                 self._pop_path_element()
 


### PR DESCRIPTION
@vijaykiran this one is a small fix as well - `disable_samples` worked only when sampler configuration was present. Now it will be considered even without sampler configuration in place - this is a temporary fix until we completely remove disable_samples from data source level.

I did not add any test coverage for this one as it seems a bit too much, 