### PR TITLE
Datasources: pass through connection properties as kwargs, add magic

### DIFF
--- a/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
+++ b/soda-core/src/soda_core/model/data_source/data_source_connection_properties.py
@@ -1,13 +1,44 @@
 from abc import ABC
+from typing import ClassVar, Dict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class DataSourceConnectionProperties(
     BaseModel,
     ABC,
     frozen=True,
-    extra="forbid",
-    validate_by_name=True,  # Allow to use both field names and aliases when populating from dict
+    extra="allow",
+    validate_by_name=True,
 ):
-    pass
+    field_mapping: ClassVar[Dict[str, str]] = {}
+
+    def to_connection_kwargs(self) -> dict:
+        data = self.model_dump()  # Pydantic v2
+        model_fields = set(self.__pydantic_fields__.keys())
+
+        # Known fields (declared ones)
+        known_fields = {field_name: value for field_name, value in data.items() if field_name in model_fields}
+
+        # Unknown fields (dynamic extras)
+        unknown_fields = {field_name: value for field_name, value in data.items() if field_name not in model_fields}
+
+        # Apply field renaming if mapping exists
+        mapped_known_fields = {}
+        for k, v in known_fields.items():
+            output_key = self.field_mapping.get(k, k)  # Rename if mapped, otherwise same name
+            if v is not None:
+                mapped_known_fields[output_key] = v
+
+        # Merge known and unknown fields
+        all_kwargs = {**mapped_known_fields, **unknown_fields}
+
+        # Final cleaning: unwrap secrets + drop None
+        cleaned_kwargs = {}
+        for k, v in all_kwargs.items():
+            if isinstance(v, SecretStr):
+                v = v.get_secret_value()
+            if v is not None:
+                cleaned_kwargs[k] = v
+
+        return cleaned_kwargs

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -26,7 +26,7 @@ class DatabricksDataSourceConnection(DataSourceConnection):
         config: DatabricksConnectionProperties,
     ):
         return sql.connect(
-            _user_agent_entry="Soda Core",
+            user_agent_entry="Soda Core",
             **config.to_connection_kwargs(),
         )
 

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Literal, Optional, Dict, Literal
+from typing import Literal, Optional, Dict, Literal, ClassVar
 
 from pydantic import Field, SecretStr
 from soda_core.model.data_source.data_source import DataSourceBase
@@ -9,32 +9,20 @@ from soda_core.model.data_source.data_source_connection_properties import (
 )
 
 
-class DatabricksConnectionProperties(DataSourceConnectionProperties, ABC):
-    @abstractmethod
-    def to_connection_kwargs(self) -> dict: ...
+class DatabricksConnectionProperties(DataSourceConnectionProperties, ABC): ...
 
 
 class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
     host: str = Field(..., description="Databricks workspace hostname (e.g. 'abc.cloud.databricks.com')")
     http_path: str = Field(..., description="HTTP path for the SQL endpoint or cluster")
-    catalog: str = Field(None, description="Optional default catalog to use")
+    catalog: str = Field(None, description="Default catalog to use")
     warehouse: Optional[str] = Field(None, description="Optional warehouse")
     session_configuration: Optional[Dict[str, str]] = Field(None, description="Optional session configuration dict")
 
-    def to_connection_kwargs(self) -> dict:
-        return {
-            "server_hostname": self.host,
-            "http_path": self.http_path,
-            "catalog": self.catalog,
-            "warehouse": self.warehouse,
-            "session_configuration": self.session_configuration,
-        }
+    field_mapping: ClassVar[Dict[str, str]] = {
+        "host": "server_hostname",
+    }
 
 
 class DatabricksTokenAuth(DatabricksSharedConnectionProperties):
     access_token: SecretStr = Field(..., description="Personal access token")
-
-    def to_connection_kwargs(self) -> dict:
-        kwargs = super().to_connection_kwargs()
-        kwargs["access_token"] = self.access_token.get_secret_value()
-        return kwargs

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Union
-
 import psycopg2
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
 )
 from soda_postgres.model.data_source.postgres_connection_properties import (
-    PostgresConnectionPassword,
-    PostgresConnectionPasswordFile,
-    PostgresConnectionString,
+    PostgresConnectionProperties,
 )
 
 
@@ -21,38 +16,6 @@ class PostgresDataSourceConnection(DataSourceConnection):
 
     def _create_connection(
         self,
-        config: Union[PostgresConnectionString, PostgresConnectionPassword, PostgresConnectionPasswordFile],
+        config: PostgresConnectionProperties,
     ):
