### PR TITLE
fix: compute value counts in DB rather than in python for categoric d…

### DIFF
--- a/soda/core/soda/execution/check/distribution_check.py
+++ b/soda/core/soda/execution/check/distribution_check.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from numbers import Number
 
 from ruamel.yaml import YAML
-
 from soda.cli.cli import DATA_SOURCES_WITH_DISTRIBUTION_CHECK_SUPPORT
 from soda.common.exceptions import SODA_SCIENTIFIC_MISSING_LOG_MESSAGE
 from soda.execution.check.check import Check

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -1359,6 +1359,30 @@ class DataSource:
         finally:
             cursor.close()
 
+    def sql_groupby_count_categorical_column(
+        self,
+        select_query: str,
+        column_name: str,
+        limit: int | None = None,
+    ) -> str:
+        cte = select_query.replace("\n", " ")
+        # delete multiple spaces
+        cte = re.sub(" +", " ", cte)
+        sql = dedent(
+            f"""
+                WITH processed_table AS (
+                    {cte}
+                )
+                SELECT
+                    {column_name}
+                    , COUNT(*) AS frequency
+                FROM processed_table
+                GROUP BY {column_name}
+            """
+        )
+        sql += f"LIMIT {limit}" if limit else ""
+        return dedent(sql)
+
     def sql_select_column_with_filter_and_limit(
         self,
         column_name: str,

--- a/soda/core/tests/data_source/test_distribution_check.py
+++ b/soda/core/tests/data_source/test_distribution_check.py
@@ -4,8 +4,8 @@ import pytest
 from helpers.common_test_tables import customers_dist_check_test_table
 from helpers.data_source_fixture import DataSourceFixture
 from helpers.fixtures import test_data_source
-
 from soda.execution.check.distribution_check import DistributionCheck
+
 from soda.scientific.distribution.comparison import CategoricalLimitExceeded
 
 

--- a/soda/scientific/soda/scientific/distribution/utils.py
+++ b/soda/scientific/soda/scientific/distribution/utils.py
@@ -60,7 +60,7 @@ def assert_bidirectional_categorial_values(
 
 
 def distribution_is_all_null(distribution: pd.Series) -> bool:
-    if pd.isnull(distribution).all():
+    if pd.isnull(distribution.index).all():
         return True
     else:
         return False

--- a/soda/scientific/tests/assets/dist_ref_categorical.yml
+++ b/soda/scientific/tests/assets/dist_ref_categorical.yml
@@ -3,4 +3,4 @@ column: cst_size
 distribution_type: categorical
 distribution reference:
     bins: [1, 2, 3]
-    weights: [0.4, 0.3, 0.3]
+    weights: [0.7, 0.19, 0.11]

--- a/soda/scientific/tests/distribution_comparison_test.py
+++ b/soda/scientific/tests/distribution_comparison_test.py
@@ -1,26 +1,38 @@
 import decimal
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
 from numpy.random import default_rng
+from ruamel.yaml import YAML
 
 from soda.scientific.distribution.comparison import (
     DistributionRefKeyException,
     DistributionRefParsingException,
-    SWDAlgorithm,
+    MissingCategories,
 )
 from soda.scientific.distribution.utils import RefDataCfg
 
 
+def read_dro(dro_path: str) -> YAML:
+    assets_path = Path(__file__).parent / "assets"
+    f_name = dro_path.split("/")[-1]
+    processed_dro_path = assets_path / f_name
+    with open(processed_dro_path) as f:
+        dro_yaml = f.read()
+    return YAML().load(dro_yaml)
+
+
 @pytest.mark.parametrize(
-    "distribution_type",
+    "distribution_type, error_expected",
     [
-        pytest.param("continuous", id="valid distribution_type continuous"),
-        pytest.param("categorical", id="valid distribution_type categorical"),
+        pytest.param("continuous", False, id="valid distribution_type continuous"),
+        pytest.param("categorical", False, id="valid distribution_type categorical"),
+        pytest.param("heyyo", True, id="invalid distribution_type heyyo"),
     ],
 )
-def test_config_distribution_type(distribution_type):
+def test_config_distribution_type(distribution_type, error_expected):
     from pydantic.error_wrappers import ValidationError
 
     try:
@@ -28,26 +40,25 @@ def test_config_distribution_type(distribution_type):
         weights = [0.1, 0.8, 0.1]
         RefDataCfg(bins=bins, weights=weights, labels=None, distribution_type=distribution_type)
     except ValidationError:
-        pass
+        assert error_expected
 
 
 @pytest.mark.parametrize(
-    "weights",
+    "weights, error_expected",
     [
-        pytest.param([0.5, 0.3, 0.2], id="valid weights with sum == 1"),
-        pytest.param([0.5, 0.5, 0.5], id="invalid weights with sum != 1"),
-        pytest.param([None, 0.5, 0.5], id="invalid weights with sum == 1 but having none"),
+        pytest.param([0.5, 0.3, 0.2], False, id="valid weights with sum == 1"),
+        pytest.param([0.5, 0.5, 0.5], True, id="invalid weights with sum != 1"),
+        pytest.param([None, 0.5, 0.5], True, id="invalid weights with sum == 1 but having none"),
     ],
 )
-def test_config_weights(weights):
+def test_config_weights(weights, error_expected):
     from pydantic.error_wrappers import ValidationError
 
+    bins = [1, 2, 3]
     try:
-        bins = [1, 2, 3]
-        method = "ks"
-        RefDataCfg(bins=bins, weights=weights, labels=None, method=method)
+        RefDataCfg(bins=bins, weights=weights, labels=None, distribution_type="continuous")
     except ValidationError:
-        pass
+        assert error_expected
 
 
 @pytest.mark.parametrize(
@@ -72,9 +83,9 @@ def test_config_weights(weights):
         pytest.param(
             "chi_square",
             "soda/scientific/tests/assets/dist_ref_categorical.yml",
-            [1, 1, 2, 3] * 1000,
-            156.32764391336602,
-            1.960998922048572e-34,
+            [(1, 700), (2, 200), (3, 100)],
+            1.4244611103249847,
+            0.4905487801068025,
             id="Different categorical distribution with chi-square",
         ),
         pytest.param(
@@ -106,10 +117,14 @@ def test_config_weights(weights):
 def test_distribution_checker(method, reference_file_path, test_data, expected_stat, expected_p):
     from soda.scientific.distribution.comparison import DistributionChecker
 
-    with open(reference_file_path) as f:
-        dist_ref_yaml = f.read()
-
-    check = DistributionChecker(method, dist_ref_yaml, reference_file_path, None, test_data)
+    parsed_dro = read_dro(reference_file_path)
+    check = DistributionChecker(
+        dist_method=method,
+        parsed_dro=parsed_dro,
+        dist_ref_file_path=reference_file_path,
+        dist_name=None,
+        data=test_data,
+    )
     check_results = check.run()
     assert check_results["stat_value"] == pytest.approx(expected_stat, abs=1e-3)
     assert check_results["check_value"] == pytest.approx(expected_p, abs=1e-3)
@@ -122,12 +137,7 @@ def test_distribution_checker(method, reference_file_path, test_data, expected_s
             "soda/scientific/tests/assets/dist_ref_missing_method.yml",
             DistributionRefKeyException,
             id="Missing key method",
-        ),
-        pytest.param(
-            "soda/scientific/tests/assets/invalid.yml",
-            DistributionRefParsingException,
-            id="Corrupted yaml file",
-        ),
+        )
     ],
 )
 def test_ref_config_file_exceptions(reference_file_path, exception):
@@ -135,9 +145,14 @@ def test_ref_config_file_exceptions(reference_file_path, exception):
 
     with pytest.raises(exception):
         test_data = list(pd.Series(default_rng(61).normal(loc=1.0, scale=1.0, size=1000)))
-        with open(reference_file_path) as f:
-            dist_ref_yaml = f.read()
-        DistributionChecker("continuous", dist_ref_yaml, reference_file_path, None, test_data)
+        parsed_dro = read_dro(reference_file_path)
+        DistributionChecker(
+            dist_method="continuous",
+            parsed_dro=parsed_dro,
+            dist_ref_file_path=reference_file_path,
+            dist_name=None,
+            data=test_data,
+        )
 
 
 # The following bins and weights are generated based on
@@ -216,7 +231,6 @@ TEST_CONFIG_CONT_1 = RefDataCfg(
         0.003,
     ],
     labels=None,
-    method="ks",
     distribution_type="continuous",
 )
 
