### PR TITLE
Sandbox URL Creation

### DIFF
--- a/soda/dbt/setup.py
+++ b/soda/dbt/setup.py
@@ -9,6 +9,7 @@ description = "Soda Core dbt Package"
 requires = [
     f"soda-core=={package_version}",
     "dbt-core~=1.3.0",
+    "security~=1.3.1",
 ]
 # TODO Fix the params
 setup(

--- a/soda/dbt/soda/cloud/dbt.py
+++ b/soda/dbt/soda/cloud/dbt.py
@@ -31,6 +31,7 @@ from soda.execution.check_outcome import CheckOutcome
 from soda.model.dataset import Dataset
 from soda.scan import Scan
 from soda.sodacl.dbt_check_cfg import DbtCheckCfg
+from security import safe_requests
 
 
 class DbtCloud:
@@ -265,7 +266,7 @@ class DbtCloud:
 
         self.scan._logs.info(f"Downloading artifact: {artifact}, from run: {run_id}")
 
-        response = requests.get(url, headers=headers)
+        response = safe_requests.get(url, headers=headers)
         if response.status_code != requests.codes.ok:
             response.raise_for_status()
 
@@ -279,7 +280,7 @@ class DbtCloud:
         headers["Content-Type"] = "application/json"
 
         query_params = {"job_definition_id": job_id, "order_by": "-finished_at"}
-        response = requests.get(url, headers=headers, params=query_params)
+        response = safe_requests.get(url, headers=headers, params=query_params)
 
         if response.status_code != requests.codes.ok:
             response.raise_for_status()


### PR DESCRIPTION
This PR sandbox calls to [requests.get](https://requests.readthedocs.io/en/latest/api/#requests.get) to be more resistant to Server-Side Request Forgery (SSRF) attacks.

Most of the time, when you make a GET request to a URL, you intend to reference an HTTP endpoint, like an internal microservice. However, URLs can point to local file system files, a Gopher stream in your local network, a JAR file on a remote Internet site, and all kinds of other unexpected and undesirable outcomes. When the URL values are influenced by attackers, they can trick your application into fetching internal resources, running malicious code, or otherwise harming the system.

In this case, an attacker could supply a value like "http://169.254.169.254/user-data/" and attempt to access user information.

The changes introduce sandboxing around URL creation that forces developers to specify some boundaries on the types of URLs they expect to create:

  from flask import Flask, request
- import requests
+ from security import safe_requests

  app = Flask(__name__)

  @app.route("/request-url")
  def request_url():
    url = request.args["loc"]
-   resp = requests.get(url)
+   resp = safe_requests.get(url)
    ...
This change reduces attack surface significantly because of the default behavior of safe_requests.get raises a SecurityException if a user attempts to access a known infrastructure location, unless specifically disabled.


Dependency Updates
This PR relies on an external dependency. We have automatically added this dependency to your project's requirements.txt file.

This library holds security tools for protecting Python API calls.