### PR TITLE
DTL-744:  Fix `contract test` failure due to derived value computation

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -426,8 +426,9 @@ class ContractImpl:
                 derived_metric for derived_metric in self.metrics if isinstance(derived_metric, DerivedMetricImpl)
             ]
             measurement_values: MeasurementValues = MeasurementValues(measurements)
-            for derived_metric_impl in derived_metric_impls:
-                measurement_values.derive_value(derived_metric_impl)
+            if not self.only_validate_without_execute:
+                for derived_metric_impl in derived_metric_impls:
+                    measurement_values.derive_value(derived_metric_impl)
 
             if self.data_source_impl:
                 # Evaluate the checks


### PR DESCRIPTION
Extend `only_validate_without_execute` usage to skip derived value computations.