### PR TITLE
Fix sampler parsing

### DIFF
--- a/soda/core/soda/configuration/configuration_parser.py
+++ b/soda/core/soda/configuration/configuration_parser.py
@@ -63,54 +63,9 @@ class ConfigurationParser(Parser):
                             location=self.location,
                         )
 
-                # Sampler configuration
-                disable_samples = None
-
-                if "disable_samples" in header_value.keys():
-                    disable_samples = header_value.get("disable_samples")
-                    self.logs.info(
-                        "Data source configuration key `disable_samples` will be removed in future versions of Soda Core. Use data_source.sampler.disable_samples instead."
-                    )
-
-                sampler_configuration = header_value.get("sampler")
-                if sampler_configuration:
-                    if isinstance(sampler_configuration, dict):
-                        disable_samples = sampler_configuration.get("disable_samples", disable_samples)
-                        exclude_columns = sampler_configuration.get("exclude_columns", {})
-                        if exclude_columns:
-                            if isinstance(exclude_columns, dict):
-                                self.configuration.exclude_columns = exclude_columns
-                            else:
-                                self.logs.error(
-                                    "'exclude_columns' configuration must be a dict",
-                                    location=self.location,
-                                )
-
-                        storage = sampler_configuration.get("storage")
-                        if storage:
-                            storage_type = storage.get("type")
-                            if storage_type in ["http", "s3"]:
-                                if storage_type == "http":
-                                    url = storage.get("url")
-                                    message = storage.get("message") or f"Failed rows have been sent to {url}"
-                                    link_text = storage.get("link_text") or message
-                                    self.configuration.sampler = HTTPSampler(url, message=message, link_text=link_text)
-                            elif self.configuration.soda_cloud and not disable_samples:
-                                self.configuration.sampler = SodaCloudSampler()
-                            else:
-                                self.logs.error(
-                                    f"Invalid storage type: {storage_type} specified, must be one of ['http', 's3'], using Soda Cloud as sampler",
-                                    location=self.location,
-                                )
-
-                    else:
-                        self.logs.error(
-                            "'sampler' configuration must be a dict",
-                            location=self.location,
-                        )
-
-                if disable_samples:
-                    self.configuration.sampler = DefaultSampler()
+                # CORE-455 only parse sampler config if the data source name in file matches the scan data source name
+                if data_source_name == self.configuration.scan._data_source_name:
+                    self.parse_sampler_config(header_value)
 
                 self._pop_path_element()
 
@@ -129,6 +84,53 @@ class ConfigurationParser(Parser):
                     f'Invalid configuration header: expected "{DATA_SOURCE} {{data source name}}".',
                     location=self.location,
                 )
+
+    def parse_sampler_config(self, header_value):
+        # Sampler configuration
+        disable_samples = None
+        if "disable_samples" in header_value.keys():
+            disable_samples = header_value.get("disable_samples")
+            self.logs.info(
+                "Data source configuration key `disable_samples` will be removed in future versions of Soda Core. Use data_source.sampler.disable_samples instead."
+            )
+        sampler_configuration = header_value.get("sampler")
+        if sampler_configuration:
+            if isinstance(sampler_configuration, dict):
+                disable_samples = sampler_configuration.get("disable_samples", disable_samples)
+                exclude_columns = sampler_configuration.get("exclude_columns", {})
+                if exclude_columns:
+                    if isinstance(exclude_columns, dict):
+                        self.configuration.exclude_columns = exclude_columns
+                    else:
+                        self.logs.error(
+                            "'exclude_columns' configuration must be a dict",
+                            location=self.location,
+                        )
+
+                storage = sampler_configuration.get("storage")
+                if storage:
+                    storage_type = storage.get("type")
+                    if storage_type in ["http", "s3"]:
+                        if storage_type == "http":
+                            url = storage.get("url")
+                            message = storage.get("message") or f"Failed rows have been sent to {url}"
+                            link_text = storage.get("link_text") or message
+                            self.configuration.sampler = HTTPSampler(url, message=message, link_text=link_text)
+                    elif self.configuration.soda_cloud and not disable_samples:
+                        self.configuration.sampler = SodaCloudSampler()
+                    else:
+                        self.logs.error(
+                            f"Invalid storage type: {storage_type} specified, must be one of ['http', 's3'], using Soda Cloud as sampler",
+                            location=self.location,
+                        )
+
+            else:
+                self.logs.error(
+                    "'sampler' configuration must be a dict",
+                    location=self.location,
+                )
+        if disable_samples:
+            self.configuration.sampler = DefaultSampler()
 
     def parse_soda_cloud_cfg(self, config_dict: dict):
         api_key = config_dict.get("api_key_id")

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -173,7 +173,7 @@ class Scan:
             )
         except Exception as e:
             self._logs.error(
-                f"Could not add environment configurations from string",
+                "Could not add environment configurations from string",
                 exception=e,
             )
 
@@ -501,7 +501,7 @@ class Scan:
                 try:
                     self.run_data_source_scan()
                 except Exception as e:
-                    self._logs.error(f"""An error occurred while executing data source scan""", exception=e)
+                    self._logs.error("""An error occurred while executing data source scan""", exception=e)
 
                 # Evaluates the checks based on all the metric values
                 for check in self._checks:
@@ -558,10 +558,10 @@ class Scan:
             if checks_warn_count + checks_fail_count + error_count == 0 and len(self._checks) > 0:
                 if checks_not_evaluated:
                     self._logs.info(
-                        f"Apart from the checks that have not been evaluated, no failures, no warnings and no errors."
+                        "Apart from the checks that have not been evaluated, no failures, no warnings and no errors."
                     )
                 else:
-                    self._logs.info(f"All is good. No failures. No warnings. No errors.")
+                    self._logs.info("All is good. No failures. No warnings. No errors.")
             elif error_count > 0:
                 exit_value = 3
                 self._logs.info(
@@ -592,7 +592,7 @@ class Scan:
 
         except Exception as e:
             exit_value = 3
-            self._logs.error(f"Error occurred while executing scan.", exception=e)
+            self._logs.error("Error occurred while executing scan.", exception=e)
         finally:
             try:
                 self._scan_end_timestamp = datetime.now(tz=timezone.utc)
@@ -608,7 +608,7 @@ class Scan:
 
             except Exception as e:
                 exit_value = 3
-                self._logs.error(f"Error occurred while sending scan results to soda cloud.", exception=e)
+                self._logs.error("Error occurred while sending scan results to soda cloud.", exception=e)
 
             self._close()
             self.scan_results = self.build_scan_results()


### PR DESCRIPTION
When multiple scan files are used, the sampler should be picked from the scan datasource config not from other files