@@ -272,70 +286,47 @@ TEST_CONFIG_CATEGORIC_1 = RefDataCfg(
 
 
 @pytest.mark.parametrize(
-    "test_data, expected_stat_val, expected_p_val, error_expected",
+    "test_data, expected_stat_val, expected_p_val",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 500)]),
             0,
             1.0,
-            False,
             id="distributions are same",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.2, 0.3, 0.5], size=1000)),
-            114.89620253164557,
-            1.1235867896657214e-25,
-            False,
+            pd.Series([(0, 200), (1, 300), (2, 500)]),
+            123.94755685044814,
+            1.2165501237202362e-27,
             id="distributions are different",
-        ),
-        pytest.param(
-            pd.Series([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2]),
-            0.0,
-            1,
-            True,
-            id="distributions do not have enough sample for each category",
-        ),
-        pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2, None], p=[0.2, 0.3, 0.4, 0.1], size=1000)),
-            139.96423321882253,
-            4.047183768366915e-31,
-            False,
-            id="distributions test data have some nulls",
         ),
     ],
 )
-def test_chi_square_comparison(test_data, expected_stat_val, expected_p_val, error_expected):
-    from soda.scientific.distribution.comparison import (
-        ChiSqAlgorithm,
-        NotEnoughSamplesException,
-    )
+def test_chi_square_comparison(test_data, expected_stat_val, expected_p_val):
+    from soda.scientific.distribution.comparison import ChiSqAlgorithm
 
