### PR TITLE
Bump telemetry versions

### DIFF
--- a/soda/core/setup.py
+++ b/soda/core/setup.py
@@ -20,9 +20,8 @@ requires = [
     "ruamel.yaml>=0.17.0,<0.18.0",
     "requests~=2.27",
     "antlr4-python3-runtime~=4.11.1",
-    "opentelemetry-api~=1.11.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.11.0",
-    "protobuf~=3.19.0",
+    "opentelemetry-api~=1.16.0",
+    "opentelemetry-exporter-otlp-proto-http~=1.16.0",
     "sqlparse~=0.4",
 ]
 

--- a/soda/core/tests/unit/test_telemetry.py
+++ b/soda/core/tests/unit/test_telemetry.py
@@ -35,7 +35,7 @@ def test_basic_telemetry_structure():
     dict_has_keys(span["attributes"], ["user_cookie_id"])
     dict_has_keys(span["context"], ["span_id", "trace_id", "trace_state"])
     dict_has_keys(
-        span["resource"],
+        span["resource"]["attributes"],
         [
             "os.architecture",
             "os.type",
@@ -49,10 +49,10 @@ def test_basic_telemetry_structure():
         ],
     )
 
-    resource = span["resource"]
-    assert resource["service.name"] == "soda"
-    assert resource["service.namespace"] == "soda-core"
-    assert resource["service.version"] == SODA_CORE_VERSION
+    resource_attributes = span["resource"]["attributes"]
+    assert resource_attributes["service.name"] == "soda"
+    assert resource_attributes["service.namespace"] == "soda-core"
+    assert resource_attributes["service.version"] == SODA_CORE_VERSION
 
 
 def test_multi_spans():


### PR DESCRIPTION
Fixes #1722  (Potentially) but the install order should be `soda-core-bigquery` and then `apache-airflow-providers-google`