### PR TITLE
feat: default check names for llm, hierarchy, and fuzzy_duplicate check types

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1102,6 +1102,8 @@ class CheckImpl:
         "aggregate": "Metric function meets threshold",
         "metric": "Metric meets threshold",
         "failed_rows": "No rows violating the condition",
+        "llm": "LLM validation passes",
+        "hierarchy": "Hierarchy structure is valid",
     }
 
     @property

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1098,6 +1098,7 @@ class CheckImpl:
         "missing": "No missing values",
         "invalid": "No invalid values",
         "duplicate": "No duplicate values",
+        "fuzzy_duplicate": "No fuzzy duplicate values",
         "aggregate": "Metric function meets threshold",
         "metric": "Metric meets threshold",
         "failed_rows": "No rows violating the condition",


### PR DESCRIPTION
## Summary
Adds default human-readable check names in `CheckImpl.DEFAULT_NAMES` for three new check types implemented in soda-extensions:

- `llm` → *"LLM validation passes"*
- `hierarchy` → *"Hierarchy structure is valid"*
- `fuzzy_duplicate` → *"No fuzzy duplicate values"*

Without these, checks with no explicit `name:` in the contract fall through to the raw type string (e.g. `"fuzzy_duplicate"`) as the `check_name` written to the diagnostics warehouse, instead of the readable label.

## Companion PRs (soda-extensions)
- sodadata/soda-extensions#298 — `feat: add soda-llm package with tools framework and reference lookups`
- sodadata/soda-extensions#300 — `feat: add soda-hierarchy package for hierarchical data quality checks`
- sodadata/soda-extensions#301 — `feat: add soda-fuzzy-duplicate extension`

## Test plan
- [ ] CI green on matching branch with soda-extensions
- [ ] Contracts using `llm`, `hierarchy`, and `fuzzy_duplicate` checks without `name:` emit the readable default to the DW

🤖 Generated with [Claude Code](https://claude.com/claude-code)