### PR TITLE
Feature/adding more file formats for duckdb

### DIFF
--- a/soda/duckdb/soda/data_sources/duckdb_data_source.py
+++ b/soda/duckdb/soda/data_sources/duckdb_data_source.py
@@ -9,8 +9,8 @@
 #  limitations under the License.
 
 import logging
-from typing import List, Optional
 from pathlib import Path
+from typing import List, Optional
 
 from soda.common.exceptions import DataSourceConnectionError
 from soda.common.logs import Logs
@@ -81,7 +81,7 @@ class DuckDBDataSource(DataSource):
         DataType.TIMESTAMP_TZ: "timestamp with time zone",
         DataType.BOOLEAN: "boolean",
     }
-    
+
     REGISTERED_FORMAT_MAP = {
         ".csv": "read_csv_auto",
         ".parquet": "read_parquet",
@@ -114,10 +114,10 @@ class DuckDBDataSource(DataSource):
             if self.duckdb_connection:
                 self.connection = DuckDBDataSourceConnectionWrapper(self.duckdb_connection)
             elif (read_function := self.REGISTERED_FORMAT_MAP.get(self.extract_format())) is not None:
-                self.connection = DuckDBDataSourceConnectionWrapper(
-                    duckdb.connect(':default:')
-                    )
-                self.connection.sql(f"CREATE TABLE {self.extract_dataset_name()} AS SELECT * FROM {read_function}('{self.path}')")
+                self.connection = DuckDBDataSourceConnectionWrapper(duckdb.connect(":default:"))
+                self.connection.sql(
+                    f"CREATE TABLE {self.extract_dataset_name()} AS SELECT * FROM {read_function}('{self.path}')"
+                )
             else:
                 self.connection = DuckDBDataSourceConnectionWrapper(
                     duckdb.connect(
@@ -167,9 +167,9 @@ class DuckDBDataSource(DataSource):
             percentile_fraction = metric_args[1] if metric_args else None
             return f"PERCENTILE_DISC({percentile_fraction}) WITHIN GROUP (ORDER BY {expr})"
         return super().get_metric_sql_aggregation_expression(metric_name, metric_args, expr)
-    
+
     def extract_dataset_name(self) -> str:
         return Path(self.path).stem
-    
+
     def extract_format(self) -> str:
         return Path(self.path).suffix

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -56,3 +56,36 @@ def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
     scan.execute(allow_warnings_only=True)
     scan.assert_all_checks_pass()
     scan.assert_no_error_logs()
+    
+def test_df_from_json(data_source_fixture: DataSourceFixture, tmp_path: Path):
+    import logging
+    import pandas as pd
+    from soda.common.logs import Logs
+    
+    json_folder = tmp_path / "json"
+    json_folder.mkdir()
+    json_path = csv_folder / "dataset.csv"
+    
+    test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
+    test_df.to_csv(json_path)
+    
+    data_source_properties = {
+      "path": json_path,
+    }
+
+    data_source = DuckDBDataSource(logs=Logs(logging.getLogger("test_df_from_csv")), 
+                                   data_source_name="dataset",
+                                   data_source_properties=data_source_properties)
+    
+    scan = data_source.create_test_scan()
+    scan.add_sodacl_yaml_str(
+        f"""
+          checks for dataset:
+            - row_count = 4
+            - missing_count(i) = 0
+            - missing_count(j) = 0
+        """
+    )
+    scan.execute(allow_warnings_only=True)
+    scan.assert_all_checks_pass()
+    scan.assert_no_error_logs()

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -77,7 +77,7 @@ def test_df_from_json(data_source_fixture: DataSourceFixture, tmp_path: Path):
         """
     )
     scan.add_sodacl_yaml_str(
-        f"""
+        """
           checks for json_dataset:
             - missing_count(i) = 0
             - missing_count(j) = 0

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from helpers.data_source_fixture import DataSourceFixture
+from soda.duckdb.soda.data_sources.duckdb_data_source import DuckDBDataSource
 
 
 def test_pandas_df(data_source_fixture: DataSourceFixture):
@@ -13,6 +15,39 @@ def test_pandas_df(data_source_fixture: DataSourceFixture):
     scan.add_sodacl_yaml_str(
         f"""
           checks for test_df:
+            - row_count = 4
+            - missing_count(i) = 0
+            - missing_count(j) = 0
+        """
+    )
+    scan.execute(allow_warnings_only=True)
+    scan.assert_all_checks_pass()
+    scan.assert_no_error_logs()
+
+def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
+    import logging
+    import pandas as pd
+    from soda.common.logs import Logs
+    
+    csv_folder = tmp_path / "csv"
+    csv_folder.mkdir()
+    csv_path = csv_folder / "dataset.csv"
+    
+    test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
+    test_df.to_csv(csv_path)
+    
+    data_source_properties = {
+      "path": csv_path,
+    }
+
+    data_source = DuckDBDataSource(logs=Logs(logging.getLogger("test_df_from_csv")), 
+                                   data_source_name="dataset",
+                                   data_source_properties=data_source_properties)
+    
+    scan = data_source.create_test_scan()
+    scan.add_sodacl_yaml_str(
+        f"""
+          checks for dataset:
             - row_count = 4
             - missing_count(i) = 0
             - missing_count(j) = 0

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -45,7 +45,7 @@ def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
         """
     )
     scan.add_sodacl_yaml_str(
-        f"""
+        """
           checks for csv_dataset:
             - row_count = 4
             - missing_count(i) = 0

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -108,7 +108,7 @@ def test_df_from_parquet(data_source_fixture: DataSourceFixture, tmp_path: Path)
         """
     )
     scan.add_sodacl_yaml_str(
-        f"""
+        """
           checks for parquet_dataset:
             - row_count = 4
             - missing_count(i) = 0

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from helpers.data_source_fixture import DataSourceFixture
-from soda.scan import Scan
 
 
 def test_pandas_df(data_source_fixture: DataSourceFixture):

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from helpers.data_source_fixture import DataSourceFixture
 
 
@@ -23,23 +24,24 @@ def test_pandas_df(data_source_fixture: DataSourceFixture):
     scan.assert_all_checks_pass()
     scan.assert_no_error_logs()
 
+
 def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
     import pandas as pd
-    
+
     csv_folder = tmp_path / "csv"
     csv_folder.mkdir()
     csv_path = csv_folder / "csv_dataset.csv"
-    
+
     test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
     test_df.to_csv(csv_path)
-    
+
     scan = data_source_fixture.create_test_scan()
     scan.set_data_source_name("csv_dataset")
     scan.add_configuration_yaml_str(
         f"""
           data_source csv_dataset:
             type: duckdb
-            path: {csv_path} 
+            path: {csv_path}
         """
     )
     scan.add_sodacl_yaml_str(
@@ -53,14 +55,15 @@ def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
     scan.execute(allow_warnings_only=True)
     scan.assert_all_checks_pass()
     scan.assert_no_error_logs()
-    
+
+
 def test_df_from_json(data_source_fixture: DataSourceFixture, tmp_path: Path):
     import pandas as pd
-    
+
     json_folder = tmp_path / "json"
     json_folder.mkdir()
     json_path = json_folder / "json_dataset.json"
-    
+
     test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
     test_df.to_json(json_path)
 
@@ -70,7 +73,7 @@ def test_df_from_json(data_source_fixture: DataSourceFixture, tmp_path: Path):
         f"""
           data_source json_dataset:
             type: duckdb
-            path: {json_path} 
+            path: {json_path}
         """
     )
     scan.add_sodacl_yaml_str(
@@ -83,14 +86,15 @@ def test_df_from_json(data_source_fixture: DataSourceFixture, tmp_path: Path):
     scan.execute(allow_warnings_only=True)
     scan.assert_all_checks_pass()
     scan.assert_no_error_logs()
-    
+
+
 def test_df_from_parquet(data_source_fixture: DataSourceFixture, tmp_path: Path):
     import pandas as pd
-    
+
     parquet_folder = tmp_path / "parquet"
     parquet_folder.mkdir()
     parquet_path = parquet_folder / "parquet_dataset.parquet"
-    
+
     test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
     test_df.to_parquet(parquet_path)
 
@@ -100,7 +104,7 @@ def test_df_from_parquet(data_source_fixture: DataSourceFixture, tmp_path: Path)
         f"""
           data_source parquet_dataset:
             type: duckdb
-            path: {parquet_path} 
+            path: {parquet_path}
         """
     )
     scan.add_sodacl_yaml_str(


### PR DESCRIPTION
Adding support for csv, parquet and json file in Soda-core for the duckdb engine.