### PR TITLE
chore: increase postgres locally to fit the version in CI/CD

### DIFF
--- a/.github/workflows/main.workflow.yaml
+++ b/.github/workflows/main.workflow.yaml
@@ -75,6 +75,7 @@ jobs:
     needs: [define-test-matrix]
     services:
       postgres:
+        # please keep the postgres version in sync with the one in docker-compose.yml for postgres
         image: ${{ ( matrix.module == 'postgres' ) && 'postgres:15.10-alpine3.21' || '' }}
         env:
           POSTGRES_USER: soda_test

--- a/soda-postgres/docker-compose.yml
+++ b/soda-postgres/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3.7"
 services:
   soda-sql-postgres:
-    image: postgres:9.6.17-alpine
+    # please keep the postgres version in sync with the one in CI/CD
+    image: postgres:15.10-alpine3.21
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
There is a discrepancy in versions used in CI/CD and the version used in docker-compose for local Postgres testing. I believe that the version in CI/CD makes more sense since the version in local postgres is fat too old (9.6 is EOLed in 2021).