### PR TITLE
CORE-457 send the link details from sample configuration

### DIFF
--- a/soda/core/soda/sampler/sample_ref.py
+++ b/soda/core/soda/sampler/sample_ref.py
@@ -61,9 +61,11 @@ class SampleRef:
         if self.soda_cloud_file_id:
             sample_ref_dict["reference"] = {"type": "sodaCloudStorage", "fileId": self.soda_cloud_file_id}
         elif self.message:
-            sample_ref_dict["reference"] = {"type": "noFile",
-                                            "message": self.message,
-                                            "link": {"href": self.link, "text": self.link_text},
-                                            "fileId": ""}
+            sample_ref_dict["reference"] = {
+                "type": "noFile",
+                "message": self.message,
+                "link": {"href": self.link, "text": self.link_text},
+                "fileId": "",
+            }
 
         return sample_ref_dict

--- a/soda/core/soda/sampler/sample_ref.py
+++ b/soda/core/soda/sampler/sample_ref.py
@@ -61,11 +61,9 @@ class SampleRef:
         if self.soda_cloud_file_id:
             sample_ref_dict["reference"] = {"type": "sodaCloudStorage", "fileId": self.soda_cloud_file_id}
         elif self.message:
-            sample_ref_dict["reference"] = {"type": "noFile", "message": self.message, "link": self.link, "fileId": ""}
-            # TODO Replace above with the following when https://sodadata.atlassian.net/browse/CLOUD-2449 is done.
-            # sample_ref_dict["reference"] = {"type": "noFile",
-            #                                 "message": self.message,
-            #                                 "link": {"href": self.link, "text": self.link_text},
-            #                                 "fileId": ""}
+            sample_ref_dict["reference"] = {"type": "noFile",
+                                            "message": self.message,
+                                            "link": {"href": self.link, "text": self.link_text},
+                                            "fileId": ""}
 
         return sample_ref_dict


### PR DESCRIPTION
When using sampler config, users can specify link and link text which will be rendered as HTML link in Soda Cloud UI