### PR TITLE
fix(athena): quote schema/database identifiers in table prefix to handle hyphenated names

### DIFF
--- a/soda/core/soda/execution/data_source.py
+++ b/soda/core/soda/execution/data_source.py
@@ -1119,7 +1119,9 @@ class DataSource:
             return self.database
             return f'"{self.database}"."{self.schema}"'
         """
-        return self.schema
+        if self.schema:
+            return f'"{self.schema}"'
+        return None
 
     def update_schema(self, schema_name):
         self.schema = schema_name


### PR DESCRIPTION
## Problem

AWS Athena database and schema names can contain hyphen (-) characters.
The current code returns self.schema unquoted in _create_table_prefix(),
causing SQL query failures when hyphens are present:

  SELECT * FROM my-schema.my_table   ← SQL engine misreads the hyphen

## Root Cause

In data_source.py, the _create_table_prefix() method returns:

  return self.schema

This bare, unquoted value is then used directly in qualified_table_name() to build SQL strings, with no protection against special characters.

## Fix
Wrap the schema in double quotes:

  if self.schema:
      return f'"{self.schema}"'
  return None

This produces valid SQL:  SELECT * FROM "my-schema".my_table

## Impact
- Fixes query failures for Athena databases/schemas with hyphens
- No breaking change for normal names without special characters
- Double quoting is standard SQL and supported by Athena

## References
- Fixes #2483