### PR TITLE
Support remote contract verification without publishing

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -489,7 +489,10 @@ class SodaCloud:
         return allowed, reason
 
     def verify_contract_on_agent(
-        self, contract_yaml: ContractYaml, blocking_timeout_in_minutes: int
+        self,
+        contract_yaml: ContractYaml,
+        blocking_timeout_in_minutes: int,
+        publish_results: bool,
     ) -> ContractVerificationResult:
         contract_yaml_str_original: str = contract_yaml.contract_yaml_source.yaml_str_original
         contract_local_file_path: Optional[str] = contract_yaml.contract_yaml_source.file_path or "REMOTE"  # TODO
@@ -540,7 +543,7 @@ class SodaCloud:
             return []
 
         verify_contract_command: dict = {
-            "type": "sodaCoreVerifyContract",
+            "type": "sodaCoreVerifyContract" if publish_results else "sodaCoreTestContract",
             "contract": {
                 "fileId": file_id,
                 "dataset": {
@@ -549,7 +552,7 @@ class SodaCloud:
                     "name": dataset_identifier.dataset_name,
                 },
                 "metadata": {"source": {"type": "local", "filePath": contract_local_file_path}},
-            },
+            }
         }
         response: Response = self._execute_command(
             command_json_dict=verify_contract_command, request_log_name="verify_contract"

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -552,7 +552,7 @@ class SodaCloud:
                     "name": dataset_identifier.dataset_name,
                 },
                 "metadata": {"source": {"type": "local", "filePath": contract_local_file_path}},
-            }
+            },
         }
         response: Response = self._execute_command(
             command_json_dict=verify_contract_command, request_log_name="verify_contract"

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -121,6 +121,7 @@ class ContractVerificationSessionImpl:
                 soda_cloud_yaml_source=soda_cloud_yaml_source,
                 soda_cloud_impl=soda_cloud_impl,
                 soda_cloud_use_agent_blocking_timeout_in_minutes=soda_cloud_use_agent_blocking_timeout_in_minutes,
+                soda_cloud_publish_results=soda_cloud_publish_results,
             )
 
         else:
@@ -252,7 +253,8 @@ class ContractVerificationSessionImpl:
         variables: Optional[dict[str, str]],
         soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         soda_cloud_impl: Optional[SodaCloud],
-        soda_cloud_use_agent_blocking_timeout_in_minutes,
+        soda_cloud_use_agent_blocking_timeout_in_minutes: int,
+        soda_cloud_publish_results: bool
     ) -> list[ContractVerificationResult]:
         contract_verification_results: list[ContractVerificationResult] = []
 
@@ -268,6 +270,7 @@ class ContractVerificationSessionImpl:
                 contract_verification_result: ContractVerificationResult = soda_cloud_impl.verify_contract_on_agent(
                     contract_yaml=contract_yaml,
                     blocking_timeout_in_minutes=soda_cloud_use_agent_blocking_timeout_in_minutes,
+                    publish_results=soda_cloud_publish_results,
                 )
                 contract_verification_results.append(contract_verification_result)
             except:

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -254,7 +254,7 @@ class ContractVerificationSessionImpl:
         soda_cloud_yaml_source: Optional[SodaCloudYamlSource],
         soda_cloud_impl: Optional[SodaCloud],
         soda_cloud_use_agent_blocking_timeout_in_minutes: int,
-        soda_cloud_publish_results: bool
+        soda_cloud_publish_results: bool,
     ) -> list[ContractVerificationResult]:
         contract_verification_results: list[ContractVerificationResult] = []
 


### PR DESCRIPTION
- Pass publish flag value to `soda_cloud` call
- When not publishing, call `sodaCoreTestContract` API instead