### PR TITLE
Fix dask `COUNT` queries on windows

### DIFF
--- a/soda/dask/soda/data_sources/dask_cursor.py
+++ b/soda/dask/soda/data_sources/dask_cursor.py
@@ -40,7 +40,7 @@ class DaskCursor:
         if self.df.empty:
             row_value = []
             for col_dtype in self.df.dtypes:
-                if col_dtype in ["int", "float"]:
+                if np.issubdtype(col_dtype, np.number):
                     row_value.append(0)
                 else:
                     row_value.append(None)


### PR DESCRIPTION
This commit fixes an issue in the dask cursor that would cause it to return `None` instead of `0` when performing a COUNT() query on Windows. `dask-sql` returns an empty data frame when there are no matches. This is normally translated to 0 in the `DaskCursor` class when using fetchone with a numeric result.

Unfortunately the logic to detect a numeric result did not behave correctly on Windows. The dtype used is int64, which on linux appears to compare equal to int but does not compare equal on Windows.

This commit uses `np.issubdtype` to have a more robust check for integer types.