### PR TITLE
fix: improve error handling when invalid metric is provided to AnomalyMetricCheck

### DIFF
--- a/soda/core/soda/execution/check/anomaly_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_metric_check.py
@@ -59,8 +59,11 @@ class AnomalyMetricCheck(MetricCheck):
             self.diagnostics = {}
             self.cloud_check_type = "anomalyDetection"
         except Exception as e:
+            self.skip_anomaly_check = True
             data_source_scan.scan._logs.error(
-                f"""An error occurred during the initialization of AnomalyMetricCheck""",
+                f"""An error occurred during the initialization of AnomalyMetricCheck. Please make sure"""
+                f""" that the metric '{check_cfg.metric_name}' is supported. For more information have"""
+                f""" a look at the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks""",
                 exception=e,
             )
 

--- a/soda/core/soda/execution/check/anomaly_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_metric_check.py
@@ -62,8 +62,8 @@ class AnomalyMetricCheck(MetricCheck):
             self.skip_anomaly_check = True
             data_source_scan.scan._logs.error(
                 f"""An error occurred during the initialization of AnomalyMetricCheck. Please make sure"""
-                f""" that the metric '{check_cfg.metric_name}' is supported. For more information have"""
-                f""" a look at the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks""",
+                f""" that the metric '{check_cfg.metric_name}' is supported. For more information see"""
+                f""" the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks.""",
                 exception=e,
             )
 

--- a/soda/core/tests/data_source/test_anomaly_check.py
+++ b/soda/core/tests/data_source/test_anomaly_check.py
@@ -272,3 +272,33 @@ def test_anomaly_detection_invalid_values(data_source_fixture):
 
     scan.execute()
     scan.assert_all_checks_pass()
+
+
+@pytest.mark.skipif(
+    condition=os.getenv("SCIENTIFIC_TESTS") == "SKIP",
+    reason="Environment variable SCIENTIFIC_TESTS is set to SKIP which skips tests depending on the scientific package",
+)
+def test_anomaly_detection_invalid_values(data_source_fixture):
+    import numpy as np
+
+    table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan = data_source_fixture.create_test_scan()
+
+    scan.add_sodacl_yaml_str(
+        f"""
+          checks for {table_name}:
+              - anomaly score for incorrect_metric < default
+        """
+    )
+
+    scan.mock_historic_values(
+        metric_identity=f"metric-{scan._scan_definition_name}-{scan._data_source_name}-{table_name}-id-invalid_count-05d677bc",
+        metric_values=[10, 10, 10, 9, 8, 0, 0, 0, 0],
+    )
+
+    with pytest.raises(Exception) as e:    
+        scan.execute()
+
+    assert "An error occurred during the initialization of AnomalyMetricCheck. Please make sure that the metric 'incorrect_metric' is supported. For more information see the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks." in str(e.value)
+

--- a/soda/core/tests/data_source/test_anomaly_check.py
+++ b/soda/core/tests/data_source/test_anomaly_check.py
@@ -278,9 +278,7 @@ def test_anomaly_detection_invalid_values(data_source_fixture):
     condition=os.getenv("SCIENTIFIC_TESTS") == "SKIP",
     reason="Environment variable SCIENTIFIC_TESTS is set to SKIP which skips tests depending on the scientific package",
 )
-def test_anomaly_detection_invalid_values(data_source_fixture):
-    import numpy as np
-
+def test_anomaly_detection_incorrect_metric(data_source_fixture):
     table_name = data_source_fixture.ensure_test_table(customers_test_table)
 
     scan = data_source_fixture.create_test_scan()

--- a/soda/core/tests/data_source/test_anomaly_check.py
+++ b/soda/core/tests/data_source/test_anomaly_check.py
@@ -295,8 +295,10 @@ def test_anomaly_detection_incorrect_metric(data_source_fixture):
         metric_values=[10, 10, 10, 9, 8, 0, 0, 0, 0],
     )
 
-    with pytest.raises(Exception) as e:    
+    with pytest.raises(Exception) as e:
         scan.execute()
 
-    assert "An error occurred during the initialization of AnomalyMetricCheck. Please make sure that the metric 'incorrect_metric' is supported. For more information see the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks." in str(e.value)
-
+    assert (
+        "An error occurred during the initialization of AnomalyMetricCheck. Please make sure that the metric 'incorrect_metric' is supported. For more information see the docs: https://docs.soda.io/soda-cl/anomaly-score.html#anomaly-score-checks."
+        in str(e.value)
+    )


### PR DESCRIPTION
This PR resolves: [Fix error handling when invalid metric is provided to AnomalyMetricCheck](https://sodadata.atlassian.net/browse/IA-37)

This PR: 

* Ensures that `self.skip_anomaly_check = True` is set if an exception occurs
* Improves the error message when an incorrect metric is used in the check