### PR TITLE
Yield the same order regardless of order in the file and database

### DIFF
--- a/soda/scientific/soda/scientific/distribution/comparison.py
+++ b/soda/scientific/soda/scientific/distribution/comparison.py
@@ -277,6 +277,10 @@ class ChiSqAlgorithm(DistributionAlgorithm):
         ref_data_frequencies = ref_data_frequencies + 1
         test_data_frequencies = test_data_frequencies + 1
 
+        # sort the data to make sure that the categories are in the same order before cast to array_like
+        ref_data_frequencies = ref_data_frequencies.sort_index()
+        test_data_frequencies = test_data_frequencies.sort_index()
+
         # Normalise because scipy wants sums of observed and reference counts to be equal
         # workaround found and discussed in: https://github.com/UDST/synthpop/issues/75#issuecomment-907137304
         stat_value, p_value = chisquare(


### PR DESCRIPTION
Sorry in advance for formulating a possible bug in a form of PR. 

I receive different results on `chi_square` for these 2 configurations (with postgres):

```yaml
...
distribution_type: categorical
distribution_reference:
  weights:
  - 0.4
  - 0.6
  bins:
  - A
  - B
```


```yaml
...
distribution_type: categorical
distribution_reference:
  weights:
  - 0.6
  - 0.4
  bins:
  - B
  - A
```

I would expect not to. 