### PR TITLE
Performance optimizations for inserts using bulk inserts

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -27,8 +27,8 @@ logger: logging.Logger = soda_logger
 
 
 class AthenaDataSourceImpl(DataSourceImpl, model_class=AthenaDataSourceModel):
-    def __init__(self, data_source_model: AthenaDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: AthenaDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
         return AthenaSqlDialect(self)

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -48,8 +48,8 @@ class BigQueryDataSourceNamespace(DataSourceNamespace):
 
 
 class BigQueryDataSourceImpl(DataSourceImpl, model_class=BigQueryDataSourceModel):
-    def __init__(self, data_source_model: BigQueryDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: BigQueryDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
         self.cached_location = None
 
     def _create_sql_dialect(self) -> SqlDialect:

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -74,6 +74,10 @@ class DataSourceImpl(ABC):
         cls.__model_classes[type_name] = model_class
         cls.__implementation_classes[type_name] = cls
 
+    def create_copy_with_different_connection(self, connection: DataSourceConnection) -> DataSourceImpl:
+        "Use this method when you want to use the DataSourceImpl while having multiple connections open. Can be used for bulk inserts for example."
+        return self.__class__(data_source_model=self.data_source_model, connection=connection)
+
     def __str__(self) -> str:
         return self.name
 

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -18,8 +18,8 @@ logger: Logger = soda_logger
 
 
 class DatabricksDataSourceImpl(DataSourceImpl, model_class=DatabricksDataSourceModel):
-    def __init__(self, data_source_model: DatabricksDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: DatabricksDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
         return DatabricksSqlDialect()

--- a/soda-postgres/setup.py
+++ b/soda-postgres/setup.py
@@ -6,7 +6,10 @@ package_name = "soda-postgres"
 package_version = "4.0.0b11"
 description = "Soda Postgres V4"
 
-requires = [f"soda-core=={package_version}", "psycopg2-binary>=2.8.5, <3.0"]
+requires = [
+    f"soda-core=={package_version}",
+    "psycopg2-binary>=2.8.5, <3.0",
+]
 
 setup(
     name=package_name,

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from typing import Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
@@ -22,8 +23,8 @@ PG_DOUBLE_PRECISION = "double precision"
 
 
 class PostgresDataSourceImpl(DataSourceImpl, model_class=PostgresDataSourceModel):
-    def __init__(self, data_source_model: PostgresDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: PostgresDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
         return PostgresSqlDialect()

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -75,6 +75,7 @@ class PostgresDataSourceConnection(DataSourceConnection):
         self,
         config: PostgresConnectionProperties,
     ):
+        self.connection_config = config
         return psycopg2.connect(**config.to_connection_kwargs())
 
     def execute_query(self, sql: str) -> QueryResult:

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
@@ -21,8 +22,8 @@ REDSHIFT_CHARACTER_VARYING = "character varying"
 
 
 class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel):
-    def __init__(self, data_source_model: RedshiftDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: RedshiftDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
         return RedshiftSqlDialect()

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from typing import Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
@@ -22,8 +23,8 @@ TIMESTAMP_WITH_LOCAL_TIME_ZONE = "timestamp with local time zone"
 
 
 class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceModel):
-    def __init__(self, data_source_model: SnowflakeDataSourceModel):
-        super().__init__(data_source_model=data_source_model)
+    def __init__(self, data_source_model: SnowflakeDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
         return SnowflakeSqlDialect()

--- a/soda-tests/tests/features/test_sql_ast_inserts.py
+++ b/soda-tests/tests/features/test_sql_ast_inserts.py
@@ -1,4 +1,5 @@
 import datetime
+from logging import Logger
 
 import pytz
 from helpers.data_source_test_helper import DataSourceTestHelper
@@ -6,6 +7,7 @@ from helpers.test_table import TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.datetime_conversions import interpret_datetime_as_utc
+from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
     COLUMN,
@@ -20,6 +22,8 @@ from soda_core.common.sql_ast import (
     VALUES_ROW,
 )
 from soda_core.common.sql_dialect import SqlDialect
+
+logger: Logger = soda_logger
 
 
 def test_full_create_insert_drop_ast(data_source_test_helper: DataSourceTestHelper):


### PR DESCRIPTION
We have some performance concerns for DWH with the amount of time it takes to insert a large number of rows.
E.g. for BigQuery, we do inserts 500 rows at a time, but that takes to long.
This PR is the start of adding bulk insertion methods to datasources, using datasource specific approaches to optimize the insertion performance.