### PR TITLE
feat: Add Dask/Pandas configurable data source naming support

### DIFF
--- a/soda/core/soda/execution/check/check.py
+++ b/soda/core/soda/execution/check/check.py
@@ -216,7 +216,7 @@ class Check(ABC):
             # Temp workaround to provide migration identities with fixed data source
             # name. See https://sodadata.atlassian.net/browse/CLOUD-5446
             for identity in self.identity_datasource_part() if isinstance(with_datasource, bool) else [with_datasource]:
-                hash_builder.add(self.data_source_scan.data_source.data_source_name)
+                hash_builder.add(identity)
 
         if with_filename:
             hash_builder.add(os.path.basename(self.check_cfg.location.file_path))

--- a/soda/core/soda/execution/check/check.py
+++ b/soda/core/soda/execution/check/check.py
@@ -245,6 +245,11 @@ class Check(ABC):
                 identities[f"v{len(identities) + 1}"] = identity
         return identities
 
+    def identity_datasource_part(self) -> list[str]:
+        return [
+            self.data_source_scan.data_source.data_source_name,
+        ]
+
     def add_outcome_reason(self, outcome_type: str, message: str, severity: str):
         self.force_send_results_to_cloud = True
         self.outcome_reasons.append({"code": outcome_type, "message": message, "severity": severity})  # error/warn/info

--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -229,6 +229,9 @@ class DataSource:
         self.table_prefix: str | None = self._create_table_prefix()
         # self.data_source_scan is initialized in create_data_source_scan(...) below
         self.data_source_scan: DataSourceScan | None = None
+        # Temporarily introduced to migrate some "wrongly implemented" data sources.
+        # See https://sodadata.atlassian.net/browse/CLOUD-5446
+        self.migrate_data_source_name = None
 
     def has_valid_connection(self) -> bool:
         query = Query(

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -217,26 +217,42 @@ class Scan:
                 exception=e,
             )
 
-    def add_dask_dataframe(self, dataset_name: str, dask_df) -> None:
-        context = self._get_or_create_dask_context(required_soda_module="soda-core-pandas-dask")
+    def add_dask_dataframe(self, dataset_name: str, dask_df, data_source_name: str = "dask") -> None:
+        if data_source_name == "dask":
+            self._logs.warning(
+                "Deprecated: implicit data_source_name is no longer supported. Make sure to provide a "
+                "data_source_name when invoking 'add_dask_dataframe()'."
+            )
+
+        context = self._get_or_create_dask_context(
+            required_soda_module="soda-core-pandas-dask", data_source_name=data_source_name
+        )
         context.create_table(dataset_name, dask_df)
 
-    def add_pandas_dataframe(self, dataset_name: str, pandas_df):
-        context = self._get_or_create_dask_context(required_soda_module="soda-core-pandas-dask")
+    def add_pandas_dataframe(self, dataset_name: str, pandas_df, data_source_name: str = "dask"):
+        if data_source_name == "dask":
+            self._logs.warning(
+                "Deprecated: implicit data_source_name is no longer supported. Make sure to provide a "
+                "data_source_name when invoking 'add_pandas_dataframe()'."
+            )
+
+        context = self._get_or_create_dask_context(
+            required_soda_module="soda-core-pandas-dask", data_source_name=data_source_name
+        )
         from dask.dataframe import from_pandas
 
         dask_df = from_pandas(pandas_df, npartitions=1)
         context.create_table(dataset_name, dask_df)
 
-    def _get_or_create_dask_context(self, required_soda_module: str):
+    def _get_or_create_dask_context(self, required_soda_module: str, data_source_name: str):
         try:
             from dask_sql import Context
         except ImportError:
             raise Exception(f"{required_soda_module} is not installed. Please install {required_soda_module}")
 
