### PR TITLE
fix(scan): add query references to check results to enable check-to-query linking in get_scan_results()

### DIFF
--- a/soda/core/soda/execution/check/check.py
+++ b/soda/core/soda/execution/check/check.py
@@ -377,6 +377,7 @@ class Check(ABC):
                 "filter": Partition.get_partition_name(self.partition),
                 "column": Column.get_partition_name(self.column),
                 "metrics": [metric.identity for metric in self.metrics.values()],
+                "queries": [query.query_name for query in self._get_all_related_queries()],
                 "outcome": self.outcome.value if self.outcome else None,
                 "outcomeReasons": self.outcome_reasons,
                 "archetype": self.archetype,


### PR DESCRIPTION
## Problem
scan.get_scan_results() returns checks[] and queries[] with no way to link them together. Users storing results in a relational database cannot determine which SQL was executed for a specific check.

## Root Cause
Check.get_dict() never included query information in its output, even though the Check class already tracks related queries internally via _get_all_related_queries().

## Fix
Add a "queries" field to get_dict() output:  "queries": [query.query_name for query in self._get_all_related_queries()]

This exposes the query names so users can cross-reference:  check["queries"] -> matches queries[]["name"]

## Result
Users can now link checks to their SQL queries:

  results = scan.get_scan_results()
  query_map = {q["name"]: q for q in results["queries"]}

  for check in results["checks"]:
      for query_name in check.get("queries", []):
          sql = query_map[query_name]["sql"]

## Impact
- No breaking change — adds a new field, removes nothing
- Works for all check types via existing _get_all_related_queries()

## References
- Fixes #2475