### PR TITLE
Chore: disable-databricks-tests

### DIFF
--- a/scripts/release_matrix.sh
+++ b/scripts/release_matrix.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-printf "[";find . -maxdepth 1 -mindepth 1 -type d -name "soda*" -printf '"%f",' | sed 's/,$//';printf "]"
+printf "["; find . -maxdepth 1 -mindepth 1 -type d -name "soda*" ! -name "soda-databricks" -printf '"%f",' | sed 's/,$//'; printf "]"


### PR DESCRIPTION
Because we're blocked on databricks because of platform setup reasons (external)