-    try:
-        check_results = ChiSqAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
-        assert expected_stat_val == pytest.approx(check_results["stat_value"], abs=1e-3)
-        assert expected_p_val == pytest.approx(check_results["check_value"], abs=1e-3)
-        assert not error_expected
-    except NotEnoughSamplesException:
-        assert error_expected
+    check_results = ChiSqAlgorithm(TEST_CONFIG_CATEGORIC_1, test_data).evaluate()
+    assert expected_stat_val == pytest.approx(check_results["stat_value"], abs=1e-3)
+    assert expected_p_val == pytest.approx(check_results["check_value"], abs=1e-3)
 
 
 @pytest.mark.parametrize(
     "test_data, config",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 500)]),
             RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, distribution_type="categorical"),
             id="category missing in reference data",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1], p=[0.1, 0.9], size=1000)),
+            pd.Series([(0, 100), (1, 900)]),
             RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, distribution_type="categorical"),
             id="category missing in test data",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([None, None, 1], p=[0.2, 0.3, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 400), (None, 100)]),
             RefDataCfg(bins=[0, 1, 2], weights=[0.1, 0.4, 0.5], labels=None, distribution_type="categorical"),
-            id="one of the distributions is fully none",
+            id="one of the distribution has nulls",
         ),
     ],
 )
@@ -354,17 +345,17 @@ def test_chi_sq_2_samples_comparison_missing_cat(test_data, config):
     "test_data, config",
     [
         pytest.param(
-            pd.Series([None, None] * 10),
+            pd.Series([(None, 20)]),
             RefDataCfg(bins=[0, 1], weights=[0.1, 0.9], labels=None, distribution_type="categorical"),
             id="test data is all none",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1], p=[0.1, 0.9], size=1000)),
+            pd.Series([(0, 100), (1, 900)]),
             RefDataCfg(bins=[None], weights=[1], labels=None, distribution_type="categorical"),
             id="ref data is all none",
         ),
         pytest.param(
-            pd.Series([None, None] * 10),
+            pd.Series([(None, 20)]),
             RefDataCfg(bins=[None], weights=[1], labels=None, distribution_type="categorical"),
             id="both distributions are null",
         ),
@@ -382,7 +373,12 @@ def test_chi_sq_2_samples_comparison_one_or_more_null_distros(test_data, config)
     "test_data, config",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([1, 2], p=[0.5, 0.5], size=2)),
+            pd.Series(
+                [
+                    (1, 1),
+                    (2, 1),
+                ]
+            ),
             RefDataCfg(bins=[1, 2], weights=[0.5, 0.5], labels=None, distribution_type="categorical"),
             id="not enough samples",
         ),
@@ -435,13 +431,13 @@ def test_swd_continuous(test_data, expected_swd):
     "test_data, expected_swd",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 500)]),
             0,
             id="distributions are same",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.2, 0.3, 0.5], size=1000)),
-            0.130034992111961,
+            pd.Series([(0, 200), (1, 300), (2, 500)]),
+            0.4472135954999579,
             id="distributions are different",
         ),
     ],
