### PR TITLE
refactor: only use last `n_points` in `detect_anomalies` method

### DIFF
--- a/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection/models/prophet_model.py
@@ -375,6 +375,11 @@ class ProphetDetector(BaseDetector):
         assert (
             self._is_trained
         ), "ProphetDetector has not been trained yet. Make sure you run `setup_and_train_ts_model` first"
+
+        # pick out n-last points to detect anomalies for
+        if self._n_points:
+            self.predictions = self.predictions.iloc[-self._n_points :]  # noqa: E203
+
         self.predictions["real_data"] = self.time_series["y"].reset_index(drop=True)
 
         self._logs.debug(f"Anomaly Detection: detecting anomalies for the last {self._n_points} points.")
@@ -403,11 +408,7 @@ class ProphetDetector(BaseDetector):
         self.predictions.loc[np.isinf(self.predictions["anomaly_probability"]), "is_anomaly"] = 0
         self.predictions.loc[np.isinf(self.predictions["anomaly_probability"]), "anomaly_probability"] = 0.0
 
-        # pick out n-last points to return to backend
-        if self._n_points:
-            self.anomalies = self.predictions.iloc[-self._n_points :]  # noqa: E203
-        else:
-            self.anomalies = self.predictions
+        self.anomalies = self.predictions
 
     def generate_severity_zones(self):
         assert (


### PR DESCRIPTION
This PR resolves: [Can we remove (seemingly) unnecessary computation from anomaly detection?](https://sodadata.atlassian.net/browse/CLOUD-2817)

* It turns out this was only relevant for the method `detect_anomalies`, contrary to the original ticket description. At the end of `detect_anomalies` trimming with `_n_points` ensured that the rest of anomaly detection was only done on the relevant parts.
* By trimming the `predictions` df to the last `_n_points` we make sure to only do the necessary computations in `detect_anomalies` for the last `_n_point`. The parameter `_n_points` is derived from [detector_config.yml](https://github.com/sodadata/soda-core/blob/6a361a3eb84daf19eacbb75ef5b9518b6400cda7/soda/scientific/soda/scientific/anomaly_detection/detector_config.yaml#L27)
* Tested the new code on [this dataset](https://dev.sodadata.io/checks/98897a3e-750e-4fe6-b634-f3f228494bde/metric-result?testResultId=404ea174-3944-4f9b-97e2-32965b19a702)