### PR TITLE
Refactor drop schema methods

### DIFF
--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -308,10 +308,10 @@ class DataSourceTestHelper:
         schema = self.dataset_prefix[schema_index]
 
         self.drop_schema_if_exists(schema)
-    
+
     def drop_schema_if_exists(self, schema: str) -> None:
         try:
-            sql: str = self.drop_schema_if_exists_sql(schema = schema)
+            sql: str = self.drop_schema_if_exists_sql(schema=schema)
             self.data_source_impl.execute_update(sql)
         except Exception as e:
             logger.warning(f"Error dropping test schema: {e}")


### PR DESCRIPTION
Generalizes DataSourceTestHelper's drop schema methods so it can be used to delete DWH schemas.

I think ideally this would be part of the SQL AST, not the test helper, but because DROP SCHEMA is a SQL update command it works differently from SELECTS and it would take more thought to add it to that structure.   This is a quick fix to move us forward now