### PR TITLE
Add `dataset_id` and `check_id` to `ContractVerificationResult`

### DIFF
--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -233,6 +233,7 @@ class Contract:
     dataset_name: str
     soda_qualified_dataset_name: str
     source: YamlFileContentInfo
+    dataset_id: Optional[str] = None  # This one can be filled later when we get the dataset id from Soda Cloud
 
 
 @dataclass
@@ -487,7 +488,6 @@ class ContractVerificationResult:
 
         # Initialze these variables to None, they will be set later when the results are sent to Soda Cloud
         self.scan_id: Optional[str] = None
-        self.dataset_id: Optional[str] = None
 
     def get_logs(self) -> list[str]:
         return [r.getMessage() for r in self.log_records]

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -626,6 +626,7 @@ class ContractImpl:
                     local_file_path=self.contract_yaml.contract_yaml_source.file_path,
                     soda_cloud_file_id=soda_cloud_file_id,
                 ),
+                dataset_id=None,  # Set this to None for now (default). Will be filled later when we get the dataset id from Soda Cloud
             ),
             data_source=data_source,
             data_timestamp=self.data_timestamp,
@@ -648,7 +649,8 @@ class ContractImpl:
                 contract_verification_result.sending_results_to_soda_cloud_failed = True
             else:
                 contract_verification_result.scan_id = scan_id
-                contract_verification_result.dataset_id = self.__get_dataset_id(
+                # Put the dataset id in the contract object
+                contract_verification_result.contract.dataset_id = self.__get_dataset_id(
                     soda_cloud_response_json, self.soda_qualified_dataset_name
                 )
         else:


### PR DESCRIPTION
As per request, add `dataset_id` and `check_id` to the `ContractVerificationSessionResult`. 
Note; the `ContractVerificationSessionResult` consists of multiple `ContractVerificationResult`. The latter is the class that contains the dataset and check ids.