### PR TITLE
Fix CTE in AST with newlines in fields (removed indenations)

### DIFF
--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -530,7 +530,7 @@ class SqlDialect:
         else:
             raise ValueError(f"Unexpected cte_query type: {cte.cte_query.__class__.__name__}")
         sql_str = sql_str.rstrip(";")
-        sql_str = indent(sql_str, "  ")
+        # Do not indent the query string! This could cause issues with multi-line text fields. sql_str = indent(sql_str, "  ")
         alias_columns_str: str = ""
         if cte.alias_columns and self.supports_cte_alias_columns():
             alias_columns_str = "(" + ", ".join([self._build_column_sql(column) for column in cte.alias_columns]) + ")"

--- a/soda-tests/tests/components/test_sql_generation.py
+++ b/soda-tests/tests/components/test_sql_generation.py
@@ -59,9 +59,38 @@ def test_sql_ast_modeling_cte():
     ) == (
         "WITH \n"
         '"customers_filtered" AS (\n'
-        "  SELECT *\n"
-        '  FROM "customers"\n'
-        '  WHERE "colA" >= 25\n'
+        "SELECT *\n"
+        'FROM "customers"\n'
+        'WHERE "colA" >= 25\n'
+        ")\n"
+        'SELECT SUM("size")\n'
+        'FROM "customers_filtered";'
+    )
+
+
+def test_sql_ast_modeling_cte_with_multi_line_text_field():
+    sql_dialect: SqlDialect = SqlDialect()
+
+    assert sql_dialect.build_select_sql(
+        [
+            WITH(
+                [
+                    CTE("customers_filtered").AS(
+                        [SELECT([STAR(), LITERAL("My\nLine")]), FROM("customers"), WHERE(GTE("colA", LITERAL(25)))]
+                    )
+                ]
+            ),
+            SELECT(SUM(COLUMN("size"))),
+            FROM("customers_filtered"),
+        ]
+    ) == (
+        "WITH \n"
+        '"customers_filtered" AS (\n'
+        "SELECT *,\n"
+        "       'My\n"
+        "Line'\n"
+        'FROM "customers"\n'
+        'WHERE "colA" >= 25\n'
         ")\n"
         'SELECT SUM("size")\n'
         'FROM "customers_filtered";'


### PR DESCRIPTION
In DWH, if text fields contain newlines, these would not join correctly. 
This PR re-applies some changes that fix the CTE to remove indents which conflict with the text fields.