### PR TITLE
Add oauth support to dbx connection

### DIFF
--- a/soda/spark/soda/data_sources/spark_data_source.py
+++ b/soda/spark/soda/data_sources/spark_data_source.py
@@ -173,10 +173,15 @@ def databricks_connection_function(host: str, http_path: str, token: str, databa
     if not token and not auth_method:
         from databricks.sdk.core import Config, oauth_service_principal
 
-        def credential_provider():
-            config = Config(
+        config = Config(
                 **kwargs.get("configuration", {})
             )
+
+        if not host:
+            host = config.hostname
+
+        def credential_provider():
+
             return oauth_service_principal(config)
 
         credentials_provider = credential_provider

--- a/soda/spark/soda/data_sources/spark_data_source.py
+++ b/soda/spark/soda/data_sources/spark_data_source.py
@@ -134,16 +134,63 @@ def odbc_connection_function(
 
 
 def databricks_connection_function(host: str, http_path: str, token: str, database: str, schema: str, **kwargs):
+    """
+    Connection to databricks with databricks sql connector.
+
+    Supplying a token will enforce connection via personal access token.
+
+    host, client_id and client_secret keys can be supplied to the configuration parameter for m2m oauth.
+
+    Setting oauth_method to "databricks-oauth" will enforce a u2m oauth connection.
+
+    Read the python-sql-connector documentation for more information.
+
+    Parameters
+    ----------
+    host : str
+        The databricks server host name.
+    http_path: str
+        The http_path to your databricks sql warehouse or cluster
+    token: str
+        Databricks personal access token
+    database: str
+        The databricks catalog
+    schema : str
+        The databricks schema
+
+    Returns
+    -------
+    out : databricks.sql.Connection
+        The databricks connection object
+    """
     from databricks import sql
 
     user_agent_entry = f"soda-core-spark/{SODA_CORE_VERSION} (Databricks)"
     logging.getLogger("databricks.sql").setLevel(logging.INFO)
+
+    auth_method = kwargs.get("auth_method")
+
+    if not token and not auth_method:
+        from databricks.sdk.core import Config, oauth_service_principal
+
+        def credential_provider():
+            config = Config(
+                **kwargs.get("configuration", {})
+            )
+            return oauth_service_principal(config)
+
+        credentials_provider = credential_provider
+    else:
+        credentials_provider = None
+
     connection = sql.connect(
         server_hostname=host,
         catalog=database,
         schema=schema,
         http_path=http_path,
         access_token=token,
+        credentials_provider=credentials_provider,
+        auth_type=kwargs.get("auth_method"),
         _user_agent_entry=user_agent_entry,
     )
     return connection


### PR DESCRIPTION
Only had access to databricks via oauth so needed to implement more connection methods.

Based on the official databricks sql connector docs: https://docs.databricks.com/aws/en/dev-tools/python-sql-connector

Solves the issue: https://github.com/sodadata/soda-core/issues/2087

This adds no new properties but the databricks connection will now make use of `auth_method` and `configuration` dict properties.

**Token authentication:** 
If supplying `token` will work as normal and use personal access token authentication.

**user to machine oauth**
If supplying `auth_method` and setting it to "databricks-oauth" will be [u2m authentication](https://docs.databricks.com/aws/en/dev-tools/python-sql-connector#oauth-user-to-machine-u2m-authentication)

**machine to machine oauth**
If neither the above are supplied it will work with the docs [m2m authentication method](https://docs.databricks.com/aws/en/dev-tools/python-sql-connector#oauth-machine-to-machine-m2m-authentication). This configuration property gets supplied to the config class in which the user can supply the host/client_id/client_secret.

I tried to set this up in a way that enables flexability.  The config class has a very large amount of options so if a more tech savvy user wants to change these settings they are not blocked from doing so and can supply them to the configuration property.

The oauth_type also has an azure oauth method that can be switched to instead.

If neither oauth_method or token are supplied, and configuration is empty, it will still use the empty Config object. This can be beneficial as the config class, if not supplied a parameter value, will look for environment variables instead. [See the source code](https://github.com/databricks/databricks-sdk-py/blob/42df0de075320ab573652edaf9e05ad2a120a503/databricks/sdk/config.py#L60). 

A caveat of how this is configured is that the if using m2m you will probably need to input host twice. once outside configuration and once inside. A way of resolving this is if host isn't set as a property, it will try and get the hostname from the instantiated config object and set it as that instead. This mean host comes from config meaning it can be from the environment variable or configuration property and doesn't have to be supplied twice.
