### PR TITLE
R-177: "Gracefully" handle exceptions from `ContractVerificationHandler` work.

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -619,16 +619,19 @@ class ContractImpl:
         else:
             logger.debug(f"Not sending results to Soda Cloud {Emoticons.CROSS_MARK}")
 
-        contract_verification_handler: Optional[ContractVerificationHandler] = ContractVerificationHandler.instance()
-        if contract_verification_handler:
-            contract_verification_handler.handle(
-                contract_impl=self,
-                data_source_impl=self.data_source_impl,
-                contract_verification_result=contract_verification_result,
-                soda_cloud=self.soda_cloud,
-                soda_cloud_send_results_response_json=soda_cloud_response_json,
-                dwh_data_source_file_path=self.dwh_data_source_file_path,
-            )
+        try:
+            contract_verification_handler: Optional[ContractVerificationHandler] = ContractVerificationHandler.instance()
+            if contract_verification_handler:
+                contract_verification_handler.handle(
+                    contract_impl=self,
+                    data_source_impl=self.data_source_impl,
+                    contract_verification_result=contract_verification_result,
+                    soda_cloud=self.soda_cloud,
+                    soda_cloud_send_results_response_json=soda_cloud_response_json,
+                    dwh_data_source_file_path=self.dwh_data_source_file_path,
+                )
+        except Exception as e:
+            logger.error(f"Error in contract verification handler: {e}", exc_info=True)
 
         return contract_verification_result
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -620,7 +620,9 @@ class ContractImpl:
             logger.debug(f"Not sending results to Soda Cloud {Emoticons.CROSS_MARK}")
 
         try:
-            contract_verification_handler: Optional[ContractVerificationHandler] = ContractVerificationHandler.instance()
+            contract_verification_handler: Optional[
+                ContractVerificationHandler
+            ] = ContractVerificationHandler.instance()
             if contract_verification_handler:
                 contract_verification_handler.handle(
                     contract_impl=self,

--- a/soda-tests/tests/components/test_contract_verification_handler.py
+++ b/soda-tests/tests/components/test_contract_verification_handler.py
@@ -1,7 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
 from helpers.test_table import TestTableSpecification
-from unittest.mock import patch, MagicMock
 
 test_table_specification = (
     TestTableSpecification.builder()
@@ -42,7 +43,9 @@ def test_failure_in_contract_verification_handler_does_not_fail_scan(
         """,
     )
 
-    assert any([
-        "Error in contract verification handler: Simulated failure in ContractVerificationHandler" in record.message
-        for record in caplog.records
-    ])
+    assert any(
+        [
+            "Error in contract verification handler: Simulated failure in ContractVerificationHandler" in record.message
+            for record in caplog.records
+        ]
+    )

--- a/soda-tests/tests/components/test_contract_verification_handler.py
+++ b/soda-tests/tests/components/test_contract_verification_handler.py
@@ -1,0 +1,48 @@
+from helpers.data_source_test_helper import DataSourceTestHelper
+from helpers.mock_soda_cloud import MockResponse
+from helpers.test_table import TestTableSpecification
+from unittest.mock import patch, MagicMock
+
+test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("row_count")
+    .column_varchar("id")
+    .rows(
+        rows=[
+            ("1",),
+            ("2",),
+            ("3",),
+        ]
+    )
+    .build()
+)
+
+
+@patch("soda_core.contracts.impl.contract_verification_impl.ContractVerificationHandler.instance")
+def test_failure_in_contract_verification_handler_does_not_fail_scan(
+    mock_instance, data_source_test_helper: DataSourceTestHelper, caplog
+):
+    mock_handler = MagicMock()
+    mock_handler.handle.side_effect = Exception("Simulated failure in ContractVerificationHandler")
+    mock_instance.return_value = mock_handler
+
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_pass(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - row_count:
+        """,
+    )
+
+    assert any([
+        "Error in contract verification handler: Simulated failure in ContractVerificationHandler" in record.message
+        for record in caplog.records
+    ])


### PR DESCRIPTION
Exceptions there will only be logged, not bubbled up. This prevents the scan from failing due to an issue in (currently only) diagnostics warehouse.

Added a test that verifies the contract verification passes and the error message is logged.