### PR TITLE
Use pydantic models for data source config

### DIFF
--- a/docs/pages/python_api.md
+++ b/docs/pages/python_api.md
@@ -9,17 +9,17 @@ See [Install Soda Core in a Python virtual environment](./install.md)
 ```
 contract_verification_session_result: ContractVerificationSessionResult = (
     ContractVerificationSession.execute(
-        contract_yaml_sources=[YamlSource.from_file_path("soda/mydb/myschema/mytable.c.yml")],
-        data_source_yaml_sources=[YamlSource.from_file_path("soda/mydb.ds.yml")],
+        contract_yaml_sources=[ContractYamlSource.from_file_path("soda/mydb/myschema/mytable.c.yml")],
+        data_source_yaml_sources=[DataSourceYamlSource.from_file_path("soda/mydb.ds.yml")],
         variables={"MY_VAR": "somevalue"},
     )
 ```
 
-You have to ensure that the data sources that are referred to in the contracts are available either to the 
-contract verification session. Contracts refer to data sources by name. 
+You have to ensure that the data sources that are referred to in the contracts are available either to the
+contract verification session. Contracts refer to data sources by name.
 
-This API usage will group all the contract by data source and create a single data source connection to verify 
-the contracts for the same data source. Typically, there will be only contracts for a single data source passed. 
+This API usage will group all the contract by data source and create a single data source connection to verify
+the contracts for the same data source. Typically, there will be only contracts for a single data source passed.
 
 ### Contract verification session execute full signature
 
@@ -29,13 +29,13 @@ class ContractVerificationSession:
     @classmethod
     def execute(
         cls,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         only_validate_without_execute: bool = False,
         variables: Optional[dict[str, str]] = None,
         data_source_impls: Optional[list["DataSourceImpl"]] = None,
-        data_source_yaml_sources: Optional[list[YamlSource]] = None,
+        data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
         soda_cloud_impl: Optional["SodaCloud"] = None,
-        soda_cloud_yaml_source: Optional[YamlSource] = None,
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource] = None,
         soda_cloud_skip_publish: bool = False,
         soda_cloud_use_agent: bool = False,
         soda_cloud_use_agent_blocking_timeout_in_minutes: int = 60,
@@ -44,7 +44,7 @@ class ContractVerificationSession:
 
 ### Variables in a contract verification
 
