### PR TITLE
Skip asserting data sources are valid objects when we're running remotely (on agent)

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -91,7 +91,7 @@ class ContractVerificationSessionImpl:
         else:
             assert isinstance(data_source_yaml_sources, list)
             assert all(
-                isinstance(data_source_yaml_source, DataSourceYamlSource)
+                isinstance(data_source_yaml_source, DataSourceYamlSource) or soda_cloud_use_agent
                 for data_source_yaml_source in data_source_yaml_sources
             )
 


### PR DESCRIPTION
There are no requirements for the datasource when running on agent.