### PR TITLE
deprecation/fix: actually remove execution of row count query in table discovery

### DIFF
--- a/soda/core/soda/execution/check/discover_tables_run.py
+++ b/soda/core/soda/execution/check/discover_tables_run.py
@@ -40,7 +40,6 @@ class DiscoverTablesRun:
         self.logs.info(f"Discovering the following tables:")
         for table_name in table_names:
             self.logs.info(f"  - {table_name}")
-            measured_row_count = self.data_source.get_table_row_count(table_name)
             discover_tables_result_table = discover_tables_result.create_table(
                 table_name, self.data_source.data_source_name
             )


### PR DESCRIPTION
In https://github.com/sodadata/soda-core/pull/1706 we were planning to deprecate the derivation of table row count. While we stopped sending it to cloud, for sure, I somehow managed to forget to actually derive it. This PR fixes that oversight.
