### PR TITLE
Fix authentication inside Fabric Notebooks

### DIFF
--- a/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
+++ b/soda/sqlserver/soda/data_sources/sqlserver_data_source.py
@@ -46,9 +46,9 @@ def _get_azure_cli_access_token(scope: str) -> AccessToken:
 
 
 def _get_mssparkutils_access_token(scope: str) -> AccessToken:
-    from notebookutils import mssparkutils
+    from notebookutils import credentials
 
-    aad_token = mssparkutils.credentials.getToken(scope)
+    aad_token = credentials.getToken(scope)
     expires_on = int(time.time() + 4500.0)
     token = AccessToken(
         token=aad_token,


### PR DESCRIPTION
Microsoft updated their mssparkutils package to be named notebookutils and also changed the scopes it can take to get a credential. This PR makes Soda compatible again with the current version of Fabric. To auth inside a Fabric Notebook you would just put authentication to "FabricSpark".