-        if isinstance(config, PostgresConnectionString):
-            if config.connection_string:
-                return psycopg2.connect(config.connection_string)
-            else:
-                raise ValueError("PostgresConnectionString must have `connection_string`")
-
-        conn_kwargs = {
-            "host": str(config.host),
-            "port": config.port,
-            "dbname": config.database,
-            "user": config.user,
-            "sslmode": config.ssl_mode,
-        }
-
-        # SSL certs
-        if config.ssl_cert:
-            conn_kwargs["sslcert"] = config.ssl_cert
-        if config.ssl_key:
-            conn_kwargs["sslkey"] = config.ssl_key
-        if config.ssl_root_cert:
-            conn_kwargs["sslrootcert"] = config.ssl_root_cert
-
-        # Password
-        if isinstance(config, PostgresConnectionPassword):
-            conn_kwargs["password"] = config.password.get_secret_value()
-        elif isinstance(config, PostgresConnectionPasswordFile):
-            conn_kwargs["password"] = Path(config.password_file).read_text().strip()
-
-        # Timeout
-        if config.connection_timeout:
-            conn_kwargs["connect_timeout"] = config.connection_timeout
-
-        return psycopg2.connect(**conn_kwargs)
+        return psycopg2.connect(**config.to_connection_kwargs())

--- a/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
+++ b/soda-postgres/src/soda_postgres/model/data_source/postgres_connection_properties.py
@@ -23,12 +23,12 @@ class PostgresConnectionPropertiesBase(PostgresConnectionProperties, ABC):
     user: str = Field(..., description="Database user (1-63 characters)", min_length=1, max_length=63)
 
     # SSL configuration
-    ssl_mode: Literal["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] = Field(
+    sslmode: Literal["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] = Field(
         "prefer", description="SSL mode for the connection"
     )
-    ssl_cert: Optional[str] = Field(None, description="Path to SSL client certificate")
-    ssl_key: Optional[str] = Field(None, description="Path to SSL client key")
-    ssl_root_cert: Optional[str] = Field(None, description="Path to SSL root certificate")
+    sslcert: Optional[str] = Field(None, description="Path to SSL client certificate")
+    sslkey: Optional[str] = Field(None, description="Path to SSL client key")
+    sslrootcert: Optional[str] = Field(None, description="Path to SSL root certificate")
 
     # Connection options
     connection_timeout: Optional[int] = Field(None, description="Connection timeout in seconds")

--- a/soda-snowflake/src/soda_snowflake/model/data_source/snowflake_connection_properties.py
+++ b/soda-snowflake/src/soda_snowflake/model/data_source/snowflake_connection_properties.py
@@ -22,24 +22,9 @@ class SnowflakeSharedConnectionProperties(SnowflakeConnectionProperties, ABC):
     session_parameters: Optional[Dict[str, str]] = Field(None, description="Session-level parameters")
     host: Optional[str] = Field(None, description="Host name of the Snowflake account")
 
-    def to_connection_kwargs(self) -> dict:
-        return {
-            "account": self.account,
-            "user": self.user,
-            "warehouse": self.warehouse,
-            "database": self.database,
-            "role": self.role,
-            "session_parameters": self.session_parameters,
-        }
-
 
 class SnowflakePasswordAuth(SnowflakeSharedConnectionProperties):
     password: SecretStr = Field(..., description="User password")
-
-    def to_connection_kwargs(self) -> dict:
-        base = super().to_connection_kwargs()
-        base["password"] = self.password.get_secret_value()
-        return base
 
 
 class SnowflakeKeyPairAuth(SnowflakeSharedConnectionProperties):
@@ -54,25 +39,10 @@ class SnowflakeKeyPairAuth(SnowflakeSharedConnectionProperties):
 class SnowflakeJWTAuth(SnowflakeSharedConnectionProperties):
     jwt_token: SecretStr = Field(..., description="JWT token for authentication")
 
-    def to_connection_kwargs(self) -> dict:
-        base = super().to_connection_kwargs()
-        base["token"] = self.jwt_token.get_secret_value()
-        return base
-
 
 class SnowflakeOAuthAuth(SnowflakeSharedConnectionProperties):
     token: SecretStr = Field(..., description="OAuth access token")
 
-    def to_connection_kwargs(self) -> dict:
-        base = super().to_connection_kwargs()
-        base["token"] = self.token.get_secret_value()
-        return base
-
 
 class SnowflakeSSOAuth(SnowflakeSharedConnectionProperties):
     authenticator: Literal["externalbrowser"] = Field("externalbrowser", description="Use external browser SSO login")
-
-    def to_connection_kwargs(self) -> dict:
-        base = super().to_connection_kwargs()
-        base["authenticator"] = self.authenticator
-        return base


### PR DESCRIPTION
- Passes kwargs as-is to driver
- Adds a bit of magic to handle secrets and connection dicts to simplify datasource specific code
- Adds support to use different name in yaml key and what is passed to the driver for controlled UX