### PR TITLE
feat: implement daily and monthly seasonality to external regressor …

### DIFF
--- a/soda/scientific/soda/scientific/anomaly_detection_v2/feedback_processor.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/feedback_processor.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 from soda.common.logs import Logs
+
 from soda.scientific.anomaly_detection_v2.globals import (
     EXTERNAL_REGRESSOR_COLUMNS,
     FEEDBACK_REASONS,

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/globals.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/globals.py
@@ -73,3 +73,25 @@ MANUAL_FREQUENCY_MAPPING = {
     "A": "A (yearly end)",
     "AS": "AS (yearly start)",
 }
+
+FEEDBACK_REASONS = {
+    "expectedWeeklySeasonality": {
+        "internal_remap": "weekly_seasonality",
+        "frequency_unit": "W",
+        "frequency_value": 1,
+    },
+    "expectedMonthlySeasonality": {
+        "internal_remap": "monthly_seasonality",
+        "frequency_unit": "M",
+        "frequency_value": 1,
+    },
+    "expectedYearlySeasonality": {
+        "internal_remap": "yearly_seasonality",
+        "frequency_unit": "Y",
+        "frequency_value": 1,
+    },
+}
+
+EXTERNAL_REGRESSOR_COLUMNS = ["external_regressor_weekly", "external_regressor_monthly", "external_regressor_yearly"]
+
+REQUIRED_FEEDBACK_COLUMNS = ["ds", "y", "skipMeasurements"]

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/models/base.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/models/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 import pandas as pd
 from soda.common.logs import Logs
-
+from soda.scientific.anomaly_detection_v2.globals import EXTERNAL_REGRESSOR_COLUMNS
 from soda.scientific.anomaly_detection_v2.pydantic_models import FreqDetectionResult
 
 
@@ -39,13 +39,9 @@ class BaseDetector(ABC):
         if "skipMeasurements" in columns:
             time_series_df = self.handle_skip_measurements(time_series_df)
 
-        # Remove unnecessary columns
-        if "external_regressor" in columns:
-            time_series_df = time_series_df[["ds", "y", "external_regressor"]]
-            time_series_df["external_regressor"] = time_series_df["external_regressor"].fillna(0)
-        else:
-            time_series_df = time_series_df[["ds", "y"]]
-        time_series_df = time_series_df.reset_index(drop=True)
+        available_regressor_columns = [col for col in columns if col in EXTERNAL_REGRESSOR_COLUMNS]
+        filtered_columns = ["ds", "y"] + available_regressor_columns
+        time_series_df = time_series_df[filtered_columns].reset_index(drop=True)
         return time_series_df
 
     def handle_skip_measurements(self, time_series_df: pd.DataFrame) -> pd.DataFrame:

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/models/base.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/models/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 
 import pandas as pd
 from soda.common.logs import Logs
+
 from soda.scientific.anomaly_detection_v2.globals import EXTERNAL_REGRESSOR_COLUMNS
 from soda.scientific.anomaly_detection_v2.pydantic_models import FreqDetectionResult
 

--- a/soda/scientific/soda/scientific/anomaly_detection_v2/models/prophet_model.py
+++ b/soda/scientific/soda/scientific/anomaly_detection_v2/models/prophet_model.py
@@ -28,7 +28,10 @@ from soda.scientific.anomaly_detection_v2.exceptions import (
     WindowLengthError,
 )
 from soda.scientific.anomaly_detection_v2.frequency_detector import FrequencyDetector
-from soda.scientific.anomaly_detection_v2.globals import ERROR_CODE_LEVEL_CUTTOFF
+from soda.scientific.anomaly_detection_v2.globals import (
+    ERROR_CODE_LEVEL_CUTTOFF,
+    EXTERNAL_REGRESSOR_COLUMNS,
+)
 from soda.scientific.anomaly_detection_v2.models.base import BaseDetector
 from soda.scientific.anomaly_detection_v2.pydantic_models import FreqDetectionResult
 from soda.scientific.anomaly_detection_v2.utils import (
@@ -298,11 +301,13 @@ class ProphetDetector(BaseDetector):
                     "The list of supported countries can be found here: "
                     "https://github.com/vacanza/python-holidays/"
                 )
-        if "external_regressor" in time_series_df:
-            self.logs.info(
-                "Anomaly Detection: Found a custom external_regressor derived from user feedback and adding it to Prophet model"
-            )
-            model = model.add_regressor("external_regressor", mode="multiplicative")
+        available_regressor_columns = [col for col in time_series_df.columns if col in EXTERNAL_REGRESSOR_COLUMNS]
+        if len(available_regressor_columns) > 0:
+            for regressor_column in available_regressor_columns:
+                model = model.add_regressor(regressor_column, mode="multiplicative")
+                self.logs.info(
+                    f"Anomaly Detection: Found a custom {regressor_column} derived from user feedback and adding it to Prophet model"
+                )
         else:
             self.logs.debug("Anomaly Detection: No external_regressor/user feedback found")
         # Set seed to get reproducible results

--- a/soda/scientific/tests/anomaly_detection_v2/feedback_processor_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/feedback_processor_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 
 import pandas as pd
@@ -11,8 +12,10 @@ from assets.anomaly_detection_assets import (
     test_feedback_processor_correctly_classified_anomalies,
     test_feedback_processor_correctly_classified_anomalies_expectation,
     test_feedback_processor_feedback_processed_df,
+    test_feedback_processor_monthly_seasonality_expectation,
     test_feedback_processor_seasonality_skip_measurements,
-    test_feedback_processor_seasonality_skip_measurements_expectation,
+    test_feedback_processor_weekly_seasonality_expectation,
+    test_feedback_processor_yearly_seasonality_expectation,
 )
 from soda.common.logs import Logs
 
@@ -52,29 +55,49 @@ def test_feedback_processor_get_processed_feedback_df(
         df_historic=df_historic,
         logs=LOGS,
     )
-    has_exogenous_regressor, df = feedback_processor.get_processed_feedback_df()
-    assert has_exogenous_regressor == False
+    has_external_regressor, df = feedback_processor.get_processed_feedback_df()
+    assert has_external_regressor == False
     pd.testing.assert_frame_equal(df, expectation, check_dtype=False)
 
 
 @pytest.mark.parametrize(
-    "check_results, expected_processed_feedback_df",
+    "reason, expected_regressor_column_name, expected_output",
     [
         pytest.param(
-            test_feedback_processor_seasonality_skip_measurements,
-            test_feedback_processor_seasonality_skip_measurements_expectation,
-        )
+            "expectedWeeklySeasonality",
+            "external_regressor_weekly",
+            test_feedback_processor_weekly_seasonality_expectation,
+            id="Test feedback processor with weekly seasonality external regressor",
+        ),
+        pytest.param(
+            "expectedMonthlySeasonality",
+            "external_regressor_monthly",
+            test_feedback_processor_monthly_seasonality_expectation,
+            id="Test feedback processor with monthly seasonality external regressor",
+        ),
+        pytest.param(
+            "expectedYearlySeasonality",
+            "external_regressor_yearly",
+            test_feedback_processor_yearly_seasonality_expectation,
+            id="Test feedback processor with yearly seasonality external regressor",
+        ),
     ],
 )
