### PR TITLE
fix: show more clearly the detected frequency using warning message first

### DIFF
--- a/soda/core/soda/execution/check/anomaly_detection_metric_check.py
+++ b/soda/core/soda/execution/check/anomaly_detection_metric_check.py
@@ -95,24 +95,18 @@ class AnomalyDetectionMetricCheck(MetricCheck):
         level, diagnostics = anomaly_detector.evaluate()
         assert isinstance(diagnostics, dict), f"Anomaly diagnostics should be a dict. Got a {type(diagnostics)} instead"
 
-        if diagnostics["anomalyErrorCode"] == "not_enough_measurements":
-            self.add_outcome_reason(
-                outcome_type=diagnostics["anomalyErrorCode"],
-                message="Anomaly detection needs at least 4 measurements",
-                severity=diagnostics["anomalyErrorSeverity"],
-            )
-            self.diagnostics = diagnostics
+        self.add_outcome_reason(
+            outcome_type=diagnostics["anomalyErrorCode"],
+            message=diagnostics["anomalyErrorMessage"],
+            severity=diagnostics["anomalyErrorSeverity"],
+        )
+        self.diagnostics = diagnostics
+
+        if diagnostics["anomalyErrorCode"] == "not_enough_measurements_custom":
             if self.diagnostics["value"] is None:
                 self.diagnostics["value"] = self.get_metric_value()
             return
         self.outcome = CheckOutcome(level)
-        self.diagnostics = diagnostics
-        if diagnostics["anomalyErrorSeverity"] in ["warn", "error"]:
-            self.add_outcome_reason(
-                outcome_type=diagnostics["anomalyErrorCode"],
-                message=diagnostics["anomalyErrorMessage"],
-                severity=diagnostics["anomalyErrorSeverity"],
-            )
 
     def get_historic_measurements(
         self, metrics: dict[str, Metric], historic_values: dict[str, dict[str, Any]]

--- a/soda/core/tests/data_source/test_anomaly_detection_check.py
+++ b/soda/core/tests/data_source/test_anomaly_detection_check.py
@@ -106,10 +106,15 @@ def test_anomaly_detection_not_enough_data(data_source_fixture: DataSourceFixtur
 
     scan.execute(allow_warnings_only=True)
     scan_cloud_result = mock_soda_cloud.pop_scan_result()
+    message = (
+        "Anomaly Detection Insufficient Training Data Warning: "
+        "The model requires a minimum of 4 historical measurements "
+        "for accurate predictions, but currently has only 2 check results available."
+    )
     assert scan_cloud_result["checks"][0]["outcomeReasons"] == [
         {
-            "code": "not_enough_measurements",
-            "message": "Anomaly detection needs at least 4 measurements",
+            "code": "not_enough_measurements_custom",
+            "message": message,
             "severity": "error",
         }
     ]
@@ -129,10 +134,15 @@ def test_anomaly_detection_have_no_data(data_source_fixture: DataSourceFixture) 
     )
     scan.execute(allow_error_warning=True)
     scan_cloud_result = mock_soda_cloud.pop_scan_result()
+    message = (
+        "Anomaly Detection Insufficient Training Data Warning: "
+        "The model requires a minimum of 4 historical measurements "
+        "for accurate predictions, but currently has only 1 check results available."
+    )
     assert scan_cloud_result["checks"][0]["outcomeReasons"] == [
         {
-            "code": "not_enough_measurements",
-            "message": "Anomaly detection needs at least 4 measurements",
+            "code": "not_enough_measurements_custom",
+            "message": message,
             "severity": "error",
         }
     ]

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/anomaly_detector.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/anomaly_detector.py
@@ -181,7 +181,7 @@ class AnomalyDetector:
                 "anomalyPredictedValue": None,
                 "anomalyErrorSeverity": freq_detection_result.error_severity,
                 "anomalyErrorCode": freq_detection_result.error_code,
-                "amomalyErrorMessage": freq_detection_result.error_message,
+                "anomalyErrorMessage": freq_detection_result.error_message,
             }
 
         diagnostics_dict: Dict[str, Any] = AnomalyDiagnostics.model_validate(diagnostics).model_dump()

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/frequency_detector.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/frequency_detector.py
@@ -4,8 +4,10 @@ from typing import Any
 
 import pandas as pd
 from soda.common.logs import Logs
-
-from soda.scientific.anomaly_detection_v2.globals import DETECTOR_MESSAGES
+from soda.scientific.anomaly_detection_v2.globals import (
+    DETECTOR_MESSAGES,
+    MANUAL_FREQUENCY_MAPPING,
+)
 from soda.scientific.anomaly_detection_v2.pydantic_models import FreqDetectionResult
 from soda.scientific.anomaly_detection_v2.utils import (
     get_not_enough_measurements_freq_result,
@@ -32,7 +34,9 @@ class FrequencyDetector:
                 error_code_int=DETECTOR_MESSAGES["manual_freq"].error_code_int,
                 error_code=DETECTOR_MESSAGES["manual_freq"].error_code_str,
                 error_severity=DETECTOR_MESSAGES["manual_freq"].severity,
-                error_message=DETECTOR_MESSAGES["manual_freq"].log_message,
+                error_message=DETECTOR_MESSAGES["manual_freq"].log_message.format(
+                    frequency=MANUAL_FREQUENCY_MAPPING.get(self.manual_freq, self.manual_freq)
+                ),
             )
         self.logs.debug("Anomaly Detection: Frequency is set to 'auto' and will be detected automatically")
         _df = self.time_series_df.copy()

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/frequency_detector.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/frequency_detector.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pandas as pd
 from soda.common.logs import Logs