-        if "dask" not in self._configuration.data_source_properties_by_name:
-            self._configuration.add_dask_context(data_source_name="dask", dask_context=Context())
-        return self._configuration.data_source_properties_by_name["dask"]["context"]
+        if data_source_name not in self._configuration.data_source_properties_by_name:
+            self._configuration.add_dask_context(data_source_name=data_source_name, dask_context=Context())
+        return self._configuration.data_source_properties_by_name[data_source_name]["context"]
 
     def add_sodacl_yaml_files(
         self,

--- a/soda/core/tests/data_source/test_check_identity.py
+++ b/soda/core/tests/data_source/test_check_identity.py
@@ -206,14 +206,14 @@ def test_check_identity_migrate_identity(data_source_fixture: DataSourceFixture)
     if data_source_fixture.data_source.migrate_data_source_name is None:
         return
 
-    new_data_source_fixture = DataSourceFixture._create("NewDask")
+    new_data_source_fixture = DataSourceFixture._create("NewDataSource")
     new_data_source_fixture._test_session_starts()
     table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
 
     scan_result = execute_scan_and_get_scan_result(
         new_data_source_fixture,
         f"""
-          checks for "{table_name}":
+          checks for {table_name}:
             - row_count > 0
             - missing_count(1) = 0
         """,
@@ -232,14 +232,14 @@ def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: D
     if data_source_fixture.data_source.migrate_data_source_name is None:
         return
 
-    new_data_source_fixture = DataSourceFixture._create("dask")
+    new_data_source_fixture = DataSourceFixture._create(data_source_fixture.data_source.migrate_data_source_name)
     new_data_source_fixture._test_session_starts()
     table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
 
     scan_result = execute_scan_and_get_scan_result(
         new_data_source_fixture,
         f"""
-          checks for "{table_name}":
+          checks for {table_name}:
             - row_count > 0
         """,
     )
@@ -247,48 +247,3 @@ def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: D
 
     new_data_source_fixture._test_session_ends()
 
-
-def test_check_identity_migrate_identity(data_source_fixture: DataSourceFixture):
-    if data_source_fixture.data_source.migrate_data_source_name is None:
-        return
-
-    new_data_source_fixture = DataSourceFixture._create("NewDask")
-    new_data_source_fixture._test_session_starts()
-    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
-
-    scan_result = execute_scan_and_get_scan_result(
-        new_data_source_fixture,
-        f"""
-          checks for "{table_name}":
-            - row_count > 0
-            - missing_count(1) = 0
-        """,
-    )
-    row_count_identity = scan_result["checks"][0]["migratedIdentities"]
-
-    assert isinstance(row_count_identity, dict)
-    assert scan_result["checks"][0]["identities"]["v1"] == scan_result["checks"][0]["migratedIdentities"]["v1"]
-    assert scan_result["checks"][0]["identities"]["v2"] != scan_result["checks"][0]["migratedIdentities"]["v2"]
-    assert scan_result["checks"][0]["identities"]["v3"] != scan_result["checks"][0]["migratedIdentities"]["v3"]
-
-    new_data_source_fixture._test_session_ends()
-
-
-def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: DataSourceFixture):
-    if data_source_fixture.data_source.migrate_data_source_name is None:
-        return
-
-    new_data_source_fixture = DataSourceFixture._create("dask")
-    new_data_source_fixture._test_session_starts()
-    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
-
-    scan_result = execute_scan_and_get_scan_result(
-        new_data_source_fixture,
-        f"""
-          checks for "{table_name}":
-            - row_count > 0
-        """,
-    )
-    assert scan_result["checks"][0]["migratedIdentities"] is None
-
-    new_data_source_fixture._test_session_ends()

--- a/soda/core/tests/data_source/test_check_identity.py
+++ b/soda/core/tests/data_source/test_check_identity.py
@@ -200,3 +200,93 @@ def test_check_identity_special_table(data_source_fixture: DataSourceFixture):
     row_count_identity = scan_result["checks"][0]["identity"]
 
     assert isinstance(row_count_identity, str)
+
+def test_check_identity_migrate_identity(data_source_fixture: DataSourceFixture):
+    if data_source_fixture.data_source.migrate_data_source_name is None:
+        return
+
+    new_data_source_fixture = DataSourceFixture._create("NewDask")
+    new_data_source_fixture._test_session_starts()
+    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan_result = execute_scan_and_get_scan_result(
+        new_data_source_fixture,
+        f"""
+          checks for "{table_name}":
+            - row_count > 0
+            - missing_count(1) = 0
+        """,
+    )
+    row_count_identity = scan_result["checks"][0]["migratedIdentities"]
+
+    assert isinstance(row_count_identity, dict)
+    assert scan_result["checks"][0]["identities"]["v1"] == scan_result["checks"][0]["migratedIdentities"]["v1"]
+    assert scan_result["checks"][0]["identities"]["v2"] != scan_result["checks"][0]["migratedIdentities"]["v2"]
+    assert scan_result["checks"][0]["identities"]["v3"] != scan_result["checks"][0]["migratedIdentities"]["v3"]
+
+    new_data_source_fixture._test_session_ends()
+
+
+def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: DataSourceFixture):
+    if data_source_fixture.data_source.migrate_data_source_name is None:
+        return
+
+    new_data_source_fixture = DataSourceFixture._create("dask")
+    new_data_source_fixture._test_session_starts()
+    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan_result = execute_scan_and_get_scan_result(
+        new_data_source_fixture,
+        f"""
+          checks for "{table_name}":
+            - row_count > 0
+        """,
+    )
+    assert scan_result["checks"][0]["migratedIdentities"] is None
+
+    new_data_source_fixture._test_session_ends()
+
+def test_check_identity_migrate_identity(data_source_fixture: DataSourceFixture):
+    if data_source_fixture.data_source.migrate_data_source_name is None:
+        return
+
+    new_data_source_fixture = DataSourceFixture._create("NewDask")
+    new_data_source_fixture._test_session_starts()
+    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan_result = execute_scan_and_get_scan_result(
+        new_data_source_fixture,
+        f"""
+          checks for "{table_name}":
+            - row_count > 0
+            - missing_count(1) = 0
+        """,
+    )
+    row_count_identity = scan_result["checks"][0]["migratedIdentities"]
+
+    assert isinstance(row_count_identity, dict)
+    assert scan_result["checks"][0]["identities"]["v1"] == scan_result["checks"][0]["migratedIdentities"]["v1"]
+    assert scan_result["checks"][0]["identities"]["v2"] != scan_result["checks"][0]["migratedIdentities"]["v2"]
+    assert scan_result["checks"][0]["identities"]["v3"] != scan_result["checks"][0]["migratedIdentities"]["v3"]
+
+    new_data_source_fixture._test_session_ends()
+
+
+def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: DataSourceFixture):
+    if data_source_fixture.data_source.migrate_data_source_name is None:
+        return
+
+    new_data_source_fixture = DataSourceFixture._create("dask")
+    new_data_source_fixture._test_session_starts()
+    table_name = new_data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan_result = execute_scan_and_get_scan_result(
+        new_data_source_fixture,
+        f"""
+          checks for "{table_name}":
+            - row_count > 0
+        """,
+    )
+    assert scan_result["checks"][0]["migratedIdentities"] is None
+
+    new_data_source_fixture._test_session_ends()

