### PR TITLE
chore: allow new versions of duckdb

### DIFF
--- a/soda/duckdb/setup.py
+++ b/soda/duckdb/setup.py
@@ -6,7 +6,7 @@ package_name = "soda-core-duckdb"
 package_version = "3.5.6"
 description = "Soda Core Duckdb Package"
 
-requires = [f"soda-core=={package_version}", "duckdb<1.1.0"]
+requires = [f"soda-core=={package_version}", "duckdb>=1.1.0, <2.0"]
 
 setup(
     name=package_name,


### PR DESCRIPTION
The duckdb version was pinned to below 1.1.0 because the dataframe behavior changed then. This PR restores the old behavior of scanning all registered dataframes, but because this option was only added in DuckDB 1.1.0, this version now becomes the minimum.

This PR also standardizes the duckdb configuration used in the in-memory and path-based connections and, because `:default:` in-memory singleton cannot accept configuration, switches from `:default:` to `:memory:`. The in-memory duckdb instances are so lightweight though that it won't make any measurable difference.

I've added `<2.0` as the dependency ceiling, but DuckDB treats its twice-a-yearly minor releases as major, so if you'd like to be conservative, the ceiling should be `<1.5`, which [will be released in February](https://duckdb.org/release_calendar).

`custom_user_agent` is a DuckDB property. It was added in DuckDB 1.0, so no additional constraints are needed.