### PR TITLE
Fix wrong parsing of scheme for soda_cloud

### DIFF
--- a/soda/core/soda/configuration/configuration_parser.py
+++ b/soda/core/soda/configuration/configuration_parser.py
@@ -152,7 +152,7 @@ class ConfigurationParser(Parser):
             port = config_dict.get("port")
         scheme = None
         if "scheme" in config_dict:
-            port = config_dict.get("scheme")
+            scheme = config_dict.get("scheme")
         return SodaCloud(
             api_key_id=api_key,
             api_key_secret=api_secret,

--- a/soda/core/tests/unit/test_configuration_yaml_parser.py
+++ b/soda/core/tests/unit/test_configuration_yaml_parser.py
@@ -22,6 +22,7 @@ def test_parse_environment_yaml(monkeypatch):
 
         soda_cloud:
           api_key_id: s09d8fs09d8f09sd
+          scheme: http
     """
         )
     )
@@ -36,6 +37,7 @@ def test_parse_environment_yaml(monkeypatch):
     assert lpsp_properties.get("password") is None
 
     assert scan._configuration.soda_cloud.api_key_id == "s09d8fs09d8f09sd"
+    assert scan._configuration.soda_cloud.scheme == "http"
 
 
 def test_parse_configuration_yaml_env_var_resolving(monkeypatch):
@@ -73,6 +75,7 @@ def test_parse_configuration_yaml_env_var_resolving(monkeypatch):
     assert lpsp_properties["password"] == "x"
 
     assert scan._configuration.soda_cloud.api_key_id == "x"
+    assert scan._configuration.soda_cloud.scheme == "https"
 
 
 def test_no_data_source_type():


### PR DESCRIPTION
Hi, this is a rather small change in the YAML configuration parsing, the `scheme` property of `soda_cloud` config block ended up being saved as a `port`, triggering invalid target URL for Soda Cloud