### PR TITLE
Remove unused MarkupSafe dependency (#2103)

### DIFF
--- a/soda/core/setup.py
+++ b/soda/core/setup.py
@@ -8,7 +8,6 @@ package_version = "3.4.4"
 description = "Soda Core"
 
 requires = [
-    "markupsafe>=2.0.1,<=2.1.2",
     "Jinja2>=2.11,<4.0",
     "click~=8.0",
     "ruamel.yaml>=0.17.0,<0.18.0",


### PR DESCRIPTION
MarkupSafe doesn't seem to be used anywhere in the code and the required version is outdated and
creates dependency conflicts with other libraries.

Closes #2103