### PR TITLE
feat: support built-in prophet public holidays

### DIFF
--- a/soda/core/soda/sodacl/anomaly_detection_metric_check_cfg.py
+++ b/soda/core/soda/sodacl/anomaly_detection_metric_check_cfg.py
@@ -150,6 +150,7 @@ class HyperparameterConfigs(ADBaseModel):
 
 class ModelConfigs(ADBaseModel):
     type: str = "prophet"
+    holidays_country_code: Optional[str] = None
     hyperparameters: HyperparameterConfigs = HyperparameterConfigs()
 
 

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/anomaly_detector.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/anomaly_detector.py
@@ -46,7 +46,7 @@ class AnomalyDetector:
             logs=self._logs,
             params=self.params,
             time_series_df=feedback_processed_df,
-            hyperparamaters_cfg=self.model_cfg.hyperparameters,
+            model_cfg=self.model_cfg,
             training_dataset_params=self.training_dataset_params,
             has_exogenous_regressor=has_exogenous_regressor,
         )

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/exceptions.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/exceptions.py
@@ -17,3 +17,10 @@ class FreqDetectionResultError(Exception):
 
     To be raised and passed as a result error message down the line.
     """
+
+
+class NotSupportedHolidayCountryError(Exception):
+    """Thrown in case of wrong holiday country.
+
+    To be raised and passed as a result error message down the line.
+    """

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/models/prophet_model.py
@@ -14,6 +14,7 @@ from prophet.diagnostics import cross_validation, performance_metrics
 from soda.common.logs import Logs
 from soda.sodacl.anomaly_detection_metric_check_cfg import (
     HyperparameterConfigs,
+    ModelConfigs,
     ProphetDefaultHyperparameters,
     TrainingDatasetParameters,
 )
@@ -34,11 +35,6 @@ from soda.scientific.anomaly_detection_v2.pydantic_models import FreqDetectionRe
 from soda.scientific.anomaly_detection_v2.utils import (
     SuppressStdoutStderr,
     get_not_enough_measurements_freq_result,
-)
-from soda.sodacl.anomaly_detection_metric_check_cfg import (
-    ModelConfigs,
-    ProphetDefaultHyperparameters,
-    TrainingDatasetParameters,
 )
 
 with SuppressStdoutStderr():

--- a/soda/scientific/tests/anomaly_detection/anomaly_detector_test.py
+++ b/soda/scientific/tests/anomaly_detection/anomaly_detector_test.py
@@ -10,10 +10,6 @@ from assets.anomaly_detection_assets import (
     test_feedback_processor_prophet_model_skip_measurements_expectation,
     test_feedback_processor_seasonality_skip_measurements,
     test_feedback_processor_seasonality_skip_measurements_expectation,
-    test_prophet_model_skip_measurements_previousAndThis,
-    test_prophet_model_skip_measurements_previousAndThis_expectation,
-    test_prophet_model_skip_measurements_this_exclusive_previous,
-    test_prophet_model_skip_measurements_this_exclusive_previous_expectation,
 )
 from soda.common.logs import Logs
 

--- a/soda/scientific/tests/anomaly_detection_v2/base_model_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/base_model_test.py
@@ -14,7 +14,6 @@ from assets.anomaly_detection_assets import (
 )
 from soda.common.logs import Logs
 from soda.sodacl.anomaly_detection_metric_check_cfg import (
-    HyperparameterConfigs,
     ModelConfigs,
     TrainingDatasetParameters,
 )
@@ -67,7 +66,7 @@ def test_base_model_preprocess(time_series_df: pd.DataFrame, expected_time_serie
         logs=LOGS,
         params=PARAMS,
         time_series_df=time_series_df,
-        hyperparamaters_cfg=HyperparameterConfigs(),
+        model_cfg=ModelConfigs(),
         training_dataset_params=TrainingDatasetParameters(),
     )
     df_preprocessed = detector.preprocess(time_series_df=time_series_df)
@@ -121,7 +120,7 @@ def test_base_model_remove_big_gaps(size: int, n_rows_to_convert_none: int, expe
         logs=LOGS,
         params=PARAMS,
         time_series_df=time_series_df,
-        hyperparamaters_cfg=HyperparameterConfigs(),
+        model_cfg=ModelConfigs(),
         training_dataset_params=TrainingDatasetParameters(),
     )
     df_preprocessed = detector.remove_big_gaps_from_time_series(

--- a/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
@@ -20,14 +20,6 @@ from assets.anomaly_detection_assets import (
     df_prophet_model_setup_fit_predict_holidays,
     test_feedback_processor_seasonality_skip_measurements,
 )
-
-from soda.scientific.anomaly_detection_v2.exceptions import (
-    AggregationValueError,
-    FreqDetectionResultError,
-    NotSupportedHolidayCountryError,
-)
-from soda.scientific.anomaly_detection_v2.feedback_processor import FeedbackProcessor
-from soda.scientific.anomaly_detection_v2.models.prophet_model import ProphetDetector
 from soda.sodacl.anomaly_detection_metric_check_cfg import (
     HyperparameterConfigs,
     ModelConfigs,
@@ -41,6 +33,7 @@ from soda.sodacl.anomaly_detection_metric_check_cfg import (
 from soda.scientific.anomaly_detection_v2.exceptions import (
     AggregationValueError,
     FreqDetectionResultError,
+    NotSupportedHolidayCountryError,
 )
 from soda.scientific.anomaly_detection_v2.feedback_processor import FeedbackProcessor
 from soda.scientific.anomaly_detection_v2.models.prophet_model import ProphetDetector

--- a/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
@@ -17,10 +17,20 @@ from anomaly_detection_v2.utils import (
 )
 from assets.anomaly_detection_assets import (
     df_prophet_model_setup_fit_predict,
+    df_prophet_model_setup_fit_predict_holidays,
     test_feedback_processor_seasonality_skip_measurements,
 )
+
+from soda.scientific.anomaly_detection_v2.exceptions import (
+    AggregationValueError,
+    FreqDetectionResultError,
+    NotSupportedHolidayCountryError,
+)
+from soda.scientific.anomaly_detection_v2.feedback_processor import FeedbackProcessor
+from soda.scientific.anomaly_detection_v2.models.prophet_model import ProphetDetector
 from soda.sodacl.anomaly_detection_metric_check_cfg import (
     HyperparameterConfigs,
+    ModelConfigs,
     ProphetDefaultHyperparameters,
     ProphetDynamicHyperparameters,
     ProphetHyperparameterProfiles,
@@ -42,7 +52,7 @@ def test_with_exit() -> None:
         logs=LOGS,
         params=PARAMS,
         time_series_df=time_series_df,
-        hyperparamaters_cfg=HyperparameterConfigs(),
+        model_cfg=ModelConfigs(),
         training_dataset_params=TrainingDatasetParameters(),
     )
     df_anomalies, frequency_result = detector.run()
@@ -76,7 +86,7 @@ def test_with_weekly_seasonality_feedback(check_results: dict) -> None:
         logs=LOGS,
         params=PARAMS,
         time_series_df=df_feedback_processed,
-        hyperparamaters_cfg=HyperparameterConfigs(),
+        model_cfg=ModelConfigs(),
         training_dataset_params=TrainingDatasetParameters(),
         has_exogenous_regressor=has_exogenous_regressor,
     )
@@ -118,7 +128,7 @@ def test_apply_training_dataset_configs_with_aggregation_error() -> None:
             logs=LOGS,
             params=PARAMS,
             time_series_df=DAILY_AND_HOURLY_TIME_SERIES_DF,
-            hyperparamaters_cfg=HyperparameterConfigs(),
+            model_cfg=ModelConfigs(),
             training_dataset_params=training_dataset_configs,
         )
         prophet_detector.apply_training_dataset_configs(
@@ -135,7 +145,7 @@ def test_apply_training_dataset_configs_with_frequency_error() -> None:
             logs=LOGS,
             params=PARAMS,
             time_series_df=DAILY_AND_HOURLY_TIME_SERIES_DF,
-            hyperparamaters_cfg=HyperparameterConfigs(),
+            model_cfg=ModelConfigs(),
             training_dataset_params=TrainingDatasetParameters(),
         )
         prophet_detector.apply_training_dataset_configs(
@@ -150,7 +160,7 @@ def test_not_enough_data() -> None:
         logs=LOGS,
         params=PARAMS,
         time_series_df=time_series_df,
-        hyperparamaters_cfg=HyperparameterConfigs(),
+        model_cfg=ModelConfigs(),
         training_dataset_params=TrainingDatasetParameters(),
     )
     df_anomalies, frequency_result = prophet_detector.run()
@@ -175,14 +185,16 @@ def test_get_prophet_hyperparameters_invalid_obhective_metric() -> None:
 
 
 def test_get_prophet_hyperparameters_with_not_enough_data() -> None:
-    hyperparameter_configs = HyperparameterConfigs(
-        static=ProphetHyperparameterProfiles(), dynamic=ProphetDynamicHyperparameters(objective_metric="smape")
+    model_cfg = ModelConfigs(
+        hyperparameters=HyperparameterConfigs(
+            static=ProphetHyperparameterProfiles(), dynamic=ProphetDynamicHyperparameters(objective_metric="smape")
+        )
     )
     prophet_detector = ProphetDetector(
         logs=LOGS,
         params=PARAMS,
         time_series_df=DAILY_TIME_SERIES_DF,
-        hyperparamaters_cfg=hyperparameter_configs,
+        model_cfg=model_cfg,
         training_dataset_params=TrainingDatasetParameters(),
     )
     best_hyperparameters = prophet_detector.get_prophet_hyperparameters(
@@ -215,22 +227,25 @@ def test_get_prophet_hyperparameters_with_tuning(
     expected_seasonality_prior_scale: float,
 ) -> None:
     time_series_df = generate_random_dataframe(size=20, n_rows_to_convert_none=0, frequency="D")
-    hyperparameter_configs = HyperparameterConfigs(
-        static=ProphetHyperparameterProfiles(),
-        dynamic=ProphetDynamicHyperparameters(
-            objective_metric=objective_metric,
-            parallelize_cross_validation=False,
-            parameter_grid=ProphetParameterGrid(
-                changepoint_prior_scale=[0.05, 0.1],
-                seasonality_prior_scale=[0.05, 0.1],
+    model_cfg = ModelConfigs(
+        hyperparameters=HyperparameterConfigs(
+            static=ProphetHyperparameterProfiles(),
+            dynamic=ProphetDynamicHyperparameters(
+                objective_metric=objective_metric,
+                parallelize_cross_validation=False,
+                parameter_grid=ProphetParameterGrid(
+                    changepoint_prior_scale=[0.05, 0.1],
+                    seasonality_prior_scale=[0.05, 0.1],
+                ),
             ),
-        ),
+        )
     )
+
     prophet_detector = ProphetDetector(
         logs=LOGS,
         params=PARAMS,
         time_series_df=time_series_df,
-        hyperparamaters_cfg=hyperparameter_configs,
+        model_cfg=model_cfg,
         training_dataset_params=TrainingDatasetParameters(),
     )
     best_hyperparameters = prophet_detector.get_prophet_hyperparameters(
@@ -253,6 +268,36 @@ def test_setup_fit_predict() -> None:
     # Test only the columns that are needed for the test
     predictions_df = predictions_df[["ds", "yhat", "yhat_lower", "yhat_upper"]]
     pd.testing.assert_frame_equal(predictions_df, df_prophet_model_setup_fit_predict, check_dtype=False)
+
+
+def test_setup_fit_predict_holidays() -> None:
+    prophet_detector = ProphetDetector(
+        logs=LOGS,
+        params=PARAMS,
+        time_series_df=DAILY_AND_HOURLY_TIME_SERIES_DF,
+        model_cfg=ModelConfigs(holidays_country_code="TR"),
+        training_dataset_params=TrainingDatasetParameters(),
+    )
+    predictions_df = prophet_detector.setup_fit_predict(
+        time_series_df=DAILY_TIME_SERIES_DF, model_hyperparameters=ProphetDefaultHyperparameters()
+    )
+    predictions_df = predictions_df[["ds", "yhat", "yhat_lower", "yhat_upper"]]
+    pd.testing.assert_frame_equal(predictions_df, df_prophet_model_setup_fit_predict_holidays, check_dtype=False)
+
+
+def test_setup_fit_predic_holidays_invalid_country() -> None:
+    with pytest.raises(NotSupportedHolidayCountryError):
+        prophet_detector = ProphetDetector(
+            logs=LOGS,
+            params=PARAMS,
+            time_series_df=DAILY_AND_HOURLY_TIME_SERIES_DF,
+            model_cfg=ModelConfigs(holidays_country_code="invalid_country_code"),
+            training_dataset_params=TrainingDatasetParameters(),
+        )
+        prophet_detector.setup_fit_predict(
+            time_series_df=DAILY_TIME_SERIES_DF,
+            model_hyperparameters=ProphetDefaultHyperparameters(),
+        )
 
 
 def test_detect_anomalies() -> None:

--- a/soda/scientific/tests/anomaly_detection_v2/utils.py
+++ b/soda/scientific/tests/anomaly_detection_v2/utils.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from soda.common.logs import Logs
 from soda.sodacl.anomaly_detection_metric_check_cfg import (
-    HyperparameterConfigs,
     ModelConfigs,
     ProphetDefaultHyperparameters,
     TrainingDatasetParameters,
@@ -68,7 +67,7 @@ PROPHET_DETECTOR = ProphetDetector(
     logs=LOGS,
     params=PARAMS,
     time_series_df=DAILY_AND_HOURLY_TIME_SERIES_DF,
-    hyperparamaters_cfg=HyperparameterConfigs(),
+    model_cfg=ModelConfigs(),
     training_dataset_params=TrainingDatasetParameters(),
 )
 

--- a/soda/scientific/tests/assets/anomaly_detection_assets.py
+++ b/soda/scientific/tests/assets/anomaly_detection_assets.py
@@ -712,3 +712,39 @@ df_prophet_model_setup_fit_predict = pd.DataFrame(
         },
     ]
 )
+
+
+df_prophet_model_setup_fit_predict_holidays = pd.DataFrame(
+    [
+        {
+            "ds": pd.Timestamp("2024-01-01 00:00:00"),
+            "yhat": 15.5022680244046,
+            "yhat_lower": 15.241236144533858,
+            "yhat_upper": 15.765476833866124,
+        },
+        {
+            "ds": pd.Timestamp("2024-01-02 00:00:00"),
+            "yhat": 17.06516797206252,
+            "yhat_lower": 16.74005361195014,
+            "yhat_upper": 17.389651163715,
+        },
+        {
+            "ds": pd.Timestamp("2024-01-03 00:00:00"),
+            "yhat": 16.208493773913087,
+            "yhat_lower": 15.925356988811041,
+            "yhat_upper": 16.53266629113661,
+        },
+        {
+            "ds": pd.Timestamp("2024-01-04 00:00:00"),
+            "yhat": 15.351819575561906,
+            "yhat_lower": 15.043435269895564,
+            "yhat_upper": 15.631571851230651,
+        },
+        {
+            "ds": pd.Timestamp("2024-01-05 00:00:00"),
+            "yhat": 14.495145377210724,
+            "yhat_lower": 14.228666023542353,
+            "yhat_upper": 14.77512428825481,
+        },
+    ]
+)


### PR DESCRIPTION
Supporting holidays for anomaly detection. See the ex below;

```
checks for {table_name}:
  - anomaly detection for row_count:
      model:
          type: prophet
          holidays_country_code: TR
```
