### PR TITLE
Add check to enforce test table name limit

### DIFF
--- a/soda-tests/src/helpers/test_table.py
+++ b/soda-tests/src/helpers/test_table.py
@@ -10,10 +10,11 @@ from soda_core.common.metadata_types import (
     SqlDataType,
 )
 
+MAX_TABLE_NAME_LENGTH = 63  # Postgres max table name length.  Needed or else table names may be incorrectly truncated.
 
-MAX_TABLE_NAME_LENGTH = 63 # Postgres max table name length.  Needed or else table names may be incorrectly truncated.
+
 # This should technically be pulled from SQL dialect and vary by data source, but we don't have access to that here
-# So far every data source can handle 63 characters.   
+# So far every data source can handle 63 characters.
 class TestTableSpecificationBuilder:
     """
     See TestTableSpecification for documentation


### PR DESCRIPTION
We hit an issue with extensions in which a table that should have been named `SODATEST_testing_failed_rows_query_with_unknown_data_types_2b2b0792` was actually being named `SODATEST_testing_failed_rows_query_with_unknown_data_t_2b2b` because the table name exceeded the limits of our dockerized postgres

this PR enforces a max limit of 63 characters for test table names, i.e. 48 characters for the "table_purpose" which sits between the prefix and hash.  

We could do something fancy like hash and truncate the table_purpose but it feels like too much work for a very rare case