### PR TITLE
chore: pin pandas<2.0.0 on scientific lib

### DIFF
--- a/soda/scientific/setup.py
+++ b/soda/scientific/setup.py
@@ -13,6 +13,7 @@ package_version = "3.0.33"
 description = "Soda Core Scientific Package"
 requires = [
     f"soda-core=={package_version}",
+    "pandas<2.0.0",
     "wheel",
     "pydantic>=1.8.1,<2.0.0",
     "scipy>=1.8.0",


### PR DESCRIPTION
Due to the deprecation of the `.append()` DataFrame method in pandas > 2 we will pin pandas to a lower version until we can upgrade all code using `.append()` on a dataframe with confidence.

This should unblock users who recently have had to re-build their soda-core installation which is likely to have installed pandas>2 and who are now getting errors.

See Slack thread here for an example of this situation: https://soda-community.slack.com/archives/C01TFMC2S57/p1682951839810839