### PR TITLE
Pes356

### DIFF
--- a/soda/athena/soda/data_sources/athena_data_source.py
+++ b/soda/athena/soda/data_sources/athena_data_source.py
@@ -100,10 +100,6 @@ class AthenaDataSource(DataSource):
     def regex_replace_flags(self) -> str:
         return ""
 
-    @staticmethod
-    def column_metadata_catalog_column() -> str:
-        return "table_schema"
-
     def default_casify_table_name(self, identifier: str) -> str:
         return identifier.lower()
 

--- a/soda/snowflake/soda/data_sources/snowflake_data_source.py
+++ b/soda/snowflake/soda/data_sources/snowflake_data_source.py
@@ -101,7 +101,7 @@ class SnowflakeDataSource(DataSource):
             user=self.user,
             password=self.password,
             token=self.token,
-            account=self.account,
+            account=re.sub(r'\.snowflakecomputing\.com(\/)*$','',self.account),
             data_source=self.data_source,
             database=self.database,
             schema=self.schema,


### PR DESCRIPTION
Associated linear: https://linear.app/atlanproduct/issue/PES-356/dr-martens-20-or-profiling-workflow-is-not-updating-as-expected

Connecting to snowflake is failing  with the following errror message. `WARNING connectionpool - urlopen: Retrying (Retry(total=0, connect=None, read=None, redire
ct=None, status=None)) after connection broken by 'NewConnectionError('<snowflake.connector.vendored.urllib3.conne
ction.HTTPSConnection object at 0x7f95aab87760>: Failed to establish a new connection: [Errno -2] Name or service
not known')': /.snowflakecomputing.com:443/session/v1/login-request?request_id=d1813e16-5448-4bdf-8814-c0f2e064e50
9&databaseName=PRESENTATION&schemaName=PRESENTATION&warehouse=COMPUTE_WH&roleName=ATLAN_USER_ROLE`

As per https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api, the account name that is being passed should not include the domain name snowflakecomputing.com.

The fix is to remove the suffix from the account if it is present.