### PR TITLE
Return cursor description when executing query one-by-one

### DIFF
--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -137,9 +137,10 @@ class DataSourceConnection(ABC):
 
     def execute_query_one_by_one(
         self, sql: str, row_callback: Callable[[tuple, tuple[tuple]], None], log_query: bool = True
-    ) -> None:
+    ) -> tuple[tuple]:
         """
         usage: execute_query_one_by_one("SELECT ...", lambda row, description: your_handle_row(row))
+        Returns the description of the query.
         """
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
@@ -148,13 +149,16 @@ class DataSourceConnection(ABC):
                 logger.debug(f"SQL query fetch one-by-one:\n{sql}")
             cursor.execute(sql)
 
+            description: tuple[tuple] = cursor.description
+
             row = cursor.fetchone()
             while row:
-                row_callback(row, cursor.description)
+                row_callback(row, description)
                 row = cursor.fetchone()
 
         finally:
             cursor.close()
+        return description
 
     def commit(self) -> None:
         # noinspection PyUnresolvedReferences

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -123,7 +123,8 @@ class DataSourceImpl(ABC):
 
     def execute_query_one_by_one(
         self, sql: str, row_callback: Callable[[tuple, tuple[tuple]], None], log_query: bool = True
-    ) -> None:
+    ) -> tuple[tuple]:
+        # Returns the description of the query.
         return self.data_source_connection.execute_query_one_by_one(
             sql=sql, row_callback=row_callback, log_query=log_query
         )


### PR DESCRIPTION
Required to support [this PR](https://github.com/sodadata/soda-extensions/pull/163)