### PR TITLE
DTL-548: Raise more understandable error when an invalid regex is passed

### DIFF
--- a/soda-core/src/soda_core/common/exceptions.py
+++ b/soda-core/src/soda_core/common/exceptions.py
@@ -1,4 +1,5 @@
 from soda_core.common.dataset_identifier import DatasetIdentifier
+from typing import Optional
 
 
 class SodaCoreException(Exception):
@@ -31,6 +32,22 @@ class DataSourceConnectionException(SodaCoreException):
 
 class InvalidContractException(SodaCoreException):
     """Base class for all invalid contract exceptions."""
+
+
+class InvalidRegexException(InvalidContractException):
+    """Indicates the regex is invalid."""
+
+    def __init__(self, sql: str):
+        super().__init__(f"Invalid regex found in SQL '{sql}'")
+
+    @classmethod
+    def should_raise(cls, exception: Exception, sql: str) -> Optional["InvalidRegexException"]:
+        if (
+            hasattr(exception, "args")
+            and exception.args[0] == "invalid regular expression: quantifier operand invalid\n"
+        ):
+            return cls(sql)
+        return None
 
 
 class InvalidDatasetQualifiedNameException(InvalidContractException):
@@ -69,3 +86,5 @@ class DatasetNotFoundException(SodaCloudException):
             f"Dataset '{dataset_identifier.dataset_name}' is unknown in Soda Cloud. "
             "Please verify the dataset name or configure it in Soda Cloud."
         )
+
+

--- a/soda-core/src/soda_core/common/exceptions.py
+++ b/soda-core/src/soda_core/common/exceptions.py
@@ -1,5 +1,6 @@
-from soda_core.common.dataset_identifier import DatasetIdentifier
 from typing import Optional
+
+from soda_core.common.dataset_identifier import DatasetIdentifier
 
 
 class SodaCoreException(Exception):
@@ -86,5 +87,3 @@ class DatasetNotFoundException(SodaCloudException):
             f"Dataset '{dataset_identifier.dataset_name}' is unknown in Soda Cloud. "
             "Please verify the dataset name or configure it in Soda Cloud."
         )
-
-

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -11,7 +11,7 @@ from soda_core.common.consistent_hash_builder import ConsistentHashBuilder
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.dataset_identifier import DatasetIdentifier
-from soda_core.common.exceptions import SodaCoreException
+from soda_core.common.exceptions import SodaCoreException, InvalidRegexException
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.soda_cloud import SodaCloud
@@ -1293,6 +1293,8 @@ class AggregationQuery(Query):
         try:
             query_result: QueryResult = self.data_source_impl.execute_query(sql)
         except Exception as e:
+            if invalid_regex_exc:=InvalidRegexException.should_raise(e, sql):
+                raise invalid_regex_exc
             raise SodaCoreException(f"Could not execute aggregation query: {e}") from e
 
         measurements: list[Measurement] = []

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -11,7 +11,7 @@ from soda_core.common.consistent_hash_builder import ConsistentHashBuilder
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.dataset_identifier import DatasetIdentifier
-from soda_core.common.exceptions import SodaCoreException, InvalidRegexException
+from soda_core.common.exceptions import InvalidRegexException, SodaCoreException
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.soda_cloud import SodaCloud
@@ -1293,7 +1293,7 @@ class AggregationQuery(Query):
         try:
             query_result: QueryResult = self.data_source_impl.execute_query(sql)
         except Exception as e:
-            if invalid_regex_exc:=InvalidRegexException.should_raise(e, sql):
+            if invalid_regex_exc := InvalidRegexException.should_raise(e, sql):
                 raise invalid_regex_exc
             raise SodaCoreException(f"Could not execute aggregation query: {e}") from e
 


### PR DESCRIPTION
This PR introduces a new `InvalidRegexException`, subclass of the `InvalidContractException` tree (not sure if it belongs there). 

It will be raised whenever a runtime exception is raised BY THE DATASOURCE mentioning the regex.
This approach is good because:
- the datasource decides what regex to accept
- can be tailored to each datasource individually

But it is bad because:
- it is tailored to each datasource individually, so implementations are very dependent on the data source (and we should consider moving this as part of an interface implemented by the datasource)


Alternative: implement this kind of verification (if we want it) in the `RegexFormat` class and apply it during its `read` method? This does mean Python regexes will be THE standard for regexes.