### PR TITLE
DTL-547: Deal with empty lists for `valid_values` and `invalid_values` in invalid checks

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -620,12 +620,16 @@ class MissingAndValidity:
             literal_values = [LITERAL(value) for value in self.valid_values if value is not None]
             if None in self.valid_values:
                 invalid_clauses.append(AND([NOT(IN(column_name, literal_values)), IS_NOT_NULL(column_name)]))
+            elif not self.valid_values:
+                invalid_clauses.append(AND([LITERAL(True)]))
             else:
                 invalid_clauses.append(NOT(IN(column_name, literal_values)))
         if isinstance(self.invalid_values, list):
             literal_values = [LITERAL(value) for value in self.invalid_values if value is not None]
             if None in self.invalid_values:
                 invalid_clauses.append(AND([IN(column_name, literal_values), IS_NULL(column_name)]))
+            elif not self.invalid_values:
+                invalid_clauses.append(AND([LITERAL(False)]))
             else:
                 invalid_clauses.append(IN(column_name, literal_values))
         if isinstance(self.valid_format, RegexFormat) and isinstance(self.valid_format.regex, str):


### PR DESCRIPTION
- empty `valid_values` -> all are treated as invalid
- empty `invalid_values` -> all are treated as valid