### PR TITLE
Fail queries gracefully

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -635,8 +635,11 @@ class ContractImpl:
         elif not self.only_validate_without_execute:
             # Executing the queries will set the value of the metrics linked to queries
             for query in self.queries:
-                query_measurements: list[Measurement] = query.execute()
-                measurements.extend(query_measurements)
+                try:
+                    query_measurements: list[Measurement] = query.execute()
+                    measurements.extend(query_measurements)
+                except Exception as e:
+                    logger.error(f"Error executing query: {e}")
 
             measurement_values: MeasurementValues = MeasurementValues(measurements)
 


### PR DESCRIPTION
This catches contract verification queries and continue the verification to still run checks that can continue. Caveat: since multiple checks types are combined into one query, this query can fail and cause a non-intuitive number of checks to be in non-evaluated state since the aggregate combined query failed. 

This changes the previous approach of "fail the whole contract immediately in case of a query issue" to "fail gracefully, execute everything that is possible, including sending data to Cloud and running extensions"

extensions tests passed locally