### PR TITLE
Add PR template for soda-extensions reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+Please provide a description of your changes:
+
+- What problem are you solving?
+- Any expected impact on downstream packages/services?
+- Reference issue # if available.
+
+
+## Checklist
+
+- [ ] I added a test to verify the new functionality.
+- [ ] I verified this PR does not break [soda-extensions][1].
+
+[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)


### PR DESCRIPTION
We've had a few times where the soda-extensions package was broken as a result of changes in soda-core. There is a workflow in place to validate they work together correctly, but this is a manual process.

This PR adds a template to promote good PR practices, including a reminder to run the soda-extensions workflow for validating compatibility.

> [!NOTE]
> This is an attempt, but I'm not sure this will work as-is. The [github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates) specify that the template needs to live on the default branch of the repository. In our case that would be `main`, but I don't think we want to place this template there as `soda-extensions` is not relevant for the `main` branch (v3).