-Contracts can refer to variables`${var.VAR_NAME}`.  To pass variables in the Soda Python API for 
+Contracts can refer to variables`${var.VAR_NAME}`.  To pass variables in the Soda Python API for
 contract verification, use parameter `variables={"MY_VAR": "somevalue"}`
 
 See ['Contract variables' in the writing check files page](writing_check_files.md#contract-variables)

--- a/soda-core/setup.py
+++ b/soda-core/setup.py
@@ -13,7 +13,11 @@ package_name = "soda-core"
 package_version = "4.0.0b1"
 description = "Soda Core V4"
 
-requires = ["ruamel.yaml>=0.17.0,<0.18.0", "requests>=2.32.3,<2.33.0"]
+requires = [
+    "ruamel.yaml>=0.17.0,<0.18.0",
+    "requests>=2.32.3,<2.33.0",
+    "pydantic>=2.0,<3.0",
+]
 
 setup(
     name=package_name,

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -3,7 +3,11 @@ from typing import Optional
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.soda_cloud import SodaCloud
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import (
+    ContractYamlSource,
+    DataSourceYamlSource,
+    SodaCloudYamlSource,
+)
 from soda_core.contracts.contract_publication import ContractPublication
 from soda_core.contracts.contract_verification import (
     ContractVerificationSession,
@@ -27,24 +31,26 @@ def handle_verify_contract(
 
     soda_cloud_client: Optional[SodaCloud] = None
     if soda_cloud_file_path:
-        soda_cloud_client = SodaCloud.from_yaml_source(YamlSource.from_file_path(soda_cloud_file_path), variables=None)
+        soda_cloud_client = SodaCloud.from_yaml_source(
+            SodaCloudYamlSource.from_file_path(soda_cloud_file_path), variables=None
+        )
 
-    contract_yaml_sources: list[YamlSource] = []
+    contract_yaml_sources: list[ContractYamlSource] = []
 
     contract_yaml_sources += [
-        YamlSource.from_file_path(contract_file_path) for contract_file_path in contract_file_paths or []
+        ContractYamlSource.from_file_path(contract_file_path) for contract_file_path in contract_file_paths or []
     ]
 
     if is_using_remote_contract(dataset_identifiers) and soda_cloud_client:
         contract_yaml_sources += [
-            YamlSource.from_str(soda_cloud_client.fetch_contract_for_dataset(dataset_identifier))
+            ContractYamlSource.from_str(soda_cloud_client.fetch_contract_for_dataset(dataset_identifier))
             for dataset_identifier in dataset_identifiers
         ]
 
-    data_source_yaml_source: Optional[YamlSource] = None
+    data_source_yaml_source: Optional[DataSourceYamlSource] = None
 
     if data_source_file_path:
-        data_source_yaml_source = YamlSource.from_file_path(data_source_file_path)
+        data_source_yaml_source = DataSourceYamlSource.from_file_path(data_source_file_path)
 
     if is_using_remote_datasource(dataset_identifiers, data_source_file_path) and soda_cloud_client:
         # TODO: decide on implications of this
@@ -58,7 +64,7 @@ def handle_verify_contract(
         dataset_identifier = dataset_identifiers[0]
 
         soda_logger.debug(f"No local data source config, trying to fetch data source config from cloud")
-        data_source_yaml_source = YamlSource.from_str(
+        data_source_yaml_source = DataSourceYamlSource.from_str(
             soda_cloud_client.fetch_data_source_configuration_for_dataset(dataset_identifier)
         )
 
@@ -66,7 +72,9 @@ def handle_verify_contract(
     contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
         contract_yaml_sources=contract_yaml_sources,
         data_source_yaml_sources=[data_source_yaml_source],
-        soda_cloud_yaml_source=(YamlSource.from_file_path(soda_cloud_file_path) if soda_cloud_file_path else None),
+        soda_cloud_yaml_source=(
+            SodaCloudYamlSource.from_file_path(soda_cloud_file_path) if soda_cloud_file_path else None
+        ),
         soda_cloud_publish_results=publish,
         soda_cloud_use_agent=use_agent,
         soda_cloud_use_agent_blocking_timeout_in_minutes=blocking_timeout_in_minutes,
@@ -154,7 +162,7 @@ def handle_test_contract(
 ) -> ExitCode:
     for contract_file_path in contract_file_paths:
         contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
-            contract_yaml_sources=[YamlSource.from_file_path(contract_file_path)],
+            contract_yaml_sources=[ContractYamlSource.from_file_path(contract_file_path)],
             only_validate_without_execute=True,
         )
         if contract_verification_session_result.has_errors():

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.logging_constants import Emoticons, soda_logger
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import DataSourceYamlSource
 
 
 def handle_create_data_source(data_source_file_path: str, data_source_type: str) -> ExitCode:
@@ -47,7 +47,9 @@ def handle_test_data_source(data_source_file_path: str) -> ExitCode:
     soda_logger.info(f"Testing data source configuration file {data_source_file_path}")
     from soda_core.common.data_source_impl import DataSourceImpl
 
-    data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(YamlSource.from_file_path(data_source_file_path))
+    data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(
+        DataSourceYamlSource.from_file_path(data_source_file_path)
+    )
     error_message: Optional[str] = (
         data_source_impl.test_connection_error_message()
         if data_source_impl

--- a/soda-core/src/soda_core/cli/handlers/soda_cloud.py
+++ b/soda-core/src/soda_core/cli/handlers/soda_cloud.py
@@ -6,7 +6,7 @@ from typing import Optional
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import SodaCloudYamlSource
 
 
 def handle_create_soda_cloud(soda_cloud_file_path: str) -> ExitCode:
@@ -44,7 +44,7 @@ def handle_test_soda_cloud(soda_cloud_file_path: str):
     logs = Logs()
 
     print(f"Testing soda cloud file {soda_cloud_file_path}")
-    soda_cloud_yaml_source: YamlSource = YamlSource.from_file_path(soda_cloud_file_path)
+    soda_cloud_yaml_source: SodaCloudYamlSource = SodaCloudYamlSource.from_file_path(soda_cloud_file_path)
     soda_cloud = SodaCloud.from_yaml_source(soda_cloud_yaml_source, variables=None)
     error_msg: Optional[str] = None
     if soda_cloud:

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -42,18 +42,10 @@ class DataSourceConnection(ABC):
         """
         if self.connection is None:
             try:
-                self._log_connection_properties_excl_pwd(self.connection_properties)
+                logger.debug(f"'{self.name}' connection properties: {self.connection_properties}")
                 self.connection = self._create_connection(self.connection_properties)
             except Exception as e:
                 logger.error(msg=f"Could not connect to '{self.name}': {e}", exc_info=True)
-
-    def _log_connection_properties_excl_pwd(self, connection_yaml_dict: dict):
-        dict_without_pwd = {
-            k: v
-            for k, v in connection_yaml_dict.items()
-            if not "password" in k and not "pwd" in k and not "key" in k and not "secret" in k
-        }
-        logger.debug(f"{self.name} connection properties: {dict_without_pwd}")
 
     def close_connection(self) -> None:
         """

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_results import QueryResult, UpdateResult
+from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_columns_query import (
@@ -15,6 +16,7 @@ from soda_core.common.statements.metadata_columns_query import (
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_core.common.yaml import YamlObject, YamlSource
 from soda_core.contracts.contract_verification import DataSource
+from soda_core.model.data_source.data_source import DataSourceBase
 
 logger: logging.Logger = soda_logger
 
@@ -24,60 +26,43 @@ class DataSourceImpl(ABC):
     def from_yaml_source(
         cls, data_source_yaml_source: YamlSource, variables: Optional[dict] = None
     ) -> Optional[DataSourceImpl]:
-        assert isinstance(data_source_yaml_source, YamlSource)
-
-        data_source_yaml_source.set_file_type("Data source")
         data_source_yaml_source.resolve(variables=variables)
         data_source_yaml: YamlObject = data_source_yaml_source.parse()
         if not data_source_yaml:
             return None
 
-        data_source_type_name: str = data_source_yaml.read_string("type")
-        data_source_name: Optional[str] = data_source_yaml.read_string("name")
+        from typing import Annotated, Union
 
-        connection_yaml: YamlObject = data_source_yaml.read_object_opt("connection")
-        connection_properties: Optional[dict] = None
-        if connection_yaml:
-            connection_properties = connection_yaml.to_dict()
-
-        return DataSourceImpl.create(
-            data_source_yaml_source=data_source_yaml_source,
-            name=data_source_name,
-            type_name=data_source_type_name,
-            connection_properties=connection_properties,
+        from pydantic import Field, TypeAdapter
+        from soda_postgres.model.data_source.postgres_data_source import (
+            PostgresDataSource,
         )
+
+        DataSourceModel = Annotated[Union[PostgresDataSource], Field(discriminator="type")]
+        adapter = TypeAdapter(DataSourceModel)
+        data_source_model = adapter.validate_python(data_source_yaml.yaml_dict)
+
+        return DataSourceImpl.create(data_source_model=data_source_model)
 
     @classmethod
     def create(
         cls,
-        data_source_yaml_source: YamlSource,
-        name: str,
-        type_name: str,
-        connection_properties: dict,
+        data_source_model: DataSourceBase,
     ) -> DataSourceImpl:
         from soda_core.common.data_sources.postgres_data_source import (
             PostgresDataSourceImpl,
         )
 
-        return PostgresDataSourceImpl(
-            data_source_yaml_source=data_source_yaml_source,
-            name=name,
-            type_name=type_name,
-            connection_properties=connection_properties,
-        )
+        return PostgresDataSourceImpl(data_source_model=data_source_model)
 
     def __init__(
         self,
-        data_source_yaml_source: YamlSource,
-        name: str,
-        type_name: str,
-        connection_properties: dict,
+        data_source_model: DataSourceBase,
     ):
-        self.data_source_yaml_source: YamlSource = data_source_yaml_source
-        self.name: str = name
-        self.type_name: str = type_name
+        self.data_source_model: DataSourceBase = data_source_model
+        self.name: str = data_source_model.name
+        self.type_name: str = data_source_model.type
         self.sql_dialect: SqlDialect = self._create_sql_dialect()
-        self.connection_properties: Optional[dict] = connection_properties
         self.data_source_connection: Optional[DataSourceConnection] = None
 
     def __str__(self) -> str:
@@ -88,7 +73,7 @@ class DataSourceImpl(ABC):
         pass
 
     @abstractmethod
-    def _create_data_source_connection(self, name: str, connection_properties: dict) -> DataSourceConnection:
+    def _create_data_source_connection(self) -> DataSourceConnection:
         pass
 
     @abstractmethod
@@ -98,11 +83,17 @@ class DataSourceImpl(ABC):
     def __enter__(self) -> None:
         self.open_connection()
 
+    def connection(self) -> DataSourceConnection:
+        if not self.has_open_connection():
+            self.open_connection()
+
+        return self.data_source_connection
+
     def open_connection(self) -> None:
-        self.data_source_connection = self._create_data_source_connection(
-            name=self.name,
-            connection_properties=self.connection_properties,
-        )
+        try:
+            self.data_source_connection = self._create_data_source_connection()
+        except Exception as e:
+            raise DataSourceConnectionException(e) from e
 
     def has_open_connection(self) -> bool:
         return (

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -14,7 +14,7 @@ from soda_core.common.statements.metadata_columns_query import (
     MetadataColumnsQuery,
 )
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
-from soda_core.common.yaml import YamlObject, YamlSource
+from soda_core.common.yaml import DataSourceYamlSource, YamlObject
 from soda_core.contracts.contract_verification import DataSource
 from soda_core.model.data_source.data_source import DataSourceBase
 
@@ -24,7 +24,7 @@ logger: logging.Logger = soda_logger
 class DataSourceImpl(ABC):
     @classmethod
     def from_yaml_source(
-        cls, data_source_yaml_source: YamlSource, variables: Optional[dict] = None
+        cls, data_source_yaml_source: DataSourceYamlSource, variables: Optional[dict] = None
     ) -> Optional[DataSourceImpl]:
         data_source_yaml_source.resolve(variables=variables)
         data_source_yaml: YamlObject = data_source_yaml_source.parse()
@@ -40,7 +40,7 @@ class DataSourceImpl(ABC):
 
         DataSourceModel = Annotated[Union[PostgresDataSource], Field(discriminator="type")]
         adapter = TypeAdapter(DataSourceModel)
-        data_source_model = adapter.validate_python(data_source_yaml.yaml_dict)
+        data_source_model = adapter.validate_python(data_source_yaml.yaml_dict, strict=True)
 
         return DataSourceImpl.create(data_source_model=data_source_model)
 

--- a/soda-core/src/soda_core/common/data_sources/postgres_data_source.py
+++ b/soda-core/src/soda_core/common/data_sources/postgres_data_source.py
@@ -2,21 +2,17 @@ from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.sql_ast import REGEX_LIKE
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.yaml import YamlSource
 from soda_postgres.common.data_sources.postgres_data_source_connection import (
     PostgresDataSourceConnection,
+)
+from soda_postgres.model.data_source.postgres_data_source import (
+    PostgresDataSource as PostgresDataSourceModel,
 )
 
 
 class PostgresDataSourceImpl(DataSourceImpl):
-    def __init__(
-        self,
-        data_source_yaml_source: YamlSource,
-        name: str,
-        type_name: str,
-        connection_properties: dict,
-    ):
-        super().__init__(data_source_yaml_source, name, type_name, connection_properties)
+    def __init__(self, data_source_model: PostgresDataSourceModel):
+        super().__init__(data_source_model=data_source_model)
 
     def get_data_source_type_name(self) -> str:
         return "postgres"
@@ -24,8 +20,10 @@ class PostgresDataSourceImpl(DataSourceImpl):
     def _create_sql_dialect(self) -> SqlDialect:
         return PostgresSqlDialect()
 
-    def _create_data_source_connection(self, name: str, connection_properties: dict) -> DataSourceConnection:
-        return PostgresDataSourceConnection(name=name, connection_properties=connection_properties)
+    def _create_data_source_connection(self) -> DataSourceConnection:
+        return PostgresDataSourceConnection(
+            name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
+        )
 
 
 class PostgresSqlDialect(SqlDialect):

--- a/soda-core/src/soda_core/common/exceptions.py
+++ b/soda-core/src/soda_core/common/exceptions.py
@@ -1,0 +1,6 @@
+class DataSourceConnectionException(Exception):
+    """Base class for all data source connection exceptions."""
+
+    def __init__(self, message: str, *args: object) -> None:
+        super().__init__(message, *args)
+        self.message = message

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -21,7 +21,7 @@ from soda_core.common.datetime_conversions import (
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.version import SODA_CORE_VERSION
-from soda_core.common.yaml import YamlObject, YamlSource
+from soda_core.common.yaml import SodaCloudYamlSource, YamlObject
 from soda_core.contracts.contract import ContractIdentifier
 from soda_core.contracts.contract_publication import ContractPublicationResult
 from soda_core.contracts.contract_verification import (
@@ -82,9 +82,8 @@ class SodaCloud:
 
     @classmethod
     def from_yaml_source(
-        cls, soda_cloud_yaml_source: YamlSource, variables: Optional[dict[str, str]]
+        cls, soda_cloud_yaml_source: SodaCloudYamlSource, variables: Optional[dict[str, str]]
     ) -> Optional[SodaCloud]:
-        soda_cloud_yaml_source.set_file_type("Soda Cloud")
         soda_cloud_yaml_source.resolve(variables=variables)
         soda_cloud_yaml_root_object: YamlObject = soda_cloud_yaml_source.parse()
 

--- a/soda-core/src/soda_core/common/utils.py
+++ b/soda-core/src/soda_core/common/utils.py
@@ -1,0 +1,3 @@
+from importlib.util import find_spec
+
+is_tabulate_available: bool = bool(find_spec(name="tabulate"))

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -22,30 +22,32 @@ class YamlParser:
 
 
 class FileType(str, Enum):
-    DATA_SOURCE = "data source"
+    DATA_SOURCE = "Data Source"
+    SODA_CLOUD = "Soda Cloud"
+    CONTRACT = "Contract"
+    YAML = "YAML"
 
 
 class YamlSource:
     """
-    YamlSource is an abstraction for 2 types of YAML sources: file and string.
+    YamlSource is an abstraction for multiple types of YAML sources: see subclasses below.
     It does lazy loading of the file so that errors are only generated when resolving or parsing.
     It's a stateful object that allows for optional variable resolving.
 
     Usage:
 
 
-    yaml_source: YamlSource = YamlSource.from_str(
+    yaml_source: YamlSource = ContractYamlSource.from_str(
         yaml_str="...yaml...",
         file_path="./some/contract.yml" # optional
     )
     # or
-    yaml_source: YamlSource = YamlSource.from_file_path(
+    yaml_source: YamlSource = ContractYamlSource.from_file_path(
         file_path="./some/contract.yml"
     )
 
-    # The default file type is 'yaml file'.
-    # Parsers can update the file type to get a better description and more concrete error messages
-    yaml_source.set_file_type("contract")
+    # The default file type is 'YAML'.
+    # Specific subclasses use different file types.
 
     # Optionally resolve variables as many times as you like:
     # resolving will trigger file loading (if applicable)
@@ -57,6 +59,7 @@ class YamlSource:
     """
 
     __yaml_parser = YamlParser()
+    __file_type = FileType.YAML.value
 
     @classmethod
     def from_str(cls, yaml_str: str, file_path: Optional[str] = None) -> YamlSource:
@@ -64,7 +67,7 @@ class YamlSource:
         Raises an assertion exception if yaml_str is not a str
         """
         assert isinstance(yaml_str, str)
-        return YamlSource(file_path=file_path, yaml_str=yaml_str)
+        return cls(file_path=file_path, yaml_str=yaml_str)
 
     @classmethod
     def from_file_path(cls, file_path: str) -> YamlSource:
@@ -75,7 +78,7 @@ class YamlSource:
         return cls(file_path=file_path)
 
     def __init__(self, file_path: Optional[str] = None, yaml_str: Optional[str] = None):
-        self.file_type: Optional[str] = None
+        self.file_type: str = self.__file_type
         self.file_path: str = file_path
         self.description: str = self._build_description(self.file_type, self.file_path)
         self.is_file_read: bool = False
@@ -85,6 +88,10 @@ class YamlSource:
         self.resolve_on_read_variables: Optional[dict[str, str]] = None
         self.resolve_on_read_use_env_vars: bool = True
         self.resolve_on_read_ignored_variable_names: Optional[set[str]] = None
+
+    def __init_subclass__(cls, file_type: FileType, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.__file_type = file_type.value
 
     def __str__(self) -> str:
         return self.description
@@ -101,14 +108,6 @@ class YamlSource:
                 return f"YAML file '{file_path}'"
             else:
                 return f"YAML string"
-
-    def set_file_type(self, file_type: str) -> None:
-        ###
-        # Deprecated. The instance should not be able to change the file type once created.
-        ###
-
-        self.file_type: str = file_type
-        self.description: str = self._build_description(self.file_type, self.file_path)
 
     def _ensure_yaml_str(self) -> None:
         if not isinstance(self.yaml_str, str) and isinstance(self.file_path, str) and not self.is_file_read:
@@ -174,11 +173,16 @@ class YamlSource:
                 )
 
 
-class DataSourceYamlSource(YamlSource):
-    def __init__(self, file_path: Optional[str] = None, yaml_str: Optional[str] = None):
-        super().__init__(file_path=file_path, yaml_str=yaml_str)
+class DataSourceYamlSource(YamlSource, file_type=FileType.DATA_SOURCE):
+    ...
 
-        self.file_type: str = FileType.DATA_SOURCE
+
+class SodaCloudYamlSource(YamlSource, file_type=FileType.SODA_CLOUD):
+    ...
+
+
+class ContractYamlSource(YamlSource, file_type=FileType.CONTRACT):
+    ...
 
 
 class YamlValue:

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from enum import Enum
 from numbers import Number
 from typing import Iterable, Optional
 
@@ -18,6 +19,10 @@ class YamlParser:
     def __init__(self):
         self.ruamel_yaml_parser: YAML = YAML()
         self.ruamel_yaml_parser.preserve_quotes = True
+
+
+class FileType(str, Enum):
+    DATA_SOURCE = "data source"
 
 
 class YamlSource:
@@ -67,7 +72,7 @@ class YamlSource:
         Raises an assertion exception if file_path is not a str
         """
         assert isinstance(file_path, str)
-        return YamlSource(file_path=file_path)
+        return cls(file_path=file_path)
 
     def __init__(self, file_path: Optional[str] = None, yaml_str: Optional[str] = None):
         self.file_type: Optional[str] = None
@@ -98,6 +103,10 @@ class YamlSource:
                 return f"YAML string"
 
     def set_file_type(self, file_type: str) -> None:
+        ###
+        # Deprecated. The instance should not be able to change the file type once created.
+        ###
+
         self.file_type: str = file_type
         self.description: str = self._build_description(self.file_type, self.file_path)
 
@@ -163,6 +172,13 @@ class YamlSource:
                     exc_info=True,
                     extra={ExtraKeys.LOCATION: location},
                 )
+
+
+class DataSourceYamlSource(YamlSource):
+    def __init__(self, file_path: Optional[str] = None, yaml_str: Optional[str] = None):
+        super().__init__(file_path=file_path, yaml_str=yaml_str)
+
+        self.file_type: str = FileType.DATA_SOURCE
 
 
 class YamlValue:

--- a/soda-core/src/soda_core/contracts/contract_command_builder.py
+++ b/soda-core/src/soda_core/contracts/contract_command_builder.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, TypeVar
 
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 
 T = TypeVar("T", bound="ContractCommandBuilder")
 
@@ -13,9 +13,9 @@ logger: logging.Logger = soda_logger
 
 class ContractCommandBuilder:
     def __init__(self, logs: Optional[Logs] = None):
-        self.contract_yaml_sources: list[YamlSource] = []
+        self.contract_yaml_sources: list[ContractYamlSource] = []
         self.soda_cloud: Optional["SodaCloud"] = None
-        self.soda_cloud_yaml_source: Optional[YamlSource] = None
+        self.soda_cloud_yaml_source: Optional[SodaCloudYamlSource] = None
         self.variables: Optional[Dict[str, str]] = {}
         self.logs: Logs = logs if logs else Logs()
         logger.debug("Publishing contract...")
@@ -23,7 +23,7 @@ class ContractCommandBuilder:
     def with_contract_yaml_file(self, contract_yaml_file_path: str) -> T:
         if isinstance(contract_yaml_file_path, str):
             logger.debug(f"  ...with contract file path '{contract_yaml_file_path}'")
-            self.contract_yaml_sources.append(YamlSource.from_file_path(file_path=contract_yaml_file_path))
+            self.contract_yaml_sources.append(ContractYamlSource.from_file_path(file_path=contract_yaml_file_path))
         else:
             logger.error(
                 f"...ignoring invalid contract yaml file '{contract_yaml_file_path}'. "
@@ -34,7 +34,7 @@ class ContractCommandBuilder:
     def with_contract_yaml_str(self, contract_yaml_str: str) -> T:
         if isinstance(contract_yaml_str, str):
             logger.debug(f"  ...with contract YAML str [{len(contract_yaml_str)}]")
-            self.contract_yaml_sources.append(YamlSource.from_str(yaml_str=contract_yaml_str))
+            self.contract_yaml_sources.append(ContractYamlSource.from_str(yaml_str=contract_yaml_str))
         else:
             logger.error(
                 f"...ignoring invalid contract_yaml_str '{contract_yaml_str}'.  "
@@ -51,7 +51,7 @@ class ContractCommandBuilder:
                     f"  ...with soda_cloud_yaml_file_path '{soda_cloud_yaml_file_path}'. "
                     f"Ignoring previously configured soda cloud '{self.soda_cloud_yaml_source}'"
                 )
-            self.soda_cloud_yaml_source = YamlSource.from_file_path(file_path=soda_cloud_yaml_file_path)
+            self.soda_cloud_yaml_source = SodaCloudYamlSource.from_file_path(file_path=soda_cloud_yaml_file_path)
         else:
             logger.error(
                 f"...ignoring invalid soda_cloud_yaml_file_path '{soda_cloud_yaml_file_path}'. "
@@ -68,7 +68,7 @@ class ContractCommandBuilder:
                     f"  ...with soda_cloud_yaml_str '{soda_cloud_yaml_str}'. "
                     f"Ignoring previously configured soda cloud '{self.soda_cloud_yaml_source}'"
                 )
-            self.soda_cloud_yaml_source = YamlSource.from_str(yaml_str=soda_cloud_yaml_str)
+            self.soda_cloud_yaml_source = SodaCloudYamlSource.from_str(yaml_str=soda_cloud_yaml_str)
         else:
             logger.error(
                 f"...ignoring invalid soda_cloud_yaml_str '{soda_cloud_yaml_str}'. "

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -11,7 +11,11 @@ from typing import Optional
 
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import (
+    ContractYamlSource,
+    DataSourceYamlSource,
+    SodaCloudYamlSource,
+)
 
 logger: logging.Logger = soda_logger
 
@@ -20,13 +24,13 @@ class ContractVerificationSession:
     @classmethod
     def execute(
         cls,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         only_validate_without_execute: bool = False,
         variables: Optional[dict[str, str]] = None,
         data_source_impls: Optional[list["DataSourceImpl"]] = None,
-        data_source_yaml_sources: Optional[list[YamlSource]] = None,
+        data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
         soda_cloud_impl: Optional["SodaCloud"] = None,
-        soda_cloud_yaml_source: Optional[YamlSource] = None,
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource] = None,
         soda_cloud_publish_results: bool = False,
         soda_cloud_use_agent: bool = False,
         soda_cloud_use_agent_blocking_timeout_in_minutes: int = 60,

--- a/soda-core/src/soda_core/contracts/impl/contract_publication_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_publication_impl.py
@@ -4,7 +4,7 @@ from typing import Optional
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import SodaCloud
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResultList
 from soda_core.contracts.impl.contract_verification_impl import ContractImpl
 from soda_core.contracts.impl.contract_yaml import ContractYaml
@@ -15,9 +15,9 @@ logger: logging.Logger = soda_logger
 class ContractPublicationImpl:
     def __init__(
         self,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         soda_cloud: Optional[SodaCloud],
-        soda_cloud_yaml_source: Optional[YamlSource],
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         variables: dict[str, str],
         logs: Logs,
     ):
@@ -35,7 +35,6 @@ class ContractPublicationImpl:
             logger.error(f"No contracts configured")
         else:
             for contract_yaml_source in contract_yaml_sources:
-                contract_yaml_source.set_file_type("Contract")
                 contract_yaml: ContractYaml = ContractYaml.parse(
                     contract_yaml_source=contract_yaml_source, variables=variables
                 )

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -14,7 +14,12 @@ from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.sql_dialect import *
-from soda_core.common.yaml import VariableResolver, YamlSource
+from soda_core.common.yaml import (
+    ContractYamlSource,
+    DataSourceYamlSource,
+    SodaCloudYamlSource,
+    VariableResolver,
+)
 from soda_core.contracts.contract_verification import (
     Check,
     CheckOutcome,
@@ -46,12 +51,12 @@ class ContractVerificationSessionImpl:
     @classmethod
     def execute(
         cls,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         only_validate_without_execute: bool = False,
         variables: Optional[dict[str, str]] = None,
         data_source_impls: Optional[list[DataSourceImpl]] = None,
-        data_source_yaml_sources: Optional[list[YamlSource]] = None,
-        soda_cloud_yaml_source: Optional[YamlSource] = None,
+        data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource] = None,
         soda_cloud_impl: Optional[SodaCloud] = None,
         soda_cloud_publish_results: bool = False,
         soda_cloud_use_agent: bool = False,
@@ -62,7 +67,9 @@ class ContractVerificationSessionImpl:
 
         # Validate input contract_yaml_sources
         assert isinstance(contract_yaml_sources, list)
-        assert all(isinstance(contract_yaml_source, YamlSource) for contract_yaml_source in contract_yaml_sources)
+        assert all(
+            isinstance(contract_yaml_source, ContractYamlSource) for contract_yaml_source in contract_yaml_sources
+        )
 
         # Validate input variables
         if variables is None:
@@ -84,12 +91,13 @@ class ContractVerificationSessionImpl:
         else:
             assert isinstance(data_source_yaml_sources, list)
             assert all(
-                isinstance(data_source_yaml_source, YamlSource) for data_source_yaml_source in data_source_yaml_sources
+                isinstance(data_source_yaml_source, DataSourceYamlSource)
+                for data_source_yaml_source in data_source_yaml_sources
             )
 
         # Validate input soda_cloud_yaml_source
         if soda_cloud_yaml_source is not None:
-            assert isinstance(soda_cloud_yaml_source, YamlSource)
+            assert isinstance(soda_cloud_yaml_source, SodaCloudYamlSource)
 
         # Validate input soda_cloud_impl
         if soda_cloud_impl is not None:
@@ -131,12 +139,12 @@ class ContractVerificationSessionImpl:
     def _execute_locally(
         cls,
         logs: Logs,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         only_validate_without_execute: bool,
         variables: dict[str, str],
         data_source_impls: list[DataSourceImpl],
-        data_source_yaml_sources: list[YamlSource],
-        soda_cloud_yaml_source: Optional[YamlSource],
+        data_source_yaml_sources: list[DataSourceYamlSource],
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         soda_cloud_impl: Optional[SodaCloud],
         soda_cloud_publish_results: bool,
     ) -> list[ContractVerificationResult]:
@@ -186,7 +194,7 @@ class ContractVerificationSessionImpl:
     def _build_data_source_impl_by_name(
         cls,
         data_source_impls: list[DataSourceImpl],
-        data_source_yaml_sources: list[YamlSource],
+        data_source_yaml_sources: list[DataSourceYamlSource],
         variables: dict[str, str],
     ) -> dict[str, DataSourceImpl]:
         data_source_impl_by_name: dict[str, DataSourceImpl] = (
@@ -205,7 +213,7 @@ class ContractVerificationSessionImpl:
     def _build_soda_cloud_impl(
         cls,
         soda_cloud_impl: Optional[SodaCloud],
-        soda_cloud_yaml_source: Optional[YamlSource],
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         variables: dict[str, str],
     ) -> Optional[SodaCloud]:
         if soda_cloud_impl:
@@ -235,9 +243,9 @@ class ContractVerificationSessionImpl:
     @classmethod
     def _execute_on_agent(
         cls,
-        contract_yaml_sources: list[YamlSource],
+        contract_yaml_sources: list[ContractYamlSource],
         variables: Optional[dict[str, str]],
-        soda_cloud_yaml_source: Optional[YamlSource],
+        soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         soda_cloud_impl: Optional[SodaCloud],
         soda_cloud_use_agent_blocking_timeout_in_minutes,
     ) -> list[ContractVerificationResult]:

--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -14,10 +14,10 @@ from soda_core.common.datetime_conversions import (
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location
 from soda_core.common.yaml import (
+    ContractYamlSource,
     VariableResolver,
     YamlList,
     YamlObject,
-    YamlSource,
     YamlValue,
 )
 
@@ -64,7 +64,6 @@ def register_check_types() -> None:
 
 
 class ContractYaml:
-
     """
     Represents YAML as close as possible.
     None means the key was not present.
@@ -74,17 +73,15 @@ class ContractYaml:
 
     @classmethod
     def parse(
-        cls, contract_yaml_source: YamlSource, variables: Optional[dict[str, str]] = None
+        cls, contract_yaml_source: ContractYamlSource, variables: Optional[dict[str, str]] = None
     ) -> Optional[ContractYaml]:
         check_types_have_been_registered: bool = len(CheckYaml.check_yaml_parsers) > 0
         if not check_types_have_been_registered:
             register_check_types()
         return ContractYaml(contract_yaml_source=contract_yaml_source, variables=variables)
 
-    def __init__(self, contract_yaml_source: YamlSource, variables: Optional[dict[str, str]]):
-        self.contract_yaml_source: YamlSource = contract_yaml_source
-        self.contract_yaml_source.set_file_type("Contract")
-
+    def __init__(self, contract_yaml_source: ContractYamlSource, variables: Optional[dict[str, str]]):
+        self.contract_yaml_source: ContractYamlSource = contract_yaml_source
         self.contract_yaml_object: Optional[YamlObject] = contract_yaml_source.parse()
 
         self.variables: list[VariableYaml] = []

--- a/soda-core/src/soda_core/model/data_source/data_source.py
+++ b/soda-core/src/soda_core/model/data_source/data_source.py
@@ -6,14 +6,16 @@ from soda_core.model.data_source.data_source_connection_properties import (
 )
 
 
-class DataSourceBase(BaseModel, abc.ABC):
+class DataSourceBase(
+    BaseModel,
+    abc.ABC,
+    frozen=True,
+    extra="forbid",
+    validate_by_name=True,  # Allow to use both field names and aliases when populating from dict
+):
     name: str = Field(..., description="Data source name")
     type: str = Field(..., description="Data source type")
     # Alias connection -> connection_properties to read that from yaml config
     connection_properties: DataSourceConnectionProperties = Field(
         ..., alias="connection", description="Data source connection details"
     )
-
-    class Config:
-        # Allow to use both field names and aliases when populating from dict
-        validate_by_name = True

--- a/soda-core/src/soda_core/model/data_source/data_source.py
+++ b/soda-core/src/soda_core/model/data_source/data_source.py
@@ -1,0 +1,19 @@
+import abc
+
+from pydantic import BaseModel, Field
+from soda_core.model.data_source.data_source_connection_properties import (
+    DataSourceConnectionProperties,
+)
+
+
+class DataSourceBase(BaseModel, abc.ABC):
+    name: str = Field(..., description="Data source name")
+    type: str = Field(..., description="Data source type")
+    # Alias connection -> connection_properties to read that from yaml config
+    connection_properties: DataSourceConnectionProperties = Field(
+        ..., alias="connection", description="Data source connection details"
+    )
+
+    class Config:
+        # Allow to use both field names and aliases when populating from dict
+        validate_by_name = True

--- a/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
+++ b/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
@@ -1,0 +1,11 @@
+from abc import ABC
+
+from pydantic import BaseModel
+
+
+class DataSourceConnectionProperties(BaseModel, ABC):
+    pass
+
+    class Config:
+        # Allow to use both field names and aliases when populating from dict
+        validate_by_name = True

--- a/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
+++ b/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
@@ -3,9 +3,11 @@ from abc import ABC
 from pydantic import BaseModel
 
 
-class DataSourceConnectionProperties(BaseModel, ABC):
+class DataSourceConnectionProperties(
+    BaseModel,
+    ABC,
+    frozen=True,
+    extra="forbid",
+    validate_by_name=True,  # Allow to use both field names and aliases when populating from dict
+):
     pass
-
-    class Config:
-        # Allow to use both field names and aliases when populating from dict
-        validate_by_name = True

--- a/soda-core/tests/soda_core/tests/components/manual_test_agent_flow.py
+++ b/soda-core/tests/soda_core/tests/components/manual_test_agent_flow.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 
 from dotenv import load_dotenv
 from soda_core.common.logging_configuration import configure_logging
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_verification import ContractVerificationSession
 
 
@@ -36,8 +36,8 @@ def main():
     ).strip()
 
     ContractVerificationSession.execute(
-        contract_yaml_sources=[YamlSource.from_str(contract_yaml_str)],
-        soda_cloud_yaml_source=YamlSource.from_str(soda_cloud_yaml_str),
+        contract_yaml_sources=[ContractYamlSource.from_str(contract_yaml_str)],
+        soda_cloud_yaml_source=SodaCloudYamlSource.from_str(soda_cloud_yaml_str),
         soda_cloud_use_agent=True,
         soda_cloud_use_agent_blocking_timeout_in_minutes=55,
     )

--- a/soda-core/tests/soda_core/tests/components/test_cli_soda_cloud_handlers.py
+++ b/soda-core/tests/soda_core/tests/components/test_cli_soda_cloud_handlers.py
@@ -57,7 +57,7 @@ def test_test_soda_cloud_connection_failure(mock_soda_cloud_cls):
     assert exit_code == ExitCode.LOG_ERRORS
 
 
-@patch("soda_core.cli.handlers.soda_cloud.YamlSource")
+@patch("soda_core.cli.handlers.soda_cloud.SodaCloudYamlSource")
 def test_test_soda_cloud_returns_none(mock_yaml_source_cls):
     mock_yaml_source = MagicMock()
     mock_yaml_source.parse_yaml_file_content.return_value = "parsed_yaml"

--- a/soda-core/tests/soda_core/tests/components/test_contract_parser_api.py
+++ b/soda-core/tests/soda_core/tests/components/test_contract_parser_api.py
@@ -1,11 +1,11 @@
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.impl.contract_yaml import CheckYaml, ColumnYaml, ContractYaml
 from soda_core.tests.helpers.test_functions import dedent_and_strip
 
 
 def test_parse_relative_complete_contract():
-    contract_yaml_source: YamlSource = YamlSource.from_str(
+    contract_yaml_source: ContractYamlSource = ContractYamlSource.from_str(
         yaml_str=dedent_and_strip(
             """
         dataset: SODATEST_test_schema_31761d69
@@ -37,7 +37,7 @@ def test_parse_relative_complete_contract():
 def test_parse_minimal_contract():
     logs: Logs = Logs()
     ContractYaml.parse(
-        contract_yaml_source=YamlSource.from_str(
+        contract_yaml_source=ContractYamlSource.from_str(
             """
             data_source: abc
             dataset: dsname

--- a/soda-core/tests/soda_core/tests/components/test_contract_verification_api.py
+++ b/soda-core/tests/soda_core/tests/components/test_contract_verification_api.py
@@ -1,5 +1,5 @@
 import pytest
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.contract_verification import (
     ContractVerificationSession,
     ContractVerificationSessionResult,
@@ -9,7 +9,7 @@ from soda_core.contracts.contract_verification import (
 
 def test_contract_verification_file_api():
     contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
-        contract_yaml_sources=[YamlSource.from_file_path("../soda/mydb/myschema/table.yml")],
+        contract_yaml_sources=[ContractYamlSource.from_file_path("../soda/mydb/myschema/table.yml")],
         variables={"env": "test"},
     )
 
@@ -22,7 +22,7 @@ def test_contract_verification_file_api():
 def test_contract_verification_file_api_exception_on_error():
     with pytest.raises(SodaException) as e:
         ContractVerificationSession.execute(
-            contract_yaml_sources=[YamlSource.from_file_path("../soda/mydb/myschema/table.yml")],
+            contract_yaml_sources=[ContractYamlSource.from_file_path("../soda/mydb/myschema/table.yml")],
             variables={"env": "test"},
         ).assert_ok()
 
@@ -36,7 +36,7 @@ def test_contract_provided_and_configured():
     """
     contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
         contract_yaml_sources=[
-            YamlSource.from_str(
+            ContractYamlSource.from_str(
                 f"""
               data_source: abc
               dataset: CUSTOMERS

--- a/soda-core/tests/soda_core/tests/components/test_data_source_api.py
+++ b/soda-core/tests/soda_core/tests/components/test_data_source_api.py
@@ -1,7 +1,7 @@
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import DataSourceYamlSource
 from soda_core.tests.helpers.data_source_test_helper import DataSourceTestHelper
 from soda_core.tests.helpers.test_table import TestTableSpecification
 
@@ -18,7 +18,7 @@ test_table_specification = (
 def test_data_source_api(data_source_test_helper: DataSourceTestHelper):
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
-    data_source_yaml_source: YamlSource = data_source_test_helper._create_data_source_yaml_source()
+    data_source_yaml_source: DataSourceYamlSource = data_source_test_helper._create_data_source_yaml_source()
     data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(data_source_yaml_source)
 
     with data_source_impl:
@@ -30,6 +30,6 @@ def test_data_source_api(data_source_test_helper: DataSourceTestHelper):
 
 def test_empty_data_source_file():
     logs: Logs = Logs()
-    data_source_yaml_source: YamlSource = YamlSource.from_str("")
+    data_source_yaml_source: DataSourceYamlSource = DataSourceYamlSource.from_str("")
     data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(data_source_yaml_source)
-    assert "Data source YAML string root must be an object, but was empty" in logs.get_errors_str()
+    assert "Data Source YAML string root must be an object, but was empty" in logs.get_errors_str()

--- a/soda-core/tests/soda_core/tests/components/test_soda_cloud.py
+++ b/soda-core/tests/soda_core/tests/components/test_soda_cloud.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from soda_core.common.datetime_conversions import convert_datetime_to_str
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResult
 from soda_core.contracts.contract_verification import ContractVerificationResult
 from soda_core.contracts.impl.contract_yaml import ContractYaml
@@ -189,7 +189,7 @@ def test_publish_contract():
 
     res = mock_cloud.publish_contract(
         ContractYaml.parse(
-            YamlSource.from_str(
+            ContractYamlSource.from_str(
                 f"""
             dataset: CUSTOMERS
             dataset_prefix: [some, schema]
@@ -223,7 +223,7 @@ def test_verify_contract_on_agent_permission_check():
 
     res = mock_cloud.verify_contract_on_agent(
         ContractYaml.parse(
-            YamlSource.from_str(
+            ContractYamlSource.from_str(
                 f"""
             dataset: CUSTOMERS
             dataset_prefix: [some, schema]

--- a/soda-core/tests/soda_core/tests/components/test_thresholds.py
+++ b/soda-core/tests/soda_core/tests/components/test_thresholds.py
@@ -1,4 +1,4 @@
-from soda_core.common.yaml import YamlObject, YamlSource
+from soda_core.common.yaml import ContractYamlSource, YamlObject
 from soda_core.contracts.impl.contract_verification_impl import ThresholdImpl
 from soda_core.contracts.impl.contract_yaml import ThresholdYaml
 from soda_core.tests.helpers.test_functions import dedent_and_strip
@@ -145,7 +145,7 @@ def test_threshold_custom_outer():
 
 def parse_threshold(threshold_yaml: str) -> ThresholdImpl:
     dedented_threshold_yaml: str = dedent_and_strip(threshold_yaml)
-    yaml_source = YamlSource.from_str(dedented_threshold_yaml)
+    yaml_source = ContractYamlSource.from_str(dedented_threshold_yaml)
     yaml_object: YamlObject = yaml_source.parse()
     threshold_yaml: ThresholdYaml = ThresholdYaml(
         threshold_yaml_object=yaml_object,

--- a/soda-core/tests/soda_core/tests/components/test_variables.py
+++ b/soda-core/tests/soda_core/tests/components/test_variables.py
@@ -1,14 +1,14 @@
 from typing import Optional
 
 from soda_core.common.logs import Logs
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.impl.contract_yaml import ContractYaml
 from soda_core.tests.helpers.test_functions import dedent_and_strip
 
 
 def parse_contract(contract_yaml_str: str, variables: Optional[dict[str, str]] = None) -> ContractYaml:
     return ContractYaml.parse(
-        contract_yaml_source=YamlSource.from_str(dedent_and_strip(contract_yaml_str)), variables=variables
+        contract_yaml_source=ContractYamlSource.from_str(dedent_and_strip(contract_yaml_str)), variables=variables
     )
 
 

--- a/soda-core/tests/soda_core/tests/helpers/data_source_test_helper.py
+++ b/soda-core/tests/soda_core/tests/helpers/data_source_test_helper.py
@@ -14,7 +14,11 @@ from soda_core.common.statements.metadata_tables_query import (
     FullyQualifiedTableName,
     MetadataTablesQuery,
 )
-from soda_core.common.yaml import YamlSource
+from soda_core.common.yaml import (
+    ContractYamlSource,
+    DataSourceYamlSource,
+    SodaCloudYamlSource,
+)
 from soda_core.contracts.contract_verification import (
     ContractVerificationResult,
     ContractVerificationSession,
@@ -75,7 +79,7 @@ class DataSourceTestHelper:
               api_key_id: ${env.SODA_CLOUD_API_KEY_ID}
               api_key_secret: ${env.SODA_CLOUD_API_KEY_SECRET}
         """
-        soda_cloud_yaml_source: YamlSource = YamlSource.from_str(yaml_str=soda_cloud_yaml_str)
+        soda_cloud_yaml_source: SodaCloudYamlSource = SodaCloudYamlSource.from_str(yaml_str=soda_cloud_yaml_str)
         self.soda_cloud = SodaCloud.from_yaml_source(soda_cloud_yaml_source=soda_cloud_yaml_source, variables={})
         if logs.has_errors():
             raise AssertionError(str(logs))
@@ -88,7 +92,7 @@ class DataSourceTestHelper:
         Called in constructor to initialized self.data_source
         """
         logs: Logs = Logs()
-        data_source_yaml_source: YamlSource = self._create_data_source_yaml_source()
+        data_source_yaml_source: DataSourceYamlSource = self._create_data_source_yaml_source()
         from soda_core.common.data_source_impl import DataSourceImpl
 
         data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(data_source_yaml_source)
@@ -102,10 +106,10 @@ class DataSourceTestHelper:
         """
         return ""
 
-    def _create_data_source_yaml_source(self) -> YamlSource:
+    def _create_data_source_yaml_source(self) -> DataSourceYamlSource:
         test_data_source_yaml_str: str = self._create_data_source_yaml_str()
         test_data_source_yaml_str = dedent(test_data_source_yaml_str).strip()
-        return YamlSource.from_str(yaml_str=test_data_source_yaml_str)
+        return DataSourceYamlSource.from_str(yaml_str=test_data_source_yaml_str)
 
     def _create_dataset_prefix(self) -> list[str]:
         database_name: str = self._create_database_name()
@@ -384,7 +388,7 @@ class DataSourceTestHelper:
     def get_parse_errors_str(self, contract_yaml_str: str) -> str:
         contract_yaml_str: str = dedent(contract_yaml_str).strip()
         contract_verification_session_result = ContractVerificationSession.execute(
-            contract_yaml_sources=[YamlSource.from_str(contract_yaml_str)], only_validate_without_execute=True
+            contract_yaml_sources=[ContractYamlSource.from_str(contract_yaml_str)], only_validate_without_execute=True
         )
         return contract_verification_session_result.get_errors_str()
 
@@ -392,7 +396,9 @@ class DataSourceTestHelper:
         contract_yaml_str: str = dedent(contract_yaml_str).strip()
 
         contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
-            contract_yaml_sources=[YamlSource.from_str(yaml_str=contract_yaml_str, file_path="yaml_string.yml")],
+            contract_yaml_sources=[
+                ContractYamlSource.from_str(yaml_str=contract_yaml_str, file_path="yaml_string.yml")
+            ],
             only_validate_without_execute=True,
             variables=variables,
             data_source_impls=[self.data_source_impl],
@@ -436,7 +442,7 @@ class DataSourceTestHelper:
         contract_yaml_str = self._dedent_strip_and_prepend_dataset(contract_yaml_str, test_table)
         logger.debug(f"Contract:\n{contract_yaml_str}")
         return ContractVerificationSession.execute(
-            contract_yaml_sources=[YamlSource.from_str(contract_yaml_str)],
+            contract_yaml_sources=[ContractYamlSource.from_str(contract_yaml_str)],
             variables=variables,
             data_source_impls=[self.data_source_impl],
             soda_cloud_impl=self.soda_cloud,

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -1,21 +1,58 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Union
+
+import psycopg2
 from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.model.data_source.data_source_connection_properties import (
+    DataSourceConnectionProperties,
+)
+from soda_postgres.model.data_source.postgres_connection_properties import (
+    PostgresConnectionPassword,
+    PostgresConnectionPasswordFile,
+    PostgresConnectionString,
+)
 
 
 class PostgresDataSourceConnection(DataSourceConnection):
-    def __init__(self, name: str, connection_properties: dict):
+    def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
         super().__init__(name, connection_properties)
 
-    def _create_connection(self, connection_yaml_dict: dict) -> object:
-        import psycopg2
+    def _create_connection(
+        self,
+        config: Union[PostgresConnectionString, PostgresConnectionPassword, PostgresConnectionPasswordFile],
+    ):
+        if isinstance(config, PostgresConnectionString):
+            if config.connection_string:
+                return psycopg2.connect(config.connection_string)
+            else:
+                raise ValueError("PostgresConnectionString must have `connection_string`")
 
-        if not "password" in connection_yaml_dict or connection_yaml_dict["password"] == "":
-            connection_yaml_dict["password"] = None
+        conn_kwargs = {
+            "host": str(config.host),
+            "port": config.port,
+            "dbname": config.database,
+            "user": config.user,
+            "sslmode": config.ssl_mode,
+        }
 
-        if "username" in connection_yaml_dict and "user" not in connection_yaml_dict:
-            raise ValueError(
-                "Rename postgres connection property username to user. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS"
-            )
+        # SSL certs
+        if config.ssl_cert:
+            conn_kwargs["sslcert"] = config.ssl_cert
+        if config.ssl_key:
+            conn_kwargs["sslkey"] = config.ssl_key
+        if config.ssl_root_cert:
+            conn_kwargs["sslrootcert"] = config.ssl_root_cert
 
-        return psycopg2.connect(**connection_yaml_dict)
+        # Password
+        if isinstance(config, PostgresConnectionPassword):
+            conn_kwargs["password"] = config.password.get_secret_value()
+        elif isinstance(config, PostgresConnectionPasswordFile):
+            conn_kwargs["password"] = Path(config.password_file).read_text().strip()
+
+        # Timeout
+        if config.connection_timeout:
+            conn_kwargs["connect_timeout"] = config.connection_timeout
+
+        return psycopg2.connect(**conn_kwargs)

--- a/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
+++ b/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
@@ -8,13 +8,15 @@ from soda_core.model.data_source.data_source_connection_properties import (
 )
 
 
-class PostgresConnectionString(DataSourceConnectionProperties):
-    connection_string: Optional[str] = Field(
-        None, description="Complete connection string (alternative to individual parameters)"
-    )
+class PostgresConnectionProperties(DataSourceConnectionProperties, ABC):
+    ...
 
 
-class PostgresConnectionPropertiesBase(DataSourceConnectionProperties, ABC):
+class PostgresConnectionString(PostgresConnectionProperties):
+    connection_string: str = Field(..., description="Complete connection string (alternative to individual parameters)")
+
+
+class PostgresConnectionPropertiesBase(PostgresConnectionProperties, ABC):
     host: Union[str, IPvAnyAddress] = Field(..., description="Database host (hostname or IP address)")
     port: int = Field(5432, description="Database port (1-65535)", ge=1, le=65535)
     database: str = Field(..., description="Database name", min_length=1, max_length=63)
@@ -33,7 +35,7 @@ class PostgresConnectionPropertiesBase(DataSourceConnectionProperties, ABC):
 
 
 class PostgresConnectionPassword(PostgresConnectionPropertiesBase):
-    password: SecretStr = Field(None, description="Database password")
+    password: SecretStr = Field(..., description="Database password")
 
 
 class PostgresConnectionPasswordFile(PostgresConnectionPropertiesBase):

--- a/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
+++ b/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
@@ -1,0 +1,40 @@
+from abc import ABC
+from pathlib import Path
+from typing import Literal, Optional, Union
+
+from pydantic import Field, IPvAnyAddress, SecretStr
+from soda_core.model.data_source.data_source_connection_properties import (
+    DataSourceConnectionProperties,
+)
+
+
+class PostgresConnectionString(DataSourceConnectionProperties):
+    connection_string: Optional[str] = Field(
+        None, description="Complete connection string (alternative to individual parameters)"
+    )
+
+
+class PostgresConnectionPropertiesBase(DataSourceConnectionProperties, ABC):
+    host: Union[str, IPvAnyAddress] = Field(..., description="Database host (hostname or IP address)")
+    port: int = Field(5432, description="Database port (1-65535)", ge=1, le=65535)
+    database: str = Field(..., description="Database name", min_length=1, max_length=63)
+    user: str = Field(..., description="Database user (1-63 characters)", min_length=1, max_length=63)
+
+    # SSL configuration
+    ssl_mode: Literal["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] = Field(
+        "prefer", description="SSL mode for the connection"
+    )
+    ssl_cert: Optional[str] = Field(None, description="Path to SSL client certificate")
+    ssl_key: Optional[str] = Field(None, description="Path to SSL client key")
+    ssl_root_cert: Optional[str] = Field(None, description="Path to SSL root certificate")
+
+    # Connection options
+    connection_timeout: Optional[int] = Field(None, description="Connection timeout in seconds")
+
+
+class PostgresConnectionPassword(PostgresConnectionPropertiesBase):
+    password: SecretStr = Field(None, description="Database password")
+
+
+class PostgresConnectionPasswordFile(PostgresConnectionPropertiesBase):
+    password_file: Path = Field(..., description="Path to file containing database password")

--- a/soda-postgres/src/soda_postgres/model/data_source/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/model/data_source/postgres_data_source.py
@@ -1,0 +1,17 @@
+import abc
+from typing import Literal, Union
+
+from pydantic import Field
+from soda_core.model.data_source.data_source import DataSourceBase
+from soda_postgres.model.data_source.postgres_connection_properties import (
+    PostgresConnectionPassword,
+    PostgresConnectionPasswordFile,
+    PostgresConnectionString,
+)
+
+
+class PostgresDataSource(DataSourceBase, abc.ABC):
+    type: Literal["postgres"]
+    connection_properties: Union[
+        PostgresConnectionPassword, PostgresConnectionPasswordFile, PostgresConnectionString
+    ] = Field(..., alias="connection", description="Data source connection details")

--- a/soda-postgres/src/soda_postgres/model/data_source/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/model/data_source/postgres_data_source.py
@@ -1,17 +1,25 @@
 import abc
-from typing import Literal, Union
+from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_postgres.model.data_source.postgres_connection_properties import (
     PostgresConnectionPassword,
     PostgresConnectionPasswordFile,
-    PostgresConnectionString,
+    PostgresConnectionProperties,
 )
 
 
 class PostgresDataSource(DataSourceBase, abc.ABC):
     type: Literal["postgres"]
-    connection_properties: Union[
-        PostgresConnectionPassword, PostgresConnectionPasswordFile, PostgresConnectionString
-    ] = Field(..., alias="connection", description="Data source connection details")
+    connection_properties: PostgresConnectionProperties = Field(
+        ..., alias="connection", description="Data source connection details"
+    )
+
+    @field_validator("connection_properties", mode="before")
+    def infer_connection_type(cls, value):
+        if "password" in value:
+            return PostgresConnectionPassword(**value)
+        elif "password_file" in value:
+            return PostgresConnectionPasswordFile(**value)
+        raise ValueError("Unknown connection structure")


### PR DESCRIPTION
First stab at using models for data source:
- no drastic changes, I contained myself to minimal scope so that we can review, merge and iterate quickly
- no actual validation using pydantic is done yet
- the packages are a mess, a more generic approach will follow

after all of the above is done, I will start with actual extra data source implementation. I want to get this at least somewhat right so that we don't pass around dicts for no reason, and so that the implementation is not too scattered. I am not super happy about how the three different classes compose a data source but I do get the intention to separate the mode from the connection and dialect. I will try to iterate on this design so that it's more intuitive to walk through and work with.