--- a/soda/core/tests/data_source/test_check_identity.py
+++ b/soda/core/tests/data_source/test_check_identity.py
@@ -246,4 +246,3 @@ def test_check_identity_migrate_identity_when_not_changed(data_source_fixture: D
     assert scan_result["checks"][0]["migratedIdentities"] is None
 
     new_data_source_fixture._test_session_ends()
-

--- a/soda/core/tests/helpers/data_source_fixture.py
+++ b/soda/core/tests/helpers/data_source_fixture.py
@@ -28,12 +28,12 @@ class DataSourceFixture:
     __test__ = False
 
     @staticmethod
-    def _create() -> DataSourceFixture:
+    def _create(test_data_source_name: str = None) -> DataSourceFixture:
         test_data_source = os.getenv("test_data_source", "postgres")
         module = import_module(f"{test_data_source}_data_source_fixture")
         data_source_fixture_class = f"{DataSource.camel_case_data_source_type(test_data_source)}DataSourceFixture"
         class_ = getattr(module, data_source_fixture_class)
-        return class_(test_data_source)
+        return class_(test_data_source_name or test_data_source)
 
     def __init__(self, test_data_source: str):
         self.data_source_name = test_data_source

--- a/soda/dask/soda/data_sources/dask_data_source.py
+++ b/soda/dask/soda/data_sources/dask_data_source.py
@@ -96,7 +96,7 @@ class DaskDataSource(DataSource):
             row_udf=False,
         )
 
-    self.migrate_data_source_name = "dask"
+        self.migrate_data_source_name = "dask"
 
     def connect(self) -> None:
         self.connection = DaskConnection(self.context)

--- a/soda/dask/soda/data_sources/dask_data_source.py
+++ b/soda/dask/soda/data_sources/dask_data_source.py
@@ -95,6 +95,7 @@ class DaskDataSource(DataSource):
             str,
             row_udf=False,
         )
