### PR TITLE
Added attributes mapping to contracts POC

### DIFF
--- a/soda/contracts/soda/contracts/check.py
+++ b/soda/contracts/soda/contracts/check.py
@@ -334,10 +334,15 @@ class AbstractCheck(Check, ABC):
             check_configs["identity_was"] = identity_was
         if self.filter_sql:
             check_configs["filter"] = self.filter_sql
+        if isinstance(self.check_yaml, dict) and "attributes" in self.check_yaml:
+            attributes = self.check_yaml.get("attributes")
+            if isinstance(attributes, dict):
+                check_configs["attributes"] = attributes
         if isinstance(check_specific_configs, dict):
             for key, value in check_specific_configs.items():
                 if value is not None:
                     check_configs[key] = value
+
         return check_configs
 
 

--- a/soda/contracts/tests/contracts/verification/test_contract_attributes.py
+++ b/soda/contracts/tests/contracts/verification/test_contract_attributes.py
@@ -1,0 +1,42 @@
+import logging
+from textwrap import dedent
+
+from contracts.helpers.contract_data_source_test_helper import (
+    ContractDataSourceTestHelper,
+)
+from helpers.test_table import TestTable
+from soda.execution.data_type import DataType
+
+from soda.contracts.check import SchemaCheckResult
+from soda.contracts.contract import CheckOutcome, ContractResult
+from soda.contracts.contract_verification import (
+    ContractVerification,
+    ContractVerificationResult,
+)
+
+contracts_attributes_test_table = TestTable(
+    name="contracts_attributes",
+    # fmt: off
+    columns=[
+        ("one", DataType.TEXT),
+    ],
+    values=[
+    ]
+    # fmt: on
+)
+
+
+def test_contract_attributes(data_source_test_helper: ContractDataSourceTestHelper):
+    contract_result: ContractResult = data_source_test_helper.assert_contract_pass(
+        test_table=contracts_attributes_test_table,
+        contract_yaml_str=f"""
+        columns:
+          - name: one
+            checks:
+            - type: no_invalid_values
+              valid_values: ['ID1']
+              attributes:
+                pii: true
+                category: missing_data
+    """,
+    )

--- a/soda/contracts/tests/contracts/verification/test_contract_attributes.py
+++ b/soda/contracts/tests/contracts/verification/test_contract_attributes.py
@@ -1,18 +1,10 @@
-import logging
-from textwrap import dedent
-
 from contracts.helpers.contract_data_source_test_helper import (
     ContractDataSourceTestHelper,
 )
 from helpers.test_table import TestTable
 from soda.execution.data_type import DataType
 
-from soda.contracts.check import SchemaCheckResult
-from soda.contracts.contract import CheckOutcome, ContractResult
-from soda.contracts.contract_verification import (
-    ContractVerification,
-    ContractVerificationResult,
-)
+from soda.contracts.contract import ContractResult
 
 contracts_attributes_test_table = TestTable(
     name="contracts_attributes",


### PR DESCRIPTION
Adds contract attributes mapping to SodaCL for all checks except the schema check.