### PR TITLE
feat: implement migrate from anomaly score check config

### DIFF
--- a/soda/core/soda/execution/check/anomaly_detection_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_detection_metric_check.py
@@ -155,6 +155,9 @@ class AnomalyDetectionMetricCheck(MetricCheck):
         This method is used to migrate the identites from anomaly score to anomaly detection.
         It's a hack to obtain the same identity for the anomaly detection check as the anomaly score check.
         """
+        if self.check_cfg.take_over_existing_anomaly_score_check is False:
+            # Do not migrate identities if the flag is set to False
+            return super().create_migrate_identities()
         original_source_line = self.check_cfg.source_line.strip()
         original_migrate_data_source_name = self.data_source_scan.data_source.migrate_data_source_name
 

--- a/soda/core/soda/execution/check/check.py
+++ b/soda/core/soda/execution/check/check.py
@@ -223,6 +223,7 @@ class Check(ABC):
 
             # Exlude hyperparameters / tuning configurations from identity for anomaly detection checks
             if isinstance(check_cfg, AnomalyDetectionMetricCheckCfg):
+                identity_source_configurations.pop("take_over_existing_anomaly_score_check", None)
                 identity_source_configurations.pop("training_dataset_parameters", None)
                 identity_source_configurations.pop("model", None)
 

--- a/soda/core/soda/sodacl/anomaly_detection_metric_check_cfg.py
+++ b/soda/core/soda/sodacl/anomaly_detection_metric_check_cfg.py
@@ -180,6 +180,7 @@ class AnomalyDetectionMetricCheckCfg(MetricCheckCfg):
         warn_threshold_cfg: ThresholdCfg | None,
         model_cfg: ModelConfigs,
         training_dataset_params: TrainingDatasetParameters,
+        take_over_existing_anomaly_score_check: bool = False,
         is_automated_monitoring: bool = False,
         samples_limit: int | None = None,
         samples_columns: List | None = None,
@@ -205,3 +206,4 @@ class AnomalyDetectionMetricCheckCfg(MetricCheckCfg):
         self.is_automated_monitoring = is_automated_monitoring
         self.model_cfg = model_cfg
         self.training_dataset_params = training_dataset_params
+        self.take_over_existing_anomaly_score_check = take_over_existing_anomaly_score_check

--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 ANOMALY_DETECTION_CONFIGS = "model"
 ANOMALY_DETECTION_TRAINING_DATASET_CONFIGS = "training_dataset_parameters"
+TAKE_OVER_EXISTING_ANOMALY_SCORE_CHECK = "take_over_existing_anomaly_score_check"
 ANOMALY_DETECTION_WARN_ONLY = "warn_only"
 ATTRIBUTES = "attributes"
 FAIL = "fail"
@@ -606,6 +607,7 @@ class SodaCLParser(Parser):
         samples_columns = None
         training_dataset_params = None
         model_cfg = None
+        take_over_existing_anomaly_score_check = None
 
         if isinstance(check_configurations, dict):
             for configuration_key in check_configurations:
@@ -676,6 +678,8 @@ class SodaCLParser(Parser):
                     )
                     if training_dataset_params is None:
                         return None
+                elif configuration_key == TAKE_OVER_EXISTING_ANOMALY_SCORE_CHECK:
+                    take_over_existing_anomaly_score_check = configuration_value
                 elif configuration_key not in [
                     NAME,
                     IDENTITY,
@@ -807,6 +811,9 @@ class SodaCLParser(Parser):
                 # Set defaults for model configurations
                 model_cfg = ModelConfigs()
 
+            if take_over_existing_anomaly_score_check is None:
+                take_over_existing_anomaly_score_check = False
+
             anomaly_detection_check_cfg = AnomalyDetectionMetricCheckCfg(
                 source_header=header_str,
                 source_line=check_str,
@@ -825,6 +832,7 @@ class SodaCLParser(Parser):
                 warn_threshold_cfg=None,
                 training_dataset_params=training_dataset_params,
                 model_cfg=model_cfg,
+                take_over_existing_anomaly_score_check=take_over_existing_anomaly_score_check,
                 samples_limit=samples_limit,
                 samples_columns=samples_columns,
             )

--- a/soda/core/tests/data_source/test_anomaly_detection_check.py
+++ b/soda/core/tests/data_source/test_anomaly_detection_check.py
@@ -637,3 +637,39 @@ def test_anomaly_detection_dynamic_hyperparameters_single_objective(data_source_
     )
     scan.execute()
     scan.assert_all_checks_pass()
+
+
+@pytest.mark.skipif(
+    condition=os.getenv("SCIENTIFIC_TESTS") == "SKIP",
+    reason="Environment variable SCIENTIFIC_TESTS is set to SKIP which skips tests depending on the scientific package",
+)
+@pytest.mark.parametrize(
+    "take_over_existing_anomaly_score_check",
+    [
+        pytest.param(True, id="migrate"),
+        pytest.param(False, id="don't migrate"),
+    ],
+)
+def test_anomaly_detection_take_over_existing_anomaly_score_check(
+    data_source_fixture: DataSourceFixture, take_over_existing_anomaly_score_check: bool
+) -> None:
+    table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan = data_source_fixture.create_test_scan()
+
+    scan.add_sodacl_yaml_str(
+        f"""
+          checks for {table_name}:
+            - anomaly detection for row_count:
+                name: "Anomaly detection for row_count"
+                take_over_existing_anomaly_score_check: {take_over_existing_anomaly_score_check}
+        """
+    )
+    metric_values = [10, 10, 10, 9, 8, 0, 0, 0, 0] * 10
+    scan.mock_historic_values(
+        metric_identity=f"metric-{scan._scan_definition_name}-{scan._data_source_name}-{table_name}-row_count",
+        metric_values=metric_values,
+        time_generator=TimeGenerator(),
+    )
+    scan.execute()
+    scan.assert_all_checks_pass()


### PR DESCRIPTION
cherry-pick from library

Implemented migrate from anomaly score configuration. By default migration is false. If user wants then they can migrate their check results from old anomaly score to new anomaly detection.

Here is the syntax;

```
checks for dim_customer:
  - anomaly detection for row_count:
      take_over_existing_anomaly_score_check: True
```