### PR TITLE
[SAS-2735] Add semver release for major, minor and latest

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,35 +8,30 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - 
-        name: check if a version tag
+      - name: check if a version tag
         id: check-version-tag
         run: |
           if [[ ${{ github.event.client_payload.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo ::set-output name=match::true
           fi
-      - 
-        name: Sleep for 900s
+      - name: Sleep for 900s
         if: steps.check-version-tag.outputs.match == 'true'
         uses: juliangruber/sleep-action@v1
         with:
           time: 900s
-      - 
-        name: check if a version tag in ref
+      - name: check if a version tag in ref
         if: steps.check-version-tag.outputs.match == 'true'
         id: get-version-tag-in-ref
         run: |
           if [[ ${{ github.event.client_payload.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo ::set-output name=versiontag::$(echo "${{github.event.client_payload.ref}}" | cut -d / -f 3)
           fi
-      -
-        name: Checkout
+      - name: Checkout
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      -
-        name: Docker meta
+      - name: Docker meta
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         id: meta
         uses: docker/metadata-action@v4
@@ -45,23 +40,21 @@ jobs:
             sodadata/soda-core
           tags: |
             type=raw,value=${{ github.event.client_payload.tag }}
-      -
-        name: Set up QEMU
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ github.event.client_payload.tag }}
+            type=semver,pattern=v{{major}},value=${{ github.event.client_payload.tag }}
+      - name: Set up QEMU
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         if: github.event.client_payload.tag == steps.get-version-tag-in-ref.outputs.versiontag
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
[SAS-2735] Allows users to pick the "latest" image in their pipelines, instead of having to manually update them. 

https://github.com/sodadata/soda-library/pull/164

[SAS-2735]: https://sodadata.atlassian.net/browse/SAS-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