### PR TITLE
Optional status and type field for contracts in Atlan

### DIFF
--- a/soda/atlan/soda/atlan/atlan_plugin.py
+++ b/soda/atlan/soda/atlan/atlan_plugin.py
@@ -42,8 +42,6 @@ class AtlanPlugin(Plugin):
             return None
 
         contract_dict: dict = contract_result.contract.contract_file.dict.copy()
-        contract_dict.setdefault("type", "Table")
-        contract_dict.setdefault("status", "DRAFT")
         contract_dict.setdefault("kind", "DataContract")
 
         contract_json_str: str = dumps(contract_dict)


### PR DESCRIPTION
Atlan API now accepts contracts without `type` and `status` fields as mandatory fields. 
 
**type**: If the `type` field is absent in the contract, Atlan will try to fetch the type with the help of the qualifiedName provided for supported dataset types. If there are multiple supported datasets present in Atlan for the given qualifiedName, the API will through an error. 

**status**: status is optional now. The default value of status is DRAFT if not present in the contract. 