### PR TITLE
bugfix: support attributes on multiple checks

### DIFF
--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -239,15 +239,26 @@ class SodaCLParser(Parser):
                 check_str, check_configurations = self.__parse_check_configuration(check_list_element)
 
                 if check_str is not None:
-                    check_cfg = self.__parse_table_check_str(header_str, check_str, check_configurations)
+                    if check_str == ATTRIBUTES:
+                        self._dataset_attributes = check_configurations
+                    else:
+                        check_cfg = self.__parse_table_check_str(header_str, check_str, check_configurations)
+                        if self._dataset_attributes:
+                            check_cfg.source_configurations = (
+                                {} if check_cfg.source_configurations is None else check_cfg.source_configurations
+                            )
+                            check_cfg.source_configurations[ATTRIBUTES] = {
+                                **check_cfg.source_configurations.get(ATTRIBUTES, {}),
+                                **self._dataset_attributes,
+                            }
 
-                    if check_cfg:
-                        column_name = check_cfg.get_column_name()
-                        if column_name:
-                            column_checks = partition_cfg.get_or_create_column_checks(column_name)
-                            column_checks.add_check_cfg(check_cfg)
-                        else:
-                            partition_cfg.add_check_cfg(check_cfg)
+                        if check_cfg:
+                            column_name = check_cfg.get_column_name()
+                            if column_name:
+                                column_checks = partition_cfg.get_or_create_column_checks(column_name)
+                                column_checks.add_check_cfg(check_cfg)
+                            else:
+                                partition_cfg.add_check_cfg(check_cfg)
 
                 self._pop_path_element()
         else:

--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -119,6 +119,7 @@ class SodaCLParser(Parser):
 
         self.sodacl_cfg: SodaCLCfg = sodacl_cfg
         self.data_source_name = data_source_name
+        self._dataset_attributes = None
 
     def assert_header_content_is_dict(func):
         @functools.wraps(func)

--- a/soda/core/tests/data_source/test_attributes.py
+++ b/soda/core/tests/data_source/test_attributes.py
@@ -12,6 +12,31 @@ mock_schema = [
 mock_variables = {"DEPT": "sales"}
 
 
+def test_dataset_attributes_valid(data_source_fixture: DataSourceFixture):
+    table_name = data_source_fixture.ensure_test_table(customers_test_table)
+
+    scan = data_source_fixture.create_test_scan()
+    scan.mock_check_attributes_schema(mock_schema)
+    scan.add_variables(mock_variables)
+    scan.add_sodacl_yaml_str(
+        f"""
+      checks for {table_name}:
+        - attributes:
+            priority: 1
+            tags: ["user-created"]
+        - row_count > 0
+    """
+    )
+    scan.execute()
+    scan.assert_all_checks_pass()
+
+    scan_result = scan.build_scan_results()
+    assert scan_result["checks"][0]["resourceAttributes"] == [
+        {"name": "priority", "value": "1"},
+        {"name": "tags", "value": ["user-created"]},
+    ]
+
+
 def test_check_attributes_valid(data_source_fixture: DataSourceFixture):
     table_name = data_source_fixture.ensure_test_table(customers_test_table)
 


### PR DESCRIPTION
Please refer to the test output to see the current state. This new test `test_dataset_attributes_valid` passes in soda-library, but not in soda-core