### PR TITLE
fix: cast boolean threshold values to int before sending to Soda Cloud

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1521,7 +1521,7 @@ def _build_diagnostics_json_dict(check_result: CheckResult) -> Optional[dict]:
 
     return {
         #  TODO: this default 0 value is here only because check.diagnostics.value is a required non-nullable field in the api.
-        "value": check_result.threshold_value or 0,
+        "value": int(check_result.threshold_value) if isinstance(check_result.threshold_value, bool) else (check_result.threshold_value or 0),
         "fail": _build_fail_threshold(check_result),
         "v4": _build_v4_diagnostics_check_type_json_dict(check_result),
     }

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1521,7 +1521,9 @@ def _build_diagnostics_json_dict(check_result: CheckResult) -> Optional[dict]:
 
     return {
         #  TODO: this default 0 value is here only because check.diagnostics.value is a required non-nullable field in the api.
-        "value": int(check_result.threshold_value) if isinstance(check_result.threshold_value, bool) else (check_result.threshold_value or 0),
+        "value": int(check_result.threshold_value)
+        if isinstance(check_result.threshold_value, bool)
+        else (check_result.threshold_value or 0),
         "fail": _build_fail_threshold(check_result),
         "v4": _build_v4_diagnostics_check_type_json_dict(check_result),
     }

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -20,7 +20,11 @@ from soda_core.common.exceptions import (
     FailedContractSkeletonGenerationException,
     SodaCloudException,
 )
-from soda_core.common.soda_cloud import ContractSkeletonGenerationState, SodaCloud, _build_diagnostics_json_dict
+from soda_core.common.soda_cloud import (
+    ContractSkeletonGenerationState,
+    SodaCloud,
+    _build_diagnostics_json_dict,
+)
 from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResult
 from soda_core.contracts.contract_verification import (

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -20,10 +20,12 @@ from soda_core.common.exceptions import (
     FailedContractSkeletonGenerationException,
     SodaCloudException,
 )
-from soda_core.common.soda_cloud import ContractSkeletonGenerationState, SodaCloud
+from soda_core.common.soda_cloud import ContractSkeletonGenerationState, SodaCloud, _build_diagnostics_json_dict
 from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResult
 from soda_core.contracts.contract_verification import (
+    CheckOutcome,
+    CheckResult,
     ContractVerificationResult,
     PostProcessingStage,
     PostProcessingStageState,
@@ -691,3 +693,25 @@ def test_trigger_contract_skeleton_generation__error(mock_post):
             "token": "some_token",
         },
     )
+
+
+@pytest.mark.parametrize(
+    "threshold_value, expected_diagnostics_value",
+    [
+        (True, 1),
+        (False, 0),
+        (42, 42),
+        (3.14, 3.14),
+        (0, 0),
+        (None, 0),
+    ],
+)
+def test_build_diagnostics_json_dict_casts_bool_to_int(threshold_value, expected_diagnostics_value):
+    check_result = CheckResult(
+        check=mock.MagicMock(),
+        outcome=CheckOutcome.PASSED,
+        threshold_value=threshold_value,
+    )
+    diagnostics = _build_diagnostics_json_dict(check_result)
+    assert diagnostics["value"] == expected_diagnostics_value
+    assert not isinstance(diagnostics["value"], bool)


### PR DESCRIPTION
## Summary

- When a metric check uses a SQL query returning a boolean (e.g. a comparison expression on Databricks), the raw Python `bool` flows through to `diagnostics.value` and gets serialized as JSON `true`/`false` instead of `1`/`0`
- The backend expects a numeric value and rejects the payload with **400 "Could not parse request from json body"**
- Cast `bool` to `int` in `_build_diagnostics_json_dict` so the serialized value is always numeric

Fixes SAS-11624

## Test plan

- [x] Added parametrized unit test covering `True`, `False`, numeric, zero, and `None` threshold values
- [x] All 6 parametrized cases pass
- [ ] Verify on a Databricks data source with a boolean-returning metric query