### PR TITLE
bug: anomaly detection doesn't use more than 3 historical check results

### DIFF
--- a/soda/core/soda/execution/check/anomaly_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_metric_check.py
@@ -17,6 +17,7 @@ from soda.sodacl.metric_check_cfg import MetricCheckCfg
 
 KEY_HISTORIC_MEASUREMENTS = "historic_measurements"
 KEY_HISTORIC_CHECK_RESULTS = "historic_check_results"
+HISTORIC_MEASUREMENTS_LIMIT = 1000
 
 
 class AnomalyMetricCheck(MetricCheck):
@@ -50,10 +51,10 @@ class AnomalyMetricCheck(MetricCheck):
 
             self.historic_descriptors[KEY_HISTORIC_MEASUREMENTS] = HistoricMeasurementsDescriptor(
                 metric_identity=metric.identity,
-                limit=1000,
+                limit=HISTORIC_MEASUREMENTS_LIMIT,
             )
             self.historic_descriptors[KEY_HISTORIC_CHECK_RESULTS] = HistoricCheckResultsDescriptor(
-                check_identity=self.create_identity(), limit=3
+                check_identity=self.create_identity(), limit=HISTORIC_MEASUREMENTS_LIMIT
             )
             self.diagnostics = {}
             self.cloud_check_type = "anomalyDetection"

--- a/soda/core/tests/data_source/test_anomaly_check.py
+++ b/soda/core/tests/data_source/test_anomaly_check.py
@@ -3,6 +3,51 @@ import os
 import pytest
 from helpers.common_test_tables import customers_test_table
 from helpers.data_source_fixture import DataSourceFixture
+from soda.soda_cloud.historic_descriptor import (
+    HistoricCheckResultsDescriptor,
+    HistoricMeasurementsDescriptor,
+)
+
+
+@pytest.mark.skipif(
+    condition=os.getenv("SCIENTIFIC_TESTS") == "SKIP",
+    reason="Environment variable SCIENTIFIC_TESTS is set to SKIP which skips tests depending on the scientific package",
+)
+def test_anomaly_detection_historic_descriptors(data_source_fixture: DataSourceFixture):
+    table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    import numpy as np
+    from soda.execution.check.anomaly_metric_check import AnomalyMetricCheck
+
+    np.random.seed(61)
+
+    scan = data_source_fixture.create_test_scan()
+    scan.add_sodacl_yaml_str(
+        f"""
+          checks for {table_name}:
+            - anomaly score for row_count < default
+        """
+    )
+    scan.mock_historic_values(
+        metric_identity=f"metric-{scan._scan_definition_name}-{scan._data_source_name}-{table_name}-row_count",
+        metric_values=[10, 10, 10, 9, 8, 8, 8, 0, 0, 0],
+    )
+    scan.execute(allow_warnings_only=True)
+    anomaly_metric_check = scan._checks[0]
+    assert isinstance(anomaly_metric_check, AnomalyMetricCheck)
+
+    historic_measurement_descriptor = anomaly_metric_check.historic_descriptors["historic_measurements"]
+    assert historic_measurement_descriptor == HistoricMeasurementsDescriptor(
+        metric_identity=f"metric-{scan._scan_definition_name}-{scan._data_source_name}-{table_name}-row_count",
+        limit=1000,
+    )
+
+    historic_check_result_descriptor = anomaly_metric_check.historic_descriptors["historic_check_results"]
+
+    # We don't mock check idendity for check results, so we can't compare it
+    assert isinstance(historic_check_result_descriptor, HistoricCheckResultsDescriptor)
+    assert historic_check_result_descriptor.check_identity is not None
+    assert historic_check_result_descriptor.limit == 1000
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
In anomaly detection, the limit of historical check results was hardcoded to 3. Instead, we changed it back to 1000. So, we will be able to handle up to 1k user feedbacks in anomaly detection. Also, some extra unit tests are added to make sure that both historic check results and historic measurements are limited up to 1000 datapoints.