### PR TITLE
Add the library version to file upload API calls.

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -277,7 +277,7 @@ class SodaCloud:
                     "Content-Type": "application/yaml",
                     "Is-V3": "true",
                     "File-Path": soda_cloud_file_path,
-                    "Soda-Library-Version": clean_soda_core_version()
+                    "Soda-Library-Version": clean_soda_core_version(),
                 }
 
                 if file_size_in_bytes == 0:

--- a/soda-core/src/soda_core/common/version.py
+++ b/soda-core/src/soda_core/common/version.py
@@ -8,7 +8,7 @@ def clean_soda_core_version() -> str:
 
 
 def clean_semver(version_str) -> str:
-    match = re.match(r'^(\d+\.\d+\.\d+)', version_str)
+    match = re.match(r"^(\d+\.\d+\.\d+)", version_str)
     if match:
         return match.group(1)
     else:


### PR DESCRIPTION
File upload calls can get blocked as a result of some server side settings when the library version is too old (or not specified). It is thus good practice to always send the library version when making these calls.

This PR adds the `Soda-Library-Version` header to the API call. It requires a "clean semver version string" (no suffixes) so added a little helper to get that from the included (and automatically updated) `version.py` file.