### PR TITLE
Fix remote contract detection logic to also consider local sources

### DIFF
--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -134,11 +134,10 @@ def all_none_or_empty(*args: list | None) -> bool:
     return all(x is None or len(x) == 0 for x in args)
 
 
-def is_using_remote_contract(contract_file_paths: Optional[list[str]], dataset_identifiers: Optional[list[str]]) -> bool:
-    return (
-        (contract_file_paths is None or len(contract_file_paths) == 0) and
-        dataset_identifiers is not None
-    )
+def is_using_remote_contract(
+    contract_file_paths: Optional[list[str]], dataset_identifiers: Optional[list[str]]
+) -> bool:
+    return (contract_file_paths is None or len(contract_file_paths) == 0) and dataset_identifiers is not None
 
 
 def is_using_remote_datasource(dataset_identifiers: Optional[list[str]], data_source_file_path: Optional[str]) -> bool:

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -101,7 +101,7 @@ def _create_datasource_yamls(
     if is_using_remote_datasource(dataset_identifiers, data_source_file_path) and soda_cloud_client:
         dataset_identifier = dataset_identifiers[0]
 
-        soda_logger.debug(f"No local data source config, trying to fetch data source config from cloud")
+        soda_logger.debug("No local data source config, trying to fetch data source config from cloud")
         data_source_config = soda_cloud_client.fetch_data_source_configuration_for_dataset(dataset_identifier)
         data_source_yaml_source = DataSourceYamlSource.from_str(data_source_config) if data_source_config else None
 

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -41,7 +41,7 @@ def handle_verify_contract(
         ContractYamlSource.from_file_path(contract_file_path) for contract_file_path in contract_file_paths or []
     ]
 
-    if is_using_remote_contract(dataset_identifiers) and soda_cloud_client:
+    if is_using_remote_contract(contract_file_paths, dataset_identifiers) and soda_cloud_client:
         for dataset_identifier in dataset_identifiers:
             contract = soda_cloud_client.fetch_contract_for_dataset(dataset_identifier)
             if not contract:
@@ -134,8 +134,11 @@ def all_none_or_empty(*args: list | None) -> bool:
     return all(x is None or len(x) == 0 for x in args)
 
 
-def is_using_remote_contract(dataset_identifiers: Optional[list[str]]) -> bool:
-    return dataset_identifiers is not None
+def is_using_remote_contract(contract_file_paths: Optional[list[str]], dataset_identifiers: Optional[list[str]]) -> bool:
+    return (
+        (contract_file_paths is None or len(contract_file_paths) == 0) and
+        dataset_identifiers is not None
+    )
 
 
 def is_using_remote_datasource(dataset_identifiers: Optional[list[str]], data_source_file_path: Optional[str]) -> bool:

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -35,7 +35,9 @@ def handle_verify_contract(
             SodaCloudYamlSource.from_file_path(soda_cloud_file_path), variables=None
         )
 
-    contract_yaml_sources, exit_code = _create_contract_yamls(contract_file_paths, dataset_identifiers, soda_cloud_client)
+    contract_yaml_sources, exit_code = _create_contract_yamls(
+        contract_file_paths, dataset_identifiers, soda_cloud_client
+    )
     if exit_code:
         return exit_code
 
@@ -50,7 +52,9 @@ def handle_verify_contract(
             f"Please pass a single dataset identifier."
         )
         return ExitCode.LOG_ERRORS
-    data_source_yaml_source, exit_code = _create_datasource_yamls(data_source_file_path, dataset_identifiers, soda_cloud_client)
+    data_source_yaml_source, exit_code = _create_datasource_yamls(
+        data_source_file_path, dataset_identifiers, soda_cloud_client
+    )
     if exit_code:
         return exit_code
 
@@ -77,9 +81,7 @@ def _create_contract_yamls(
     contract_yaml_sources = []
 
     if contract_file_paths:
-        contract_yaml_sources += [
-            ContractYamlSource.from_file_path(p) for p in contract_file_paths
-        ]
+        contract_yaml_sources += [ContractYamlSource.from_file_path(p) for p in contract_file_paths]
 
     if is_using_remote_contract(contract_file_paths, dataset_identifiers) and soda_cloud_client:
         for dataset_identifier in dataset_identifiers:


### PR DESCRIPTION
The old implementation only looked at the `--dataset` parameter, causing issues when passing that parameter to indicate using a remote data source configuration combined with a local contract.