### PR TITLE
Rename argument in set_scan_results_file method

### DIFF
--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -124,8 +124,8 @@ class Scan:
         global verbose
         verbose = verbose_var
 
-    def set_scan_results_file(self, set_scan_results_file: str):
-        self._scan_results_file = set_scan_results_file
+    def set_scan_results_file(self, scan_results_file: str):
+        self._scan_results_file = scan_results_file
 
     def add_configuration_yaml_file(self, file_path: str):
         """


### PR DESCRIPTION
The argument name `set_scan_results_file` in the `set_scan_results_file` method was confusing as it shared the same name as the function itself. This commit renames the argument to `scan_results_file` for improved clarity and consistency. Resolves #2040