@@ -497,13 +493,13 @@ def test_psi_continuous(test_data, expected_psi):
     "test_data, expected_psi",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 500)]),
             0,
             id="distributions are same",
         ),
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.2, 0.3, 0.5], size=1000)),
-            0.09000613400978587,
+            pd.Series([(0, 200), (1, 300), (2, 500)]),
+            13.885334329209103,
             id="distributions are different",
         ),
     ],
@@ -547,16 +543,21 @@ def test_ref_config_incompatible(test_data, dist_ref_file_path, method):
     )
 
     with pytest.raises(DistributionRefIncompatibleException):
-        with open(dist_ref_file_path) as f:
-            dist_ref_yaml = f.read()
-        DistributionChecker(method, dist_ref_yaml, dist_ref_file_path, None, test_data)
+        parsed_dro = read_dro(dist_ref_file_path)
+        DistributionChecker(
+            dist_method=method,
+            parsed_dro=parsed_dro,
+            dist_ref_file_path=dist_ref_file_path,
+            dist_name=None,
+            data=test_data,
+        )
 
 
 @pytest.mark.parametrize(
     "test_data, dist_ref_file_path, method",
     [
         pytest.param(
-            pd.Series(default_rng(61).choice([0, 1, 2], p=[0.1, 0.4, 0.5], size=1000)),
+            pd.Series([(0, 100), (1, 400), (2, 500)]),
             "soda/scientific/tests/assets/dist_ref_categorical_no_bins.yml",
             "chi_square",
             id="missing bins and weights with with distribution_type categorical",
@@ -576,9 +577,14 @@ def test_missing_bins_weights(test_data, dist_ref_file_path, method):
     )
 
     with pytest.raises(MissingBinsWeightsException):
-        with open(dist_ref_file_path) as f:
-            dist_ref_yaml = f.read()
-        DistributionChecker(method, dist_ref_yaml, dist_ref_file_path, None, test_data)
+        parsed_dro = read_dro(dist_ref_file_path)
+        DistributionChecker(
+            dist_method=method,
+            parsed_dro=parsed_dro,
+            dist_ref_file_path=dist_ref_file_path,
+            dist_name=None,
+            data=test_data,
+        )
 
 
 @pytest.mark.parametrize(
@@ -599,6 +605,11 @@ def test_empty_test_data(test_data, dist_ref_file_path, method):
     )
 
     with pytest.raises(EmptyDistributionCheckColumn):
-        with open(dist_ref_file_path) as f:
-            dist_ref_yaml = f.read()
-        DistributionChecker(method, dist_ref_yaml, dist_ref_file_path, None, test_data)
+        parsed_dro = read_dro(dist_ref_file_path)
+        DistributionChecker(
+            dist_method=method,
+            parsed_dro=parsed_dro,
+            dist_ref_file_path=dist_ref_file_path,
+            dist_name=None,
+            data=test_data,
+        )


### PR DESCRIPTION
Cherry-picked from soda-library

For categorical values, we will count the distinct number of values in DB using group by queries instead of doing this operation in python. It will speed up distro checks and will use much less memory for categorical values.

It will evaluate up to 1M categorical distinct values. If we have more than 1M categorical values, then the check will be skipped with a warning message. For demo purpose, I set the limit to 3 instead of 1M. See the example output below for a categoric column having more than 3 distinct values.

```
[16:25:38] Scan summary:
[16:25:38] 1/1 check NOT EVALUATED: 
[16:25:38]     reworth_test in adventureworks
[16:25:38]       distribution_difference(dia) > 0.05 [NOT EVALUATED]
[16:25:38]         value: None
[16:25:38]         fail: {'lessThanOrEqual': 0.05}
[16:25:38] 1 checks not evaluated.
[16:25:38] 1 errors.
[16:25:38] Oops! 1 error. 0 failures. 0 warnings. 0 pass.
ERRORS:
[16:25:38] During the 'Distribution Check', it was observed that the column 'id' contains over 3 distinct categories. The check will not be evaluated due to performance reasons. Consider applying a `sample` or `filter` 
  +-> line=28,col=5 in /Users/baturayofluoglu/workspace/test-gh-action-baturay/soda/checks.yaml
[16:25:38] Sending results to Soda Cloud
[16:25:38] Soda Cloud Trace: 8177112288415893125
successfully flushed about 0 items.
consumer exited.
```