### PR TITLE
Chore: add proper "release" support

### DIFF
--- a/.github/workflows/main.workflow.yaml
+++ b/.github/workflows/main.workflow.yaml
@@ -299,7 +299,7 @@ jobs:
 
           RELEASE_VERSION="$(echo ${GITHUB_REF_NAME} | sed -E 's/v(.*)/\1/')"
           tbump --only-patch --non-interactive ${RELEASE_VERSION}
-          echo "Using tag version: $VERSION"
+          echo "Using tag version: RELEASE_VERSION"
 
           cd ${{ matrix.module }}
           python3 -m build

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,17 +42,18 @@ if [[ "$NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)([0-9]+)$ ]]; then
   PRERELEASE_SUFFIX="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
   NEXT_PRERELEASE="${MAJOR}.${MINOR}.${PATCH}${PRERELEASE_SUFFIX}"
 # Matches: 1.2.3-alpha.1 / 1.2.3-beta.2 (SemVer)
-elif [[ "$NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha.|-beta.)([0-9]+)?$ ]]; then
+elif [[ "$NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha.|-beta.)([0-9]+)$ ]]; then
   PRERELEASE_SUFFIX="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
   NEXT_PRERELEASE="${MAJOR}.${MINOR}.${PATCH}${PRERELEASE_SUFFIX}"
 else
-  echo "No or unknown prerelease schema; not bumping to next prerelease version."
+  echo "No or unknown prerelease schema"
+  exit 1
 fi
 
 echo "Setting next prerelease $NEXT_PRERELEASE"
-if [[[ "$DRY_RUN" = true ]]; then
-   echo "[DRY RUN] Would execute: tbump --non-interactive --no-tag $NEXT_PRERELEASE"
-   tbump --no-tag --dry-run $NEXT_PRERELEASE
+if [[ "$DRY_RUN" = true ]]; then
+  echo "[DRY RUN] Would execute: tbump --non-interactive --no-tag $NEXT_PRERELEASE"
+  tbump --no-tag --dry-run $NEXT_PRERELEASE
 else
   tbump --non-interactive --no-tag "$NEXT_PRERELEASE"
 fi


### PR DESCRIPTION
Introduces build support for version numbers, including prereleases (alpha, beta and release candidates).

When tagged with one of those version numbers, the resulting build will ALSO publish the resulting package to our public PyPI repo (pypi.cloud.soda.io).