### PR TITLE
feat(cli): add contract fetch command

### DIFF
--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -237,13 +237,13 @@ def handle_test_contract(
     return ExitCode.OK
 
 
-def handle_pull_contract(
+def handle_fetch_contract(
     contract_file_paths: Optional[list[str]],
     dataset_identifiers: Optional[list[str]],
     soda_cloud_client: Optional[SodaCloud],
 ) -> ExitCode:
     try:
-        validate_pull_arguments(contract_file_paths, dataset_identifiers, soda_cloud_client)
+        validate_fetch_arguments(contract_file_paths, dataset_identifiers, soda_cloud_client)
 
         # fetch contract YAML strings
         contract_yaml_sources = []
@@ -252,7 +252,7 @@ def handle_pull_contract(
                 contract = soda_cloud_client.fetch_contract_for_dataset(dataset_identifier)
                 if not contract:
                     soda_logger.error(
-                        f"Could not fetch contract for dataset '{dataset_identifier}': skipping pull")
+                        f"Could not fetch contract for dataset '{dataset_identifier}': skipping fetch")
                     continue
                 contract_yaml_sources.append(ContractYamlSource.from_str(contract))
         if not contract_yaml_sources or len(contract_yaml_sources) == 0:
@@ -283,24 +283,24 @@ def handle_pull_contract(
         return ExitCode.LOG_ERRORS
 
 
-def validate_pull_arguments(
+def validate_fetch_arguments(
     contract_file_paths: Optional[list[str]],
     dataset_identifiers: Optional[list[str]],
     soda_cloud_client: Optional[SodaCloud],
 ) -> None:
     if not contract_file_paths:
         raise InvalidArgumentException(
-            "A Soda Data Contract file path is required to use the pull command. "
+            "A Soda Data Contract file path is required to use the fetch command. "
             "Please provide the '-c/--contract' argument with a valid contract file path."
         )
     if not dataset_identifiers:
         raise InvalidArgumentException(
-            "A Soda Cloud dataset identifier is required to use the pull command. "
+            "A Soda Cloud dataset identifier is required to use the fetch command. "
             "Please provide the '-d/--dataset' argument with a valid dataset identifier."
         )
     if not soda_cloud_client:
         raise InvalidArgumentException(
-            "A Soda Cloud configuration file is required to use the pull command. "
+            "A Soda Cloud configuration file is required to use the fetch command. "
             "Please provide the '--soda-cloud' argument with a valid configuration file path."
         )
     if len(contract_file_paths) != len(dataset_identifiers):

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -249,8 +249,7 @@ def handle_pull_contract(
             for dataset_identifier in dataset_identifiers:
                 contract = soda_cloud_client.fetch_contract_for_dataset(dataset_identifier)
                 if not contract:
-                    soda_logger.error(
-                        f"Could not fetch contract for dataset '{dataset_identifier}': skipping pull")
+                    soda_logger.error(f"Could not fetch contract for dataset '{dataset_identifier}': skipping pull")
                     continue
                 contract_yaml_sources.append(ContractYamlSource.from_str(contract))
         if not contract_yaml_sources or len(contract_yaml_sources) == 0:
@@ -259,7 +258,7 @@ def handle_pull_contract(
 
         # write to local contract YAML files
         for contract_file_path, contract_yaml in zip(contract_file_paths, contract_yaml_sources):
-            with open(contract_file_path, 'w') as contract_file:
+            with open(contract_file_path, "w") as contract_file:
                 contract_file.write(contract_yaml.yaml_str)
 
         return ExitCode.OK

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -1,4 +1,6 @@
 from typing import Dict, Optional
+from os.path import dirname, exists
+from pathlib import Path
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.exceptions import (
@@ -262,7 +264,7 @@ def handle_pull_contract(
             dir_name = dirname(contract_file_path)
             try:
                 Path(dir_name).mkdir(parents=True, exist_ok=True)
-                if os.path.exists(contract_file_path):
+                if exists(contract_file_path):
                     action = "Updated"
                 else:
                     action = "Created"

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -1,6 +1,6 @@
-from typing import Dict, Optional
 from os.path import dirname, exists
 from pathlib import Path
+from typing import Dict, Optional
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.exceptions import (
@@ -251,8 +251,7 @@ def handle_fetch_contract(
             for dataset_identifier in dataset_identifiers:
                 contract = soda_cloud_client.fetch_contract_for_dataset(dataset_identifier)
                 if not contract:
-                    soda_logger.error(
-                        f"Could not fetch contract for dataset '{dataset_identifier}': skipping fetch")
+                    soda_logger.error(f"Could not fetch contract for dataset '{dataset_identifier}': skipping fetch")
                     continue
                 contract_yaml_sources.append(ContractYamlSource.from_str(contract))
         if not contract_yaml_sources or len(contract_yaml_sources) == 0:
@@ -268,7 +267,7 @@ def handle_fetch_contract(
                     action = "Updated"
                 else:
                     action = "Created"
-                with open(contract_file_path, 'w') as contract_file:
+                with open(contract_file_path, "w") as contract_file:
                     contract_file.write(contract_yaml.yaml_str)
                 soda_logger.info(f"{Emoticons.WHITE_CHECK_MARK}  {action} contract source file '{contract_file_path}'")
                 return ExitCode.OK

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -270,7 +270,7 @@ def handle_fetch_contract(
                     action = "Created"
                 with open(contract_file_path, 'w') as contract_file:
                     contract_file.write(contract_yaml.yaml_str)
-                soda_logger.info(f"{Emoticons.WHITE_CHECK_MARK} {action} contract source file '{contract_file_path}'")
+                soda_logger.info(f"{Emoticons.WHITE_CHECK_MARK}  {action} contract source file '{contract_file_path}'")
                 return ExitCode.OK
             except Exception as exc:
                 soda_logger.error(f"An unexpected exception occurred: {exc}")

--- a/soda-core/src/soda_core/cli/soda.py
+++ b/soda-core/src/soda_core/cli/soda.py
@@ -8,10 +8,10 @@ from typing import Dict, List, Optional
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.contract import (
+    handle_fetch_contract,
     handle_publish_contract,
     handle_test_contract,
     handle_verify_contract,
-    handle_fetch_contract
 )
 from soda_core.cli.handlers.data_source import (
     handle_create_data_source,
@@ -273,7 +273,6 @@ def _setup_contract_fetch_command(contract_parsers) -> None:
         type=str,
         nargs="+",
         help="The path(s) to the contract files to be created or updated. (directories will be created if needed)",
-
     )
     fetch_parser.add_argument(
         "-v",
@@ -290,11 +289,7 @@ def _setup_contract_fetch_command(contract_parsers) -> None:
         soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path)
         dataset_identifiers = args.dataset
 
-        exit_code = handle_fetch_contract(
-            contract_file_paths,
-            dataset_identifiers,
-            soda_cloud_client
-        )
+        exit_code = handle_fetch_contract(contract_file_paths, dataset_identifiers, soda_cloud_client)
         exit_with_code(exit_code)
 
     fetch_parser.set_defaults(handler_func=handle)

--- a/soda-core/src/soda_core/cli/soda.py
+++ b/soda-core/src/soda_core/cli/soda.py
@@ -11,6 +11,7 @@ from soda_core.cli.handlers.contract import (
     handle_publish_contract,
     handle_test_contract,
     handle_verify_contract,
+    handle_pull_contract
 )
 from soda_core.cli.handlers.data_source import (
     handle_create_data_source,
@@ -81,6 +82,7 @@ def _setup_contract_resource(resource_parsers) -> None:
     _setup_contract_verify_command(contract_subparsers)
     _setup_contract_publish_command(contract_subparsers)
     _setup_contract_test_command(contract_subparsers)
+    _setup_contract_pull_command(contract_subparsers)
 
 
 def _setup_contract_verify_command(contract_parsers) -> None:
@@ -247,6 +249,55 @@ def _setup_contract_test_command(contract_parsers) -> None:
         exit_with_code(exit_code)
 
     test_contract_parser.set_defaults(handler_func=handle)
+
+
+def _setup_contract_pull_command(contract_parsers) -> None:
+    pull_parser = contract_parsers.add_parser("pull", help="Pull a contract")
+    pull_parser.add_argument(
+        "-d",
+        "--dataset",
+        type=str,
+        nargs="+",
+        help="Fully qualified names of datasets whose cloud contracts you wish to fetch.",
+    )
+    pull_parser.add_argument(
+        "-sc",
+        "--soda-cloud",
+        type=str,
+        help="A Soda Cloud configuration file path.",
+        required=True,
+    )
+    pull_parser.add_argument(
+        "-c",
+        "--contract",
+        type=str,
+        nargs="+",
+        help="One or more contract file paths."
+    )
+
+    pull_parser.add_argument(
+        "-v",
+        "--verbose",
+        const=True,
+        action="store_const",
+        default=False,
+        help="Show more detailed logs on the console.",
+    )
+
+    def handle(args):
+        contract_file_paths = args.contract
+        soda_cloud_file_path = args.soda_cloud
+        soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path)
+        dataset_identifiers = args.dataset
+
+        exit_code = handle_pull_contract(
+            contract_file_paths,
+            dataset_identifiers,
+            soda_cloud_client
+        )
+        exit_with_code(exit_code)
+
+    pull_parser.set_defaults(handler_func=handle)
 
 
 def _setup_data_source_resource(resource_parsers) -> None:

--- a/soda-core/src/soda_core/cli/soda.py
+++ b/soda-core/src/soda_core/cli/soda.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Optional
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.contract import (
     handle_publish_contract,
-    handle_pull_contract,
     handle_test_contract,
     handle_verify_contract,
+    handle_pull_contract
 )
 from soda_core.cli.handlers.data_source import (
     handle_create_data_source,
@@ -267,8 +267,14 @@ def _setup_contract_pull_command(contract_parsers) -> None:
         help="A Soda Cloud configuration file path.",
         required=True,
     )
-    pull_parser.add_argument("-c", "--contract", type=str, nargs="+", help="One or more contract file paths.")
+    pull_parser.add_argument(
+        "-f",
+        "--file",
+        type=str,
+        nargs="+",
+        help="The path(s) to the contract files to be created or updated. (directories will be created if needed)",
 
+    )
     pull_parser.add_argument(
         "-v",
         "--verbose",
@@ -279,12 +285,16 @@ def _setup_contract_pull_command(contract_parsers) -> None:
     )
 
     def handle(args):
-        contract_file_paths = args.contract
+        contract_file_paths = args.file
         soda_cloud_file_path = args.soda_cloud
         soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path)
         dataset_identifiers = args.dataset
 
-        exit_code = handle_pull_contract(contract_file_paths, dataset_identifiers, soda_cloud_client)
+        exit_code = handle_pull_contract(
+            contract_file_paths,
+            dataset_identifiers,
+            soda_cloud_client
+        )
         exit_with_code(exit_code)
 
     pull_parser.set_defaults(handler_func=handle)

--- a/soda-core/src/soda_core/cli/soda.py
+++ b/soda-core/src/soda_core/cli/soda.py
@@ -11,7 +11,7 @@ from soda_core.cli.handlers.contract import (
     handle_publish_contract,
     handle_test_contract,
     handle_verify_contract,
-    handle_pull_contract
+    handle_fetch_contract
 )
 from soda_core.cli.handlers.data_source import (
     handle_create_data_source,
@@ -82,7 +82,7 @@ def _setup_contract_resource(resource_parsers) -> None:
     _setup_contract_verify_command(contract_subparsers)
     _setup_contract_publish_command(contract_subparsers)
     _setup_contract_test_command(contract_subparsers)
-    _setup_contract_pull_command(contract_subparsers)
+    _setup_contract_fetch_command(contract_subparsers)
 
 
 def _setup_contract_verify_command(contract_parsers) -> None:
@@ -251,23 +251,23 @@ def _setup_contract_test_command(contract_parsers) -> None:
     test_contract_parser.set_defaults(handler_func=handle)
 
 
-def _setup_contract_pull_command(contract_parsers) -> None:
-    pull_parser = contract_parsers.add_parser("pull", help="Pull a contract")
-    pull_parser.add_argument(
+def _setup_contract_fetch_command(contract_parsers) -> None:
+    fetch_parser = contract_parsers.add_parser("fetch", help="Pull a contract")
+    fetch_parser.add_argument(
         "-d",
         "--dataset",
         type=str,
         nargs="+",
         help="Fully qualified names of datasets whose cloud contracts you wish to fetch.",
     )
-    pull_parser.add_argument(
+    fetch_parser.add_argument(
         "-sc",
         "--soda-cloud",
         type=str,
         help="A Soda Cloud configuration file path.",
         required=True,
     )
-    pull_parser.add_argument(
+    fetch_parser.add_argument(
         "-f",
         "--file",
         type=str,
@@ -275,7 +275,7 @@ def _setup_contract_pull_command(contract_parsers) -> None:
         help="The path(s) to the contract files to be created or updated. (directories will be created if needed)",
 
     )
-    pull_parser.add_argument(
+    fetch_parser.add_argument(
         "-v",
         "--verbose",
         const=True,
@@ -290,14 +290,14 @@ def _setup_contract_pull_command(contract_parsers) -> None:
         soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path)
         dataset_identifiers = args.dataset
 
-        exit_code = handle_pull_contract(
+        exit_code = handle_fetch_contract(
             contract_file_paths,
             dataset_identifiers,
             soda_cloud_client
         )
         exit_with_code(exit_code)
 
-    pull_parser.set_defaults(handler_func=handle)
+    fetch_parser.set_defaults(handler_func=handle)
 
 
 def _setup_data_source_resource(resource_parsers) -> None:

--- a/soda-core/src/soda_core/cli/soda.py
+++ b/soda-core/src/soda_core/cli/soda.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Optional
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.contract import (
     handle_publish_contract,
+    handle_pull_contract,
     handle_test_contract,
     handle_verify_contract,
-    handle_pull_contract
 )
 from soda_core.cli.handlers.data_source import (
     handle_create_data_source,
@@ -267,13 +267,7 @@ def _setup_contract_pull_command(contract_parsers) -> None:
         help="A Soda Cloud configuration file path.",
         required=True,
     )
-    pull_parser.add_argument(
-        "-c",
-        "--contract",
-        type=str,
-        nargs="+",
-        help="One or more contract file paths."
-    )
+    pull_parser.add_argument("-c", "--contract", type=str, nargs="+", help="One or more contract file paths.")
 
     pull_parser.add_argument(
         "-v",
@@ -290,11 +284,7 @@ def _setup_contract_pull_command(contract_parsers) -> None:
         soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path)
         dataset_identifiers = args.dataset
 
-        exit_code = handle_pull_contract(
-            contract_file_paths,
-            dataset_identifiers,
-            soda_cloud_client
-        )
+        exit_code = handle_pull_contract(contract_file_paths, dataset_identifiers, soda_cloud_client)
         exit_with_code(exit_code)
 
     pull_parser.set_defaults(handler_func=handle)


### PR DESCRIPTION
## Summary
As discussed on slack [here](https://sodadata.slack.com/archives/C08AAF7EEJD/p1747784568119889), I thought it would be nice to have a `contract pull` command in soda core. So, I am proposing these changes to add such a `contract pull` command. The command requires three arguments (`-d`, `-c` and `-sc`) as described here:
```
usage: soda contract pull [-h] [-d DATASET [DATASET ...]] -sc SODA_CLOUD [-c CONTRACT [CONTRACT ...]] [-v]

options:
  -h, --help            show this help message and exit
  -d DATASET [DATASET ...], --dataset DATASET [DATASET ...]
                        Fully qualified names of datasets whose cloud contracts you wish to fetch.
  -sc SODA_CLOUD, --soda-cloud SODA_CLOUD
                        A Soda Cloud configuration file path.
  -c CONTRACT [CONTRACT ...], --contract CONTRACT [CONTRACT ...]
                        One or more contract file paths.
  -v, --verbose         Show more detailed logs on the console.
```
The command fetches the contract YAML strings from Soda Cloud for a given dataset and then writes these strings to the given YAML file paths. The command re-uses the same `soda_cloud_client.fetch_contract_for_dataset(dataset_identifier)` method used by the `contract verify` command. 

## Example usage
```shell
soda contract pull -d demo_unity_catalog/unity_catalog/tyler/obs_test_data -sc sc.yml -c /Users/adkinsty/PycharmProjects/soda-core-contracts/obs_test_data.yml
```
Prints:
```
  __|  _ \|  \   \\
\__ \ (   |   | _ \\
____/\___/___/_/  _\\ CLI 4.0.0.dev??
📜 Fetching contract from Soda Cloud for dataset 'demo_unity_catalog/unity_catalog/tyler/obs_test_data'
``` 
And then a new file is created at `/Users/adkinsty/PycharmProjects/soda-core-contracts/obs_test_data.yml` with the following contents:
```yaml
dataset: demo_unity_catalog/unity_catalog/tyler/obs_test_data
filter: timestamps >= current_timestamp() - INTERVAL 1 DAY
soda_agent:
  checks_schedule:
    cron: 0 8 * * *
    timezone: America/New_York
checks:
  - row_count:
      name: Table is not empty
  - freshness:
      column: timestamps
      name: Data is less than 48 hrs old
      threshold:
        unit: hour
        must_be_less_than: 48
  - schema:
      allow_other_column_order: true
      name: Schema is valid
  - duplicate:
      name: No duplicate records
      columns:
        - id
        - latencies
        - responses
        - timestamps
columns:
  - name: id
    data_type: STRING
    checks:
      - missing:
          name: ID is complete
      - duplicate:
          name: ID is unique
      - invalid:
          name: ID has valid format (uuid4)
          invalid_format:
            name: uuid4
            regex: \b[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b
  - name: latencies
    data_type: DOUBLE
    checks:
      - aggregate:
          function: min
          name: Response latency is positive
          threshold:
            must_be_greater_than_or_equal: 0
      - invalid:
          name: Response latencies are less than 10 seconds
          valid_max: 10
  - name: responses
    data_type: STRING
    checks:
      - invalid:
          valid_values:
            - f
            - j
          threshold:
            metric: count
            must_be: 0
          name: Responses are valid (f, j)
  - name: timestamps
    data_type: TIMESTAMP
```