### PR TITLE
DTL-633: add support for token authentication

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -113,8 +113,8 @@ class SodaCloud:
 
         return SodaCloud(
             host=soda_cloud_yaml_object.read_string_opt(key="host", default_value="cloud.soda.io"),
-            api_key_id=soda_cloud_yaml_object.read_string(key="api_key_id"),
-            api_key_secret=soda_cloud_yaml_object.read_string(key="api_key_secret"),
+            api_key_id=soda_cloud_yaml_object.read_string(key="api_key_id", required=False),
+            api_key_secret=soda_cloud_yaml_object.read_string(key="api_key_secret", required=False),
             token=soda_cloud_token,
             port=soda_cloud_yaml_object.read_string_opt(key="port"),
             scheme=soda_cloud_yaml_object.read_string_opt(key="scheme", default_value="https"),

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -99,7 +99,8 @@ class SodaCloud:
         if not soda_cloud_yaml_object:
             logger.debug("key 'soda_cloud' is required in a Soda Cloud configuration file.")
 
-        soda_cloud_token = os.environ.get("SODA_CLOUD_TOKEN")
+        if soda_cloud_token := os.environ.get("SODA_CLOUD_TOKEN"):
+            logger.debug("Found an authentication token in environment variables, ignoring API key authentication.")
 
         if not soda_cloud_token and not soda_cloud_yaml_object.has_key("api_key_id"):
             raise InvalidSodaCloudConfigurationException(

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -99,12 +99,14 @@ class SodaCloud:
         if not soda_cloud_yaml_object:
             logger.debug("key 'soda_cloud' is required in a Soda Cloud configuration file.")
 
-        if not soda_cloud_yaml_object.has_key("api_key_id"):
+        soda_cloud_token = os.environ.get("SODA_CLOUD_TOKEN")
+
+        if not soda_cloud_token and not soda_cloud_yaml_object.has_key("api_key_id"):
             raise InvalidSodaCloudConfigurationException(
                 f"Missing required 'api_key_id' property in your Soda Cloud configuration."
             )
 
-        if not soda_cloud_yaml_object.has_key("api_key_secret"):
+        if not soda_cloud_token and not soda_cloud_yaml_object.has_key("api_key_secret"):
             raise InvalidSodaCloudConfigurationException(
                 f"Missing required 'api_key_secret' property in your Soda Cloud configuration."
             )
@@ -113,7 +115,7 @@ class SodaCloud:
             host=soda_cloud_yaml_object.read_string_opt(key="host", default_value="cloud.soda.io"),
             api_key_id=soda_cloud_yaml_object.read_string(key="api_key_id"),
             api_key_secret=soda_cloud_yaml_object.read_string(key="api_key_secret"),
-            token=soda_cloud_yaml_object.read_string_opt(key="token"),
+            token=soda_cloud_token,
             port=soda_cloud_yaml_object.read_string_opt(key="port"),
             scheme=soda_cloud_yaml_object.read_string_opt(key="scheme", default_value="https"),
         )

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -319,12 +319,12 @@ class YamlObject(YamlValue):
         l = self.read_list(key, expected_element_type=str, required=False)
         return l.to_list() if isinstance(l, YamlList) else None
 
-    def read_string(self, key: str, env_var: Optional[str] = None) -> Optional[str]:
+    def read_string(self, key: str, env_var: Optional[str] = None, required: bool = True) -> Optional[str]:
         """
         An error is generated if the value is missing or not a string.
         :return: a str if the value for the key is a YAML string, otherwise None.
         """
-        return self.read_value(key=key, env_var=env_var, expected_type=str, required=True, default_value=None)
+        return self.read_value(key=key, env_var=env_var, expected_type=str, required=required, default_value=None)
 
     def read_string_opt(
         self, key: str, env_var: Optional[str] = None, default_value: Optional[str] = None

--- a/soda-core/tests/components/test_soda_cloud.py
+++ b/soda-core/tests/components/test_soda_cloud.py
@@ -1,8 +1,7 @@
-import pytest
-
 import os
 from datetime import datetime
 
+import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import (
     MockHttpMethod,

--- a/soda-core/tests/components/test_soda_cloud.py
+++ b/soda-core/tests/components/test_soda_cloud.py
@@ -1,3 +1,6 @@
+import pytest
+
+import os
 from datetime import datetime
 
 from helpers.data_source_test_helper import DataSourceTestHelper
@@ -9,7 +12,8 @@ from helpers.mock_soda_cloud import (
 )
 from helpers.test_table import TestTableSpecification
 from soda_core.common.datetime_conversions import convert_datetime_to_str
-from soda_core.common.yaml import ContractYamlSource
+from soda_core.common.soda_cloud import SodaCloud
+from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResult
 from soda_core.contracts.contract_verification import ContractVerificationResult
 from soda_core.contracts.impl.contract_yaml import ContractYaml
@@ -29,6 +33,41 @@ test_table_specification = (
     )
     .build()
 )
+
+
+def test_soda_cloud_from_yaml_source_with_api_key_auth():
+    yaml_source = SodaCloudYamlSource.from_str(
+        """
+        soda_cloud:
+          host: dev.sodadata.io
+          api_key_id: some_key_id
+          api_key_secret: some_key_secret
+        """
+    )
+    try:
+        soda_cloud = SodaCloud.from_yaml_source(yaml_source, variables={})
+        assert soda_cloud.api_key_id == "some_key_id"
+        assert soda_cloud.api_key_secret == "some_key_secret"
+        assert not soda_cloud.token
+    except Exception as exc:
+        pytest.fail("An unexpected exception occurred: {exc}")
+
+
+def test_soda_cloud_from_yaml_source_with_token_auth():
+    os.environ.update({"SODA_CLOUD_TOKEN": "some_token"})
+    yaml_source = SodaCloudYamlSource.from_str(
+        """
+        soda_cloud:
+          host: dev.sodadata.io
+        """
+    )
+    try:
+        soda_cloud = SodaCloud.from_yaml_source(yaml_source, variables={})
+        assert not soda_cloud.api_key_id
+        assert not soda_cloud.api_key_secret
+        assert soda_cloud.token == "some_token"
+    except Exception as exc:
+        pytest.fail("An unexpected exception occurred: {exc}")
 
 
 def test_soda_cloud_results(data_source_test_helper: DataSourceTestHelper, env_vars: dict):


### PR DESCRIPTION
An authentication token will be provided via an environment variable when running on a Soda-hosted agent. 

This PR ensures that:
- Soda cloud configuration file parsing doesn't fail when no API key id/secret are there
- The token is read from the env vars and provided to the `SodaCloud` instance, which should sidestep requesting a token using the API key credentials
- There's some debug logging when the env var token is used to authenticate