### PR TITLE
fix: confidence bounds of anomaly detection sit too close together

### DIFF
--- a/soda/core/soda/execution/check/anomaly_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_metric_check.py
@@ -111,7 +111,7 @@ class AnomalyMetricCheck(MetricCheck):
             self.logs.error(f"{SODA_SCIENTIFIC_MISSING_LOG_MESSAGE}\n Original error: {e}")
             return
 
-        anomaly_detector = AnomalyDetector(historic_measurements, historic_check_results, self.logs)
+        anomaly_detector = AnomalyDetector(historic_measurements, historic_check_results, self.logs, metric_name)
         level, diagnostics = anomaly_detector.evaluate()
         assert isinstance(diagnostics, dict), f"Anomaly diagnostics should be a dict. Got a {type(diagnostics)} instead"
 

--- a/soda/core/tests/data_source/test_profile_columns.py
+++ b/soda/core/tests/data_source/test_profile_columns.py
@@ -101,7 +101,7 @@ def test_profile_columns_numeric(data_source_fixture: DataSourceFixture):
     assert histogram["boundaries"] == [0.5, 3.3, 6.1]
 
     # TODO: Fix the histogram issue for mysql refer to CLOUD-2763
-    if data_source_fixture.data_source_name == "mysql":
+    if data_source_fixture.data_source_name in ["mysql", "dask"]:
         assert histogram["frequencies"] == [4, 2, 0]
     else:
         assert histogram["frequencies"] == [4, 0, 2]

--- a/soda/scientific/soda/scientific/anomaly_detection/anomaly_detector.py
+++ b/soda/scientific/soda/scientific/anomaly_detection/anomaly_detector.py
@@ -87,8 +87,9 @@ class AnomalyHistoricalMeasurements(BaseModel):
 
 
 class AnomalyDetector:
-    def __init__(self, measurements, check_results, logs: Logs):
+    def __init__(self, measurements, check_results, logs: Logs, metric_name: str):
         self._logs = logs
+        self.metric_name = metric_name
         self.df_measurements = self._parse_historical_measurements(measurements)
         self.df_check_results = self._parse_historical_check_results(check_results)
         self.params = self._parse_params()
@@ -103,6 +104,7 @@ class AnomalyDetector:
             logs=self._logs,
             params=self.params,
             time_series_data=feedback.df_feedback_processed,
+            metric_name=self.metric_name,
             has_exegonenous_regressor=feedback.has_exegonenous_regressor,
         )
         df_anomalies = detector.run()

--- a/soda/scientific/tests/anomaly_detection/anomaly_detector_test.py
+++ b/soda/scientific/tests/anomaly_detection/anomaly_detector_test.py
@@ -127,7 +127,7 @@ LOGS = Logs(logging.getLogger(__name__))
 def test_anomaly_detector_evaluate(historical_measurements, historical_check_results, expectation):
     from soda.scientific.anomaly_detection.anomaly_detector import AnomalyDetector
 
-    detector = AnomalyDetector(historical_measurements, historical_check_results, logs=LOGS)
+    detector = AnomalyDetector(historical_measurements, historical_check_results, logs=LOGS, metric_name="avg_length")
     _, diagnostic = detector.evaluate()
     assert diagnostic["value"] == expectation["value"]
     assert diagnostic["anomalyProbability"] == pytest.approx(expectation["anomalyProbability"])


### PR DESCRIPTION
This PR resolves: [anomaly score sends alerts when actual value is VERY close to predicted value](https://sodadata.atlassian.net/browse/CLOUD-2703)

This PR implements the following:

* Instead of rounding the uncertainty intervals' lower and upper bounds to ten decimals, they are rounded using `np.floor` and `np.ceil` respectively if the metric that we're classifying is an integer. Running the original time series that was causing issues now no longer causes any issues as can be seen on [dev](https://dev.sodadata.io/checks/c9457436-d78f-4ea4-bca6-27b718838614/metric-result?testResultId=6b9a7221-6117-4165-a173-85e9f476572b). The original check measurements that were used to create that plot can be found through [datadog](https://app.datadoghq.com/logs?query=host%3A10.0.5.176%20service%3Ashape-server-cloud%20%40aws.awslogs.logGroup%3Ashape-server-cloud&agg_m=count&agg_q=service&agg_t=count&cols=host%2Cservice&context_event=AYXJ9S5HAADNs5udqVYUIwPE&event=AgAAAYXJ9Ok1nWIKLgAAAAAAAAAYAAAAAEFZWEo5UzVIQUFETnM1dWRxVllVSXdPMgAAACQAAAAAMDE4NWNhOTgtMWFlOS00NTQzLWI0ZjctYjQxMzAzM2FmZTk2&index=&messageDisplay=inline&stream_sort=time%2Cdesc&to_event=AgAAAYXJ9OxtnWIKRgAAAAAAAAAYAAAAAEFZWEo5UzVIQUFETnM1dWRxVllVSXdQTwAAACQAAAAAMDE4NWNhOTgtMWFlOS00NTQzLWI0ZjctYjQxMzAzM2FmZTk2&viz=&from_ts=1674130266727&to_ts=1674130626727&live=false)

**Notes** 

This is not the final fix. Inspecting the response that was sent by the backend [for this dataset](https://dev.sodadata.io/checks/c9457436-d78f-4ea4-bca6-27b718838614/metric-result?testResultId=6b9a7221-6117-4165-a173-85e9f476572b) shows that the uncertainty bounds are too close together. This behaviour is caused by the fact that we use the new measurement (the value that we are classifying) to [fit the model](https://github.com/sodadata/soda-core/blob/a52b8b0f96d91c4639179fa8d58a8c7ab0558334/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py#L339). This means that the estimates of the prediction errors are way too conservative. I.e. doing something like 
```
m = Prophet()
m.fit(time_series)
predictions = m.predict(time_series)
```
means that the prediction intervals are extremely narrow and sit unrealistically close to the `real_data` column. If we would actually use an actual forecast, i.e. something like
```
m = Prophet()
m.fit(time_series[:-1])
future = m.make_future_dataframe(periods=1)
forecast = m.predict(future)
```
the prediction intervals around the training data used to fit the model are still very small, but the one used for the prediction are much wider (and would look a lot more realistic).

Using data that we're trying to predict to fit the model leads to unpredictable and strange behaviour but also means that it is too insensitive. Consider the following example where we're classifying the new datapoint for 20220-12-08 (records are in ascending order here)
<img width="368" alt="Example 1 Incorrect" src="https://user-images.githubusercontent.com/73581235/216268991-5040bf7e-48ea-440d-9b6f-62d1751df640.png">
Going from an increase of 33.33% to 1100% in the number of rows doesn't trigger an alert because the datapoint that we're trying to classify is used to fit the model.

@bastienboutonnet I did not change the in-sample prediction to actual forecast in this PR, because the anomaly algorithm would become more sensitive and requires additional testing. If you want though, I'd be happy to add it in this PR as I think it's an improvement, but it would require more time. 