+    self.migrate_data_source_name = "dask"
 
     def connect(self) -> None:
         self.connection = DaskConnection(self.context)
@@ -320,6 +321,12 @@ class DaskDataSource(DataSource):
         logging.debug(f"Running SQL query:\n{sql}")
         df = self.connection.context.sql(sql)
         df.compute()
+
+    def get_basic_properties(self) -> dict:
+        return {
+            "type": self.type,
+            "prefix": self.data_source_name,
+        }
 
     @staticmethod
     def regexp_like(value: str | Series, regex_pattern: str) -> int:

--- a/soda/dask/tests/conftest.py
+++ b/soda/dask/tests/conftest.py
@@ -1,0 +1,1 @@
+from helpers.fixtures import * #NOQA

--- a/soda/dask/tests/dask_data_source_fixture.py
+++ b/soda/dask/tests/dask_data_source_fixture.py
@@ -16,11 +16,13 @@ class DaskDataSourceFixture(DataSourceFixture):
         super().__init__(test_data_source)
 
     def _build_configuration_dict(self, schema_name: str | None = None) -> dict:
-        return {"data_source dask": {"type": "dask"}, "schema": schema_name}
+        return {f"data_source {self.data_source_name}": {"type": "dask"}, "schema": schema_name}
 
     def _test_session_starts(self) -> None:
         scan = Scan()
-        self.context = scan._get_or_create_dask_context(required_soda_module="soda-core-pandas-dask")
+        self.context = scan._get_or_create_dask_context(
+            required_soda_module="soda-core-pandas-dask", data_source_name=self.data_source_name
+        )
         self.data_source = scan._data_source_manager.get_data_source(self.data_source_name)
         scan._get_or_create_data_source_scan(self.data_source_name)
 

--- a/soda/dask/tests/test_dask.py
+++ b/soda/dask/tests/test_dask.py
@@ -1,2 +1,2 @@
 def test_dask_data_source():
-    pass;
+    pass

--- a/soda/dask/tests/test_dask.py
+++ b/soda/dask/tests/test_dask.py
@@ -1,2 +1,16 @@
-def test_dask():
-    """Add plugin specific tests here. Present so that CI is simpler and to avoid false plugin-specific tests passing."""
+from helpers.common_test_tables import customers_test_table
+from helpers.data_source_fixture import DataSourceFixture
+from helpers.utils import execute_scan_and_get_scan_result
+
+
+def test_dask_data_source_prefix(data_source_fixture: DataSourceFixture):
+    table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan_result = execute_scan_and_get_scan_result(
+        data_source_fixture,
+        f"""
+        checks for "{table_name}":
+            - row_count > 0
+        """,
+    )
+    assert scan_result["defaultDataSourceProperties"]["prefix"] == data_source_fixture.data_source_name

--- a/soda/dask/tests/test_dask.py
+++ b/soda/dask/tests/test_dask.py
@@ -1,16 +1,2 @@
-from helpers.common_test_tables import customers_test_table
-from helpers.data_source_fixture import DataSourceFixture
-from helpers.utils import execute_scan_and_get_scan_result
-
-
-def test_dask_data_source_prefix(data_source_fixture: DataSourceFixture):
-    table_name = data_source_fixture.ensure_test_table(customers_test_table)
-
-    scan_result = execute_scan_and_get_scan_result(
-        data_source_fixture,
-        f"""
-        checks for "{table_name}":
-            - row_count > 0
-        """,
-    )
-    assert scan_result["defaultDataSourceProperties"]["prefix"] == data_source_fixture.data_source_name
+def test_dask_data_source():
+    pass;

--- a/soda/spark_df/soda/data_sources/spark_df_data_source.py
+++ b/soda/spark_df/soda/data_sources/spark_df_data_source.py
@@ -33,6 +33,7 @@ class SparkDfDataSource(SparkSQLBase):
     def __init__(self, logs: Logs, data_source_name: str, data_source_properties: dict):
         super().__init__(logs, data_source_name, data_source_properties)
         self.spark_session = data_source_properties.get("spark_session")
+        self.migrate_data_source_name = "spark_df"
 
     def connect(self):
         self.connection = SparkDfConnection(self.spark_session)


### PR DESCRIPTION
Adds support for configurable Spark/Dask data source names 

[CLOUD-5446] - https://github.com/sodadata/soda-library/pull/120

[CLOUD-5446]: https://sodadata.atlassian.net/browse/CLOUD-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