### PR TITLE
[trino] Remove experimental python types arg

### DIFF
--- a/soda/trino/soda/data_sources/trino_data_source.py
+++ b/soda/trino/soda/data_sources/trino_data_source.py
@@ -83,9 +83,6 @@ class TrinoDataSource(DataSource):
             return
 
         self.connection = trino.dbapi.connect(
-            # experimental_python_types is required to recieve values in appropriate python data types
-            # https://github.com/trinodb/trino-python-client#improved-python-types
-            experimental_python_types=True,
             host=self.host,
             port=self.port,
             catalog=self.catalog,


### PR DESCRIPTION
This is no longer needed as of trino 0.321.0 https://github.com/trinodb/trino-python-client\#legacy-primitive-types