### PR TITLE
[WIP] Custom Sampler: read/write data from/to a scan

### DIFF
--- a/soda/core/soda/sampler/sample_context.py
+++ b/soda/core/soda/sampler/sample_context.py
@@ -37,3 +37,9 @@ class SampleContext:
             self.sample_name,
         ]
         return "_".join([part for part in parts if part])
+
+    def scan_context_get(self, key: str, default: any = None) -> any:
+        return self.scan.scan_context_get(key, default)
+
+    def scan_context_set(self, key: str | list, value: any, overwrite: bool = True):
+        return self.scan.scan_context_set(key, value, overwrite)

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -67,6 +67,7 @@ class Scan:
         self._sample_tables_result_tables: list[SampleTablesResultTable] = []
         self._logs.info(f"Soda Core {SODA_CORE_VERSION}")
         self.scan_results: dict = {}
+        self.scan_context: dict = {}
 
     def build_scan_results(self) -> dict:
         checks = [check.get_dict() for check in self._checks if check.outcome is not None and check.archetype is None]
@@ -958,3 +959,27 @@ class Scan:
 
     def has_soda_cloud_connection(self):
         return self._configuration.soda_cloud is not None
+
+    def scan_context_get(self, key: str, default: any = None) -> any:
+        return self.scan_context.get(key, default)
+
+    def scan_context_set(self, key: str | list, value: any, overwrite: bool = True):
+        dic = self.scan_context
+        dic_key = key
+
+        if type(key) == list:
+            for k in key[:-1]:
+                if type(dic) != dict:
+                    raise ValueError(
+                        f"Value '{dic}' is not a dictionary but you are trying to use it as one using nested key in sample context."
+                    )
+                if k not in dic:
+                    dic = dic.setdefault(k, {})
+                else:
+                    dic = dic[k]
+            dic_key = key[-1]
+
+        if dic_key in self.scan_context and not overwrite:
+            raise ValueError(f"Key '{key}' already exists in scan context")
+
+        dic[dic_key] = value


### PR DESCRIPTION
Allows to read/write data from/to a scan. Simple example using custom sampler:

```
from soda.scan import Scan
from soda.sampler.sampler import Sampler
from soda.sampler.sample_context import SampleContext
import pandas as pd


class CustomSampler(Sampler):
    def store_sample(self, sample_context: SampleContext):
        # Read data from scan context and use it in the sampler.
        # This example just takes a list of unique ids from the scan context and filters the sample dataframe by those ids.
        unique_ids = sample_context.scan_context_get("unique_ids")

        rows = sample_context.sample.get_rows()

        filtered_rows = [row for row in rows if row[0] in unique_ids]

        columns = [col.name for col in sample_context.sample.get_schema().columns]

        df = pd.DataFrame(filtered_rows, columns=columns)

        # scan_context_set takes both a string and a list of strings to set a (nested) value
        # example below will store the sample dataframe in the scan_context in a nested dictionary "samples.soda_demo.public.dim_employee.duplicate_count(gender) = 0": df
        sample_context.scan_context_set(
            [
                "samples",
                sample_context.data_source.data_source_name,
                sample_context.data_source.schema,
                sample_context.partition.table.table_name,
                sample_context.check_name,
            ],
            df,
        )


if __name__ == "__main__":
    s = Scan()
    s.sampler = CustomSampler()

    s.set_scan_definition_name("test_scan")
    s.set_verbose(True)
    s.set_data_source_name("soda_demo")

    s.scan_context_set("unique_ids", [1, 2, 3, 4, 5])

    s.add_configuration_yaml_str(
        f"""
    data_source soda_demo:
        type: postgres
        schema: public
        host: localhost
        username: postgres
        password: secret
        database: postgres
    """
    )

    s.add_sodacl_yaml_str(
        f"""
    checks for dim_employee:
        - missing_count(status) = 0
        - failed rows:
            fail condition: employee_key = 1
        # Following check does not collect failed rows samples, CustomSampler will not be invoked.
        - duplicate_count(gender) = 0:
            samples limit: 0
    """
    )
    s.execute()

    # Dataframes created in CustomSampler are available in the scan context.
    print(s.scan_context["samples"])
    # Will print:
    # {
    #     'soda_demo': {
    #         'public': {
    #             'dim_employee': {
    #                 'missing_count(status) = 0': [df]
    #                 'failed rows': [df]

    #             }
    #         }
    #     }
    # }

    # Simple example that collects all queries that end with ".failing_sql", this can be used to execute failed rows queries manually.
    failed_rows_queries = [
        query["sql"] for query in s.scan_results["queries"] if query["name"].endswith(".failing_sql")
    ]
    print(failed_rows_queries)
    # Will print two queries:
    # [
    #     'SELECT * FROM public.dim_employee \n WHERE (status IS NULL)',
    #     '\nWITH frequencies AS (\n    SELECT gender\n    FROM public.dim_employee\n    WHERE gender IS NOT NULL\n    GROUP BY gender\n    HAVING COUNT(*) > 1)\nSELECT main.*\nFROM public.dim_employee main\nJOIN frequencies ON main.gender = frequencies.gender\n'
    # ]
```