### PR TITLE
Set up devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.9-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    procps \
+    build-essential curl \
+    libpq-dev \
+    libssl-dev libffi-dev \
+    unixodbc-dev git lsb-release \
+    alien odbcinst
+
+# Install Microsoft ODBC driver 18 for SQL Server https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/debian/12/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/microsoft-prod.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y libsasl2-dev odbcinst mssql-tools18 msodbcsql18 unixodbc-dev
+
+# Dremio support
+RUN curl -L https://download.dremio.com/arrow-flight-sql-odbc-driver/arrow-flight-sql-odbc-driver-LATEST.x86_64.rpm -o arrow-driver.rpm && \
+    alien -iv --scripts arrow-driver.rpm
+
+# Run sleep infinity so that the dev container stays alive
+CMD [ "sleep", "infinity" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+	"name": "soda-core",
+	"dockerComposeFile": [
+		"docker-compose.yml",
+		"../soda/postgres/docker-compose.yml"
+	],
+	"service": "devcontainer",
+	"postStartCommand": "./.devcontainer/initialize.sh",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.mypy-type-checker",
+				"ms-python.black-formatter",
+				"ms-python.isort"
+			],
+			"settings": {
+				"editor.formatOnSave": true,
+				"editor.formatOnType": true,
+				"files.exclude": {
+					".mypy_cache": true,
+					".venv": true,
+					".pytest_cache": true,
+					"**/*.egg-info": true,
+					"**/__pycache__": true,
+					"soda/*/build": true
+				},
+				"python.analysis.enablePytestSupport": true,
+				"python.defaultInterpreterPath": ".venv/bin/python",
+				"python.testing.pytestEnabled": true,
+				"python.testing.pytestPath": "soda/core/tests/",
+				"python.languageServer": "Pylance",
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "always",
+						"source.fixAll": "always"
+					}
+				}
+			}
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      POSTGRES_HOST: soda-sql-postgres
+      test_data_source: postgres

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -x
+
+# Install dependencies
+sudo apt-get update && sudo apt-get install libsasl2-dev
+
+# Create the virtual environment if it does not already exist
+if [ ! -d .venv ]; then
+  scripts/recreate_venv.sh
+fi
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Setup pre-commit
+pre-commit install

--- a/soda/postgres/tests/postgres_data_source_fixture.py
+++ b/soda/postgres/tests/postgres_data_source_fixture.py
@@ -18,7 +18,7 @@ class PostgresDataSourceFixture(DataSourceFixture):
         return {
             "data_source postgres": {
                 "type": "postgres",
-                "host": "localhost",
+                "host": os.getenv("POSTGRES_HOST", "localhost"),
                 "username": os.getenv("POSTGRES_USERNAME", "sodasql"),
                 "password": os.getenv("POSTGRES_PASSWORD"),
                 "database": os.getenv("POSTGRES_DATABASE", "sodasql"),


### PR DESCRIPTION
This is a proposal to add a devcontainer configuration in order to facilitate onboarding of new developers, enforcement of contributing guidelines, and facilitate usage of GitHub codespaces.

This set up is tested with GitHub codespaces and mostly works, but some random unit tests are failing.

Some further configuration refinement would also help to make sure that the environment configuration (in particular Mypy and Pylance) is fine-tuned and well aligned with pre-commit hooks/CI pipeline.

Let me know if this is of interest.