-def test_feedback_processor_with_exogenous_regressor(
-    check_results: dict, expected_processed_feedback_df: pd.DataFrame
+def test_feedback_processor_external_regressors(
+    reason: str, expected_regressor_column_name: str, expected_output: dict
 ) -> None:
-    df_historic = pd.DataFrame(check_results)
+    input_data = copy.deepcopy(test_feedback_processor_seasonality_skip_measurements)
+    # change the reason to expectedMonthlySeasonality to test monthly seasonality
+    input_data["feedback"][0]["reason"] = reason  # type: ignore
+    df_historic = pd.DataFrame(input_data)
     df_historic["ds"] = pd.to_datetime(df_historic["ds"])
-    expected_processed_feedback = pd.DataFrame(expected_processed_feedback_df)
-    expected_processed_feedback["ds"] = pd.to_datetime(expected_processed_feedback["ds"])
-
     feedback_processor = FeedbackProcessor(params=PARAMS, df_historic=df_historic, logs=LOGS)
-    has_exogenous_regressor, df_feedback_processed = feedback_processor.get_processed_feedback_df()
-    assert has_exogenous_regressor is True
-    pd.testing.assert_frame_equal(df_feedback_processed, expected_processed_feedback, check_dtype=False)
+    has_external_regressor, df_feedback_processed = feedback_processor.get_processed_feedback_df()
+    assert has_external_regressor is True
+    filtered_columns = ["ds", "y", expected_regressor_column_name]
+    df_feedback_processed = df_feedback_processed[
+        [col for col in filtered_columns if col in df_feedback_processed.columns]
+    ]
+    df_expected = pd.DataFrame(expected_output)
+    df_expected["ds"] = pd.to_datetime(df_expected["ds"])
+    pd.testing.assert_frame_equal(df_feedback_processed, df_expected, check_dtype=False)

--- a/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
+++ b/soda/scientific/tests/anomaly_detection_v2/prophet_model_test.py
@@ -74,8 +74,8 @@ def test_with_weekly_seasonality_feedback(check_results: dict) -> None:
     feedback_processor = FeedbackProcessor(params=PARAMS, df_historic=df_historic, logs=LOGS)
     has_exogenous_regressor, df_feedback_processed = feedback_processor.get_processed_feedback_df()
     assert has_exogenous_regressor == True
-    assert df_feedback_processed.columns.tolist() == ["y", "ds", "skipMeasurements", "external_regressor"]
-    assert np.round(df_feedback_processed["external_regressor"].values[0], 4) == pytest.approx(-0.8325)
+    assert "external_regressor_weekly" in df_feedback_processed.columns
+    assert df_feedback_processed["external_regressor_weekly"].tolist() == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]
 
     detector = ProphetDetector(
         logs=LOGS,
@@ -89,12 +89,12 @@ def test_with_weekly_seasonality_feedback(check_results: dict) -> None:
 
     anomalies_df, freq_detection_result = detector.run()
     assert anomalies_df.level.values[0] == "warn"
-    assert np.round(anomalies_df.yhat.values[0], 3) == pytest.approx(-0.692)
+    assert np.round(anomalies_df.yhat.values[0], 3) == pytest.approx(-0.803)
     assert np.round(anomalies_df.real_data.values[0], 3) == pytest.approx(14.237)
-    assert np.round(anomalies_df.critical_greater_than_or_equal.values[0], 3) == pytest.approx(14.241)
-    assert np.round(anomalies_df.critical_lower_than_or_equal.values[0], 3) == pytest.approx(-15.101)
-    assert np.round(anomalies_df.warning_greater_than_or_equal.values[0], 3) == pytest.approx(11.796)
-    assert np.round(anomalies_df.warning_lower_than_or_equal.values[0], 3) == pytest.approx(-12.655)
+    assert np.round(anomalies_df.critical_greater_than_or_equal.values[0], 3) == pytest.approx(14.491)
+    assert np.round(anomalies_df.critical_lower_than_or_equal.values[0], 3) == pytest.approx(-15.559)
+    assert np.round(anomalies_df.warning_greater_than_or_equal.values[0], 3) == pytest.approx(11.987)
+    assert np.round(anomalies_df.warning_lower_than_or_equal.values[0], 3) == pytest.approx(-13.054)
     assert freq_detection_result.inferred_frequency == "D"
     assert freq_detection_result.freq_detection_strategy == "native_freq"
 

--- a/soda/scientific/tests/assets/anomaly_detection_assets.py
+++ b/soda/scientific/tests/assets/anomaly_detection_assets.py
@@ -407,6 +407,27 @@ test_feedback_processor_seasonality_skip_measurements_expectation = {
     },
 }
 
