### PR TITLE
R-340: send dataset as part of the logs for DWH stage

### DIFF
--- a/soda-core/src/soda_core/common/logs_queue.py
+++ b/soda-core/src/soda_core/common/logs_queue.py
@@ -34,13 +34,14 @@ def _to_jsonl(batch: list[LogRecord]) -> str:
 
 
 class LogsQueue(LogsBase):
-    def __init__(self, soda_cloud: SodaCloud, stage: str, scan_reference: str):
+    def __init__(self, soda_cloud: SodaCloud, stage: str, scan_reference: str, dataset: str):
         super().__init__()
         self.index = 0
         self.soda_cloud = soda_cloud
         self.scan_reference = scan_reference
         self.stage = stage
         self.thread = str(uuid.uuid4())
+        self.dataset = dataset
         self.flush_interval = DEFAULT_FLUSH_INTERVAL
         self.batch_size = MAX_LOG_LINES
         self.log_queue = queue.Queue()
@@ -91,6 +92,7 @@ class LogsQueue(LogsBase):
             log_record.__setattr__("stage", self.stage)
             log_record.__setattr__("index", self.index)
             log_record.__setattr__("thread", self.thread)
+            log_record.__setattr__("dataset", self.dataset)
             self.index += 1
             self.log_queue.put(log_record)
             self._preserve_if_error_log(log_record)

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1595,12 +1595,13 @@ def build_log_cloud_json_dict(log_record: LogRecord, index: int) -> dict:
     return {
         "level": log_record.levelname.lower(),
         "message": log_record.getMessage(),
-        "timestamp": datetime.fromtimestamp(log_record.created),
+        "timestamp": datetime.fromtimestamp(log_record.created, tz=timezone.utc),
         "index": log_record.index if hasattr(log_record, "index") else index,
         "stage": log_record.stage if hasattr(log_record, "stage") else None,
         "doc": log_record.doc if hasattr(log_record, "doc") else None,
         "exception": log_record.exception if hasattr(log_record, "exception") else None,
         "thread": log_record.thread if hasattr(log_record, "thread") else None,
+        "dataset": log_record.dataset if hasattr(log_record, "dataset") else None,
         "location": (
             log_record.location.get_dict()
             if hasattr(log_record, ExtraKeys.LOCATION) and isinstance(log_record.location, Location)


### PR DESCRIPTION
This is core part to allow filtering DWH logs based on dataset name.

Misc changes:
- implement correct timezone for log records that converts the parsed timestamp to UTC

This PR allows this filter be shown on the FE page:

<img width="714" height="1084" alt="CleanShot 2025-10-22 at 18 35 28@2x" src="https://github.com/user-attachments/assets/13f19213-e38f-4901-a413-fd9c0693f05f" />
