### PR TITLE
fix(mysql): explicitly set charset=utf8mb4 to resolve connection failure with mysql-connector-python >= 8.0.30

### DIFF
--- a/soda/mysql/soda/data_sources/mysql_data_source.py
+++ b/soda/mysql/soda/data_sources/mysql_data_source.py
@@ -78,8 +78,9 @@ class MySQLDataSource(DataSource):
     def connect(self):
         try:
             self.connection = mysql.connector.connect(
-                user=self.username, password=self.password, host=self.host, port=self.port, database=self.database
+                user=self.username, password=self.password, host=self.host, port=self.port, database=self.database, charset="utf8mb4", use_unicode=True
             )
+
             return self.connection
         except Exception as e:
             raise DataSourceConnectionError(self.TYPE, e)

--- a/soda/mysql/soda/data_sources/mysql_data_source.py
+++ b/soda/mysql/soda/data_sources/mysql_data_source.py
@@ -78,7 +78,13 @@ class MySQLDataSource(DataSource):
     def connect(self):
         try:
             self.connection = mysql.connector.connect(
-                user=self.username, password=self.password, host=self.host, port=self.port, database=self.database, charset="utf8mb4", use_unicode=True
+                user=self.username,
+                password=self.password,
+                host=self.host,
+                port=self.port,
+                database=self.database,
+                charset="utf8mb4",
+                use_unicode=True,
             )
 
             return self.connection


### PR DESCRIPTION
## Problem

When using soda-core-mysql with mysql-connector-python >= 8.0.30,
connecting to a MySQL data source fails with:

  "Character set 'utf8' unsupported"
  "Encountered a problem while trying to connect to mysql: 
   Character set 'utf8' unsupported"

## Root Cause

The connect() method in mysql_data_source.py creates a MySQL connection
without specifying a charset parameter:

  mysql.connector.connect(
      user=self.username, password=self.password,
      host=self.host, port=self.port, database=self.database
  )

Starting from mysql-connector-python 8.0.30, when no charset is
specified, the connector defaults to 'utf8' and then silently remaps
utf8 → utf8mb4. This remapping fails on MySQL servers older than 5.5.3
which do not support utf8mb4.

## Fix

Explicitly pass charset="utf8mb4" and use_unicode=True:

  mysql.connector.connect(
      user=self.username, password=self.password,
      host=self.host, port=self.port, database=self.database,
      charset="utf8mb4", use_unicode=True
  )

This bypasses the connector's internal remapping logic entirely.

## Impact

- Fixes connection failures for users on mysql-connector-python >= 8.0.30
- No breaking change — utf8mb4 is fully backwards compatible with utf8
- No impact on users running older connector versions

## References

- Fixes #2583
- Community workaround: https://pypi.org/project/soda-core-mysql-utf8-hotfix/