### PR TITLE
Improve profiling tests

### DIFF
--- a/soda/vertica/soda/data_sources/vertica_data_source.py
+++ b/soda/vertica/soda/data_sources/vertica_data_source.py
@@ -187,7 +187,7 @@ class VerticaDataSource(DataSource):
         return identifier
 
     def default_casify_column_name(self, identifier: str) -> str:
-        return identifier
+        return identifier.lower()
 
     def default_casify_type_name(self, identifier: str) -> str:
         return identifier.lower()


### PR DESCRIPTION
@vijaykiran this one changes Vertica default column casify method to lowercase.

@baturayo I just refactored the profiling tests to use the data source built in casify methods and removed loading the test data source type directly.