### PR TITLE
added BigQuery Job Labels

### DIFF
--- a/soda/bigquery/soda/data_sources/bigquery_data_source.py
+++ b/soda/bigquery/soda/data_sources/bigquery_data_source.py
@@ -124,6 +124,8 @@ class BigQueryDataSource(DataSource):
         if storage_project_id:
             self.storage_project_id = storage_project_id
 
+        self.labels = self.data_source_properties.get("labels", {})
+
     def connect(self):
         try:
             from google.api_core.client_info import ClientInfo
@@ -136,6 +138,7 @@ class BigQueryDataSource(DataSource):
                 credentials=self.credentials,
                 default_query_job_config=bigquery.QueryJobConfig(
                     default_dataset=f"{self.storage_project_id}.{self.dataset}",
+                    labels=self.labels,
                 ),
                 location=self.location,
                 client_info=client_info,


### PR DESCRIPTION
- add BigQuery job labels in the standard configuration file (example below) based on https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.QueryJobConfig
- tested a simple check.yaml file with and without labels set up at the configuration.yaml file level, the results are in line with the expected behavior

- ![image](https://github.com/sodadata/soda-core/assets/12852045/654950c6-9d6b-4ab1-af17-ec738c9a9b07)



