### PR TITLE
Apply sample limit to UDFailedRowsExpressionQuery

### DIFF
--- a/soda/core/soda/execution/check/user_defined_failed_rows_expression_check.py
+++ b/soda/core/soda/execution/check/user_defined_failed_rows_expression_check.py
@@ -81,6 +81,7 @@ class UserDefinedFailedRowsExpressionCheck(Check):
             scan = self.data_source_scan.scan
             condition = scan.jinja_resolve(definition=partition_filter, location=self.check_cfg.location)
             sql += f"\n      AND ({condition})"
+
         return sql
 
     def get_log_diagnostic_dict(self) -> dict:

--- a/soda/core/soda/execution/query/query.py
+++ b/soda/core/soda/execution/query/query.py
@@ -160,7 +160,7 @@ class Query:
         finally:
             self.duration = datetime.now() - start
 
-    def store(self):
+    def store(self, allow_samples=True):
         """
         DataSource query execution exceptions will be caught and result in the
         self.exception being populated.
@@ -174,7 +174,6 @@ class Query:
             try:
                 # Check if query does not contain forbidden columns and only create sample if it does not.
                 # Query still needs to execute in case this is a query that also sets a metric value. (e.g. reference check)
-                allow_samples = True
                 offending_columns = []
 
                 if self.partition and self.partition.table:


### PR DESCRIPTION
Github Issue: [#1985](https://github.com/sodadata/soda-core/issues/1985)

This changes the way samples are collected from `UserDefinedFailedRowsExpressionQueries`. In order to apply the samples limit given in the check configuration, or apply the default samples limit, the failed rows expression needs to fire off an additional SampleQuery. The SampleQuery executes a copy of the query, appending a LIMIT clause.