+
 from soda.scientific.anomaly_detection_v2.globals import (
     DETECTOR_MESSAGES,
     MANUAL_FREQUENCY_MAPPING,

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/globals.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/globals.py
@@ -8,36 +8,41 @@ ERROR_CODE_LEVEL_CUTTOFF = 99
 
 DETECTOR_MESSAGES: Dict[str, DetectorMessageComponent] = {
     "native_freq": DetectorMessageComponent(
-        log_message="native frequency detected",
+        log_message="Frequency Detection Info: native frequency detected",
         severity="info",
         error_code_int=0,
         error_code_str="Native frequency is detected successfully",
     ),
     "converted_daily_no_dupes": DetectorMessageComponent(
-        log_message="converted to daily frequency no dupes with time info removed",
+        log_message="Frequency Detection Info: Converted to daily frequency no dupes with time info removed",
         severity="info",
         error_code_int=1,
-        error_code_str="",
+        error_code_str="converted_daily_no_dupes",
     ),
     "coerced_daily": DetectorMessageComponent(
-        log_message="Coerced to daily frequency with last daily time point kept",
+        log_message=(
+            "Frequency Detection Warning: Due to unpredictable time intervals, "
+            "we have assumed a daily frequency. If more than 1 data point occurs "
+            "in one day we take the last record. Free free to set the "
+            "frequency manually in your SodaCL."
+        ),
         severity="warn",
         error_code_int=2,
-        error_code_str="made_daily_keeping_last_point_only",
+        error_code_str="made_daily_keeping_last_point_only_custom",
     ),
     "last_four": DetectorMessageComponent(
-        log_message="Frequency inferred from the last 4 stable data points",
+        log_message="Frequency Detection Warning: Frequency inferred from the last 4 stable data points",
         severity="warn",
         error_code_int=3,
         error_code_str="frequency_from_last_4_points",
     ),
     "manual_freq": DetectorMessageComponent(
-        log_message="Manual frequency provided by SodaCL",
+        log_message="Frequency Detection Info: Frequency is set to '{frequency}' manually.",
         severity="info",
         error_code_int=4,
-        error_code_str="Manual frequency is detected successfully",
+        error_code_str="manual_frequency",
     ),
-    "not_enough_measurements": DetectorMessageComponent(
+    "not_enough_measurements_custom": DetectorMessageComponent(
         log_message=(
             "Anomaly Detection Insufficient Training Data Warning:"
             " The model requires a minimum of 4 historical measurements"
@@ -46,12 +51,25 @@ DETECTOR_MESSAGES: Dict[str, DetectorMessageComponent] = {
         ),
         severity="error",
         error_code_int=100,
-        error_code_str="not_enough_measurements",
+        error_code_str="not_enough_measurements_custom",
     ),
     "bailing_out": DetectorMessageComponent(
-        log_message="All attempts to detect the datset frequency failed. Process terminated.",
+        log_message="Frequency Detection Error: All attempts to detect the datset frequency failed. Process terminated.",
         severity="error",
         error_code_int=ERROR_CODE_LEVEL_CUTTOFF,
         error_code_str="all_freq_detection_attempts_failed",
     ),
+}
+
+MANUAL_FREQUENCY_MAPPING = {
+    "T": "T (minute)",
+    "H": "H (hourly)",
+    "D": "D (daily)",
+    "W": "W (weekly)",
+    "M": "M (monthly end)",
+    "MS": "MS (monthly start)",
+    "Q": "Q (quarterly end)",
+    "QS": "QS (quarterly start)",
+    "A": "A (yearly end)",
+    "AS": "AS (yearly start)",
 }

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/utils.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/utils.py
@@ -43,9 +43,11 @@ def get_not_enough_measurements_freq_result(n_data_points: int) -> FreqDetection
     return FreqDetectionResult(
         inferred_frequency=None,
         df=pd.DataFrame(),
-        freq_detection_strategy="not_enough_measurements",
-        error_code_int=DETECTOR_MESSAGES["not_enough_measurements"].error_code_int,
-        error_code=DETECTOR_MESSAGES["not_enough_measurements"].error_code_str,
-        error_severity=DETECTOR_MESSAGES["not_enough_measurements"].severity,
-        error_message=DETECTOR_MESSAGES["not_enough_measurements"].log_message.format(n_data_points=n_data_points),
+        freq_detection_strategy="not_enough_measurements_custom",
+        error_code_int=DETECTOR_MESSAGES["not_enough_measurements_custom"].error_code_int,
+        error_code=DETECTOR_MESSAGES["not_enough_measurements_custom"].error_code_str,
+        error_severity=DETECTOR_MESSAGES["not_enough_measurements_custom"].severity,
+        error_message=DETECTOR_MESSAGES["not_enough_measurements_custom"].log_message.format(
+            n_data_points=n_data_points
+        ),
     )

--- a/soda/scientific/tests/anomaly_detection_v2/frequency_detector_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/frequency_detector_test.py
@@ -38,7 +38,7 @@ def test_auto_daily_frequency_detector() -> None:
     assert frequency_detector_result.freq_detection_strategy == "native_freq"
     assert frequency_detector_result.error_code_int == 0
     assert frequency_detector_result.error_severity == "info"
-    assert frequency_detector_result.error_message == "native frequency detected"
+    assert frequency_detector_result.error_message == "Frequency Detection Info: native frequency detected"
 
 
 def test_auto_hourly_frequency_detector() -> None:
@@ -54,7 +54,7 @@ def test_auto_hourly_frequency_detector() -> None:
     assert frequency_detector_result.freq_detection_strategy == "native_freq"
     assert frequency_detector_result.error_code_int == 0
     assert frequency_detector_result.error_severity == "info"
-    assert frequency_detector_result.error_message == "native frequency detected"
+    assert frequency_detector_result.error_message == "Frequency Detection Info: native frequency detected"
 
 
 def test_not_enough_data_frequency_detector() -> None:
@@ -67,7 +67,7 @@ def test_not_enough_data_frequency_detector() -> None:
     )
     frequency_detector_result = frequency_detector.detect_frequency()
     assert frequency_detector_result.inferred_frequency == None
-    assert frequency_detector_result.freq_detection_strategy == "not_enough_measurements"
+    assert frequency_detector_result.freq_detection_strategy == "not_enough_measurements_custom"
     assert frequency_detector_result.error_code_int == 100
     assert frequency_detector_result.error_severity == "error"
     assert frequency_detector_result.error_message == (
@@ -93,7 +93,12 @@ def test_coerced_daily_frequency_detector() -> None:
     assert frequency_detector_result.freq_detection_strategy == "coerced_daily"
     assert frequency_detector_result.error_code_int == 0
     assert frequency_detector_result.error_severity == "warn"
-    assert frequency_detector_result.error_message == "Coerced to daily frequency with last daily time point kept"
+    assert frequency_detector_result.error_message == (
+        "Frequency Detection Warning: Due to unpredictable time intervals, "
+        "we have assumed a daily frequency. If more than 1 data point occurs "
+        "in one day we take the last record. Free free to set the "
+        "frequency manually in your SodaCL."
+    )
 
 
 def test_no_duplicate_dates_daily_frequency_detector() -> None:
@@ -111,4 +116,6 @@ def test_no_duplicate_dates_daily_frequency_detector() -> None:
     assert frequency_detector_result.freq_detection_strategy == "converted_daily_no_dupes"
     assert frequency_detector_result.error_code_int == 0
     assert frequency_detector_result.error_severity == "info"
-    assert frequency_detector_result.error_message == "converted to daily frequency no dupes with time info removed"
+    assert frequency_detector_result.error_message == (
+        "Frequency Detection Info: Converted to daily frequency no dupes with time info removed"
+    )

--- a/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
@@ -53,7 +53,7 @@ def test_with_exit() -> None:
     df_anomalies, frequency_result = detector.run()
     assert df_anomalies.empty
     assert frequency_result.error_code_int == 100
-    assert frequency_result.freq_detection_strategy == "not_enough_measurements"
+    assert frequency_result.freq_detection_strategy == "not_enough_measurements_custom"
 
 
 @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ def test_not_enough_data() -> None:
     df_anomalies, frequency_result = prophet_detector.run()
     assert df_anomalies.empty
     assert frequency_result.error_code_int == 100
-    assert frequency_result.freq_detection_strategy == "not_enough_measurements"
+    assert frequency_result.freq_detection_strategy == "not_enough_measurements_custom"
 
 
 def test_get_prophet_hyperparameters_no_tuning() -> None:


### PR DESCRIPTION
- Make check outcomes more clear for the users
- update warning messages for freq detection
- improve frequency detection message

In the screenshots, you will see 3 different examples for info, warn and error messages for freq detection

<img width="1166" alt="Screen Shot 2024-02-08 at 1 33 10 PM" src="https://github.com/sodadata/soda-library/assets/17006601/18a89ee8-82d3-415f-b119-6a8874015bd9">
<img width="1157" alt="Screen Shot 2024-02-07 at 11 21 45 AM" src="https://github.com/sodadata/soda-library/assets/17006601/b27f31f6-aac3-414a-b483-46bbbbdce150">
<img width="1070" alt="Screen Shot 2024-02-08 at 2 12 07 PM" src="https://github.com/sodadata/soda-library/assets/17006601/86567bc6-d2fb-4ac8-ae8f-dbcbfa7bb3bb">