### PR TITLE
remove needless headers from log batch upload

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1257,8 +1257,6 @@ class SodaCloud:
         headers = {
             "Authorization": self._get_token(),
             "Content-Type": "application/jsonlines",
-            "Is-V3": "true",
-            "Soda-Library-Version": SODA_CORE_VERSION,
         }
 
         response = self._http_post(


### PR DESCRIPTION
I have noticed that the code that upload logs in soda-library which I migrated into soda core v4 had one part I haven't cleaned up yet: the headers `Is-V3` and `Soda-Library-Version` are not needed and not taken into consideration by backend, so they are there just for confusion (e.g. in this issue I wrongly assumed a change on backend is needed which is not true: https://linear.app/sodadata/issue/R-328/backend-should-log-error-as-a-log-line-of-the-stage-when-updating)