### PR TITLE
allow user to override scope for Microsoft Entra ID access token

### DIFF
--- a/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
+++ b/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
@@ -64,6 +64,7 @@ def _get_synapse_spark_access_token(scope: str) -> AccessToken:
 def _get_fabric_spark_access_token(scope: str) -> AccessToken:
     return _get_mssparkutils_access_token(scope)
 
+
 def _derive_scope(authentication_method: str, hostname: str) -> str:
     if "azuresynapse.net" in hostname:
         return _SYNAPSE_CREDENTIAL_SCOPE
@@ -97,7 +98,7 @@ def convert_access_token_to_mswindows_byte_string(token):
     return convert_bytes_to_mswindows_byte_string(value)
 
 
-def get_pyodbc_attrs(authentication_method: str, scope: str|None, host: str):
+def get_pyodbc_attrs(authentication_method: str, scope: str | None, host: str):
     if not authentication_method.lower() in _AZURE_AUTH_FUNCTIONS:
         return None
 


### PR DESCRIPTION
I am the contributor of the Microsoft Entra ID auth support in Soda.

Currently I am trying to connect from a Fabric Notebook to my SQL Server Managed Instance. But I made a logical mistake in my first version of the code below where I always assumed that in Fabric Notebooks you would connect a Fabric Data Warehouse or Lakehouse.

The code below changes that and tries to be smart about the scope for the access token. The user can pass a `scope` to indicate the scope for the access token. If not, it will try to figure out the scope based on the hostname.