### PR TITLE
Use `svv_*` tables for Redshift metadata queries

### DIFF
--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -3,7 +3,7 @@ import logging
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import SodaDataTypeName
+from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
 from soda_core.common.sql_ast import COLUMN, COUNT, DISTINCT, REGEX_LIKE, TUPLE, VALUES
 from soda_core.common.sql_dialect import SqlDialect
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
@@ -162,3 +162,15 @@ class RedshiftSqlDialect(SqlDialect):
 
     def supports_data_type_datetime_precision(self) -> bool:
         return False
+
+    def information_schema_namespace_elements(self, data_source_namespace: DataSourceNamespace) -> list[str]:
+        return []
+
+    def schema_information_schema(self) -> str | None:
+        return None
+
+    def table_tables(self) -> str:
+        return "svv_tables"
+
+    def table_columns(self) -> str:
+        return "svv_columns"


### PR DESCRIPTION
Redshift supports a concept of external tables. These tables can be queried and insert into, but they are not exposed in the regular `information_schema.tables` metadata. We should instead use `svv_tables` and `svv_columns` to get information about the tables (those views contain information for both external and regular tables).

This PR is an attempt to add support for external tables to our Redshift implementation. Unfortunately it breaks some of the assumptions in the metadata queries