### PR TITLE
Add default limit for fetching failed rows in DbSample

### DIFF
--- a/soda/core/soda/sampler/db_sample.py
+++ b/soda/core/soda/sampler/db_sample.py
@@ -1,8 +1,8 @@
 from typing import Tuple
 
-from soda.sampler.sampler import DEFAULT_FAILED_ROWS_SAMPLE_LIMIT
 from soda.sampler.sample import Sample
 from soda.sampler.sample_schema import SampleColumn, SampleSchema
+from soda.sampler.sampler import DEFAULT_FAILED_ROWS_SAMPLE_LIMIT
 
 
 class DbSample(Sample):
@@ -18,7 +18,7 @@ class DbSample(Sample):
             try:
                 self.rows = self.cursor.fetchmany(DEFAULT_FAILED_ROWS_SAMPLE_LIMIT)
             except:
-                self.rows =self.cursor.fetchall()
+                self.rows = self.cursor.fetchall()
 
         return self.rows
 


### PR DESCRIPTION
Github Issue: https://github.com/sodadata/soda-core/issues/1985

Currently the `failed rows` check sample fetches **all** rows in dataset that fails. This fetches arbitrarily large data into memory, causing bugs. A comment in the code currently acknowledges this risk. The check does not respect either the default limit or the specified limit in a check yaml. 

In PR proposes to resolve this bug by always respecting the default limit of 100. It is a very simple and contained PR. However, it does not resolve the issue of not respecting a user-specified samples limit. Nonetheless, this is an improvement. It makes the situation better and no worse.