### PR TITLE
DTL-617: small various changes

### DIFF
--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -44,7 +44,7 @@ def handle_verify_contract(
             )
 
         data_source_yaml_source = _create_datasource_yamls(
-            data_source_file_path, dataset_identifiers, soda_cloud_client
+            data_source_file_path, dataset_identifiers, soda_cloud_client, use_agent,
         )
 
         contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(
@@ -96,7 +96,8 @@ def _create_datasource_yamls(
     data_source_file_path: Optional[str],
     dataset_identifiers: Optional[list[str]],
     soda_cloud_client: SodaCloud,
-) -> DataSourceYamlSource:
+    use_agent: bool,
+) -> Optional[DataSourceYamlSource]:
     if data_source_file_path:
         return DataSourceYamlSource.from_file_path(data_source_file_path)
 
@@ -112,6 +113,11 @@ def _create_datasource_yamls(
         data_source_config = soda_cloud_client.fetch_data_source_configuration_for_dataset(dataset_identifier)
 
         return DataSourceYamlSource.from_str(data_source_config)
+
+    # By this point, we can only progress if we are using an agent.
+    # Then the agent will provide the data source config.
+    if use_agent:
+        return None
 
     raise InvalidDataSourceConfigurationException(
         "No data source configuration provided and no dataset identifiers given. "

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -44,7 +44,10 @@ def handle_verify_contract(
             )
 
         data_source_yaml_source = _create_datasource_yamls(
-            data_source_file_path, dataset_identifiers, soda_cloud_client, use_agent,
+            data_source_file_path,
+            dataset_identifiers,
+            soda_cloud_client,
+            use_agent,
         )
 
         contract_verification_session_result: ContractVerificationSessionResult = ContractVerificationSession.execute(

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -193,7 +193,7 @@ class SodaCloud:
         Marks a scan as failed in Soda Cloud. This is used when the scan fails before we have any results to send.
         """
         if not scan_id:
-            if not "SODA_SCAN_ID" in os.environ:
+            if "SODA_SCAN_ID" not in os.environ:
                 logger.debug("No scan ID provided, not marking scan as failed")
                 return
             scan_id = os.environ["SODA_SCAN_ID"]

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1061,7 +1061,7 @@ def _build_log_cloud_json_dict(log_record: LogRecord, index: int) -> dict:
 def _exception_to_cloud_log_dict(exception: Exception) -> dict:
     return {
         "level": "error",
-        "message": "An exception occurred",
+        "message": f"An exception occurred: {str(exception)}",
         "timestamp": datetime.now(timezone.utc),
         "index": 0,
         "exception": str(exception),


### PR DESCRIPTION
Small changes wrapping up the exception flow for remote execution in core:

- Fixed an issue where data source configuration was no longer optional when running remote
- Add exception details to the log record transmitted as part of the `mark_scan_as_failed` API call
- Quick nit on membership tests