+test_feedback_processor_weekly_seasonality_expectation = [
+    {"ds": pd.Timestamp("2023-03-06 11:00:00"), "y": 42.0, "external_regressor_weekly": 1.0},
+    {"ds": pd.Timestamp("2023-03-05 11:00:00"), "y": 41.0, "external_regressor_weekly": 0.0},
+    {"ds": pd.Timestamp("2023-03-04 11:00:00"), "y": 40.0, "external_regressor_weekly": 0.0},
+    {"ds": pd.Timestamp("2023-03-03 11:00:00"), "y": 35.0, "external_regressor_weekly": 0.0},
+]
+
+test_feedback_processor_monthly_seasonality_expectation = [
+    {"ds": pd.Timestamp("2023-03-06 11:00:00"), "y": 42.0, "external_regressor_monthly": 1.0},
+    {"ds": pd.Timestamp("2023-03-05 11:00:00"), "y": 41.0, "external_regressor_monthly": 0.0},
+    {"ds": pd.Timestamp("2023-03-04 11:00:00"), "y": 40.0, "external_regressor_monthly": 0.0},
+    {"ds": pd.Timestamp("2023-03-03 11:00:00"), "y": 35.0, "external_regressor_monthly": 0.0},
+]
+
+test_feedback_processor_yearly_seasonality_expectation = [
+    {"ds": pd.Timestamp("2023-03-06 11:00:00"), "y": 42.0, "external_regressor_yearly": 1.0},
+    {"ds": pd.Timestamp("2023-03-05 11:00:00"), "y": 41.0, "external_regressor_yearly": 0.0},
+    {"ds": pd.Timestamp("2023-03-04 11:00:00"), "y": 40.0, "external_regressor_yearly": 0.0},
+    {"ds": pd.Timestamp("2023-03-03 11:00:00"), "y": 35.0, "external_regressor_yearly": 0.0},
+]
+
 test_feedback_processor_prophet_model_skip_measurements_expectation = {
     "y": {
         0: 42.0,
@@ -633,7 +654,6 @@ test_feedback_processor_correctly_classified_anomalies_expectation = pd.DataFram
             "freeTextReason": None,
             "skipMeasurements": None,
             "is_correctly_classified_anomaly": True,
-            "predicted_to_real_delta": 0.1294836644914028,
         }
     ]
 )
@@ -730,7 +750,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": 0.1294836644914028,
         },
         {
             "y": 21.0,
@@ -745,7 +764,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": nan,
         },
         {
             "y": 2.0,
@@ -760,7 +778,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": nan,
         },
         {
             "y": 1.0,
@@ -775,7 +792,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": nan,
         },
         {
             "y": 1.0,
@@ -790,7 +806,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": nan,
         },
         {
             "y": 21.0,
@@ -805,7 +820,6 @@ test_feedback_processor_feedback_processed_df = pd.DataFrame(
             "freeTextReason": nan,
             "skipMeasurements": nan,
             "is_correctly_classified_anomaly": None,
-            "predicted_to_real_delta": nan,
         },
     ]
 )


### PR DESCRIPTION
- refactor the existing external regressor
- Instead of using the delta between yhat and y, only use the binary value
- Add three potential external regressors and each regressor can only have binary values
      - yearly
      - monthly
      - weekly 
- Implement custom external regressor for monthly and yearly
