### PR TITLE
DTL-807: Floor the current freshness in seconds so it returns an `int`

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/freshness_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/freshness_check.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from math import floor
+
 import logging
 from datetime import date, datetime, timedelta, timezone
 
@@ -87,7 +89,7 @@ class FreshnessCheckImpl(CheckImpl):
         data_timestamp_utc: datetime = self._get_now_timestamp_utc(data_timestamp)
         diagnostic_metric_values: dict[str, float] = {}
         freshness: Optional[timedelta] = None
-        freshness_in_seconds: Optional[float] = None
+        freshness_in_seconds: Optional[int] = None
         threshold_metric_name: str = f"freshness_in_{self.unit}s"
 
         threshold_value: Optional[float] = None
@@ -99,7 +101,7 @@ class FreshnessCheckImpl(CheckImpl):
                 f"Calculating freshness using '{max_timestamp}' as 'max' and '{data_timestamp}' as 'now' values"
             )
             freshness = data_timestamp_utc - max_timestamp_utc
-            freshness_in_seconds = freshness.total_seconds()
+            freshness_in_seconds = floor(freshness.total_seconds())
 
             if self.unit == "minute":
                 threshold_value = freshness_in_seconds / 60

--- a/soda-tests/tests/features/test_freshness_check.py
+++ b/soda-tests/tests/features/test_freshness_check.py
@@ -51,7 +51,7 @@ def test_freshness(data_source_test_helper: DataSourceTestHelper):
         assert str(check_result.data_timestamp) == "2025-01-04 10:00:00+00:00"
         assert str(check_result.data_timestamp_utc) == "2025-01-04 10:00:00+00:00"
         assert str(check_result.freshness) == "1:00:00"
-        assert str(check_result.freshness_in_seconds) == "3600.0"
+        assert str(check_result.freshness_in_seconds) == "3600"
         assert str(check_result.unit) == "hour"
         assert get_diagnostic_value(check_result, "freshness_in_hours") == 1
 
@@ -78,7 +78,7 @@ def test_freshness_in_days(data_source_test_helper: DataSourceTestHelper):
         assert str(check_result.data_timestamp) == "2025-01-05 11:00:00+00:00"
         assert str(check_result.data_timestamp_utc) == "2025-01-05 11:00:00+00:00"
         assert str(check_result.freshness) == "1 day, 2:00:00"
-        assert str(check_result.freshness_in_seconds) == "93600.0"
+        assert str(check_result.freshness_in_seconds) == "93600"
         assert str(check_result.unit) == "day"
         assert 1.08 < get_diagnostic_value(check_result, "freshness_in_days") < 1.09
 
@@ -112,7 +112,7 @@ def test_freshness_now_variable(data_source_test_helper: DataSourceTestHelper):
     assert str(check_result.data_timestamp) == "2025-01-04 10:00:00+00:00"
     assert str(check_result.data_timestamp_utc) == "2025-01-04 10:00:00+00:00"
     assert str(check_result.freshness) == "1:00:00"
-    assert str(check_result.freshness_in_seconds) == "3600.0"
+    assert str(check_result.freshness_in_seconds) == "3600"
     assert str(check_result.unit) == "hour"
     assert 0.99 < get_diagnostic_value(check_result, "freshness_in_hours") < 1.01
 


### PR DESCRIPTION
I think this makes the most sense given the unit. This also matches what Soda Cloud is expecting.

Adjusted tests accordingly.