### PR TITLE
fix: Pre-flight probe for Databricks connection (SCS-884)

### DIFF
--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -33,9 +33,10 @@ def _probe_databricks_reachability(host: str, port: int = 443, timeout: float = 
     try:
         with socket.create_connection((host, port), timeout=timeout) as sock:
             ctx = ssl.create_default_context()
+            ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             with ctx.wrap_socket(sock, server_hostname=host):
                 return
-    except (socket.gaierror, socket.timeout, ConnectionError, ssl.SSLError, OSError) as e:
+    except OSError as e:
         raise ConnectionError(f"Databricks host {host}:{port} is not reachable: {e}") from e
 
 

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import socket
+import ssl
 
 from databricks import sql
 from soda_core.common.data_source_connection import DataSourceConnection
@@ -15,6 +17,28 @@ from soda_databricks.model.data_source.databricks_connection_properties import (
 logger: logging.Logger = soda_logger
 
 
+def _probe_databricks_reachability(host: str, port: int = 443, timeout: float = 10.0) -> None:
+    """Pre-flight TCP+TLS probe to the Databricks workspace.
+
+    Raises immediately if the server is not reachable at the network layer
+    (DNS failure, TCP refused, TLS handshake error). This short-circuits
+    the databricks-sql-connector's retry loop for connect-phase failures,
+    which otherwise exponentially back off for up to ~15 min on a
+    misconfigured hostname. See SCS-884 / OBSL-445.
+
+    Reachable-but-unhealthy cases (503 cluster warming, 404, 401/403) are
+    intentionally passed through: the connector handles them correctly
+    (patient wait on 503 + Retry-After, fast-fail on auth errors).
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            ctx = ssl.create_default_context()
+            with ctx.wrap_socket(sock, server_hostname=host):
+                return
+    except (socket.gaierror, socket.timeout, ConnectionError, ssl.SSLError, OSError) as e:
+        raise ConnectionError(f"Databricks host {host}:{port} is not reachable: {e}") from e
+
+
 class DatabricksDataSourceConnection(DataSourceConnection):
     def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
         super().__init__(name, connection_properties)
@@ -23,9 +47,11 @@ class DatabricksDataSourceConnection(DataSourceConnection):
         self,
         config: DatabricksConnectionProperties,
     ):
+        connection_kwargs = config.to_connection_kwargs()
+        _probe_databricks_reachability(connection_kwargs["server_hostname"])
         return sql.connect(
             user_agent_entry="Soda Core",
-            **config.to_connection_kwargs(),
+            **connection_kwargs,
         )
 
     def rollback(self) -> None:

--- a/soda-databricks/tests/unit/test_databricks_connection_probe.py
+++ b/soda-databricks/tests/unit/test_databricks_connection_probe.py
@@ -1,0 +1,70 @@
+"""Tests for the Databricks pre-flight reachability probe in soda-core v4.
+
+Mirrors the soda-library test file. See SCS-884 / OBSL-445.
+"""
+
+import socket
+import ssl
+from unittest.mock import MagicMock, patch
+
+import pytest
+from soda_databricks.common.data_sources.databricks_data_source_connection import (
+    _probe_databricks_reachability,
+)
+
+
+def test_probe_succeeds_when_tcp_and_tls_handshake_ok():
+    """Happy path: TCP+TLS succeed, probe returns None."""
+    mock_sock = MagicMock()
+    mock_sock.__enter__.return_value = mock_sock
+    mock_ctx = MagicMock()
+    mock_ctx.wrap_socket.return_value.__enter__.return_value = MagicMock()
+
+    with patch(
+        "soda_databricks.common.data_sources.databricks_data_source_connection.socket.create_connection",
+        return_value=mock_sock,
+    ) as mock_conn, patch(
+        "soda_databricks.common.data_sources.databricks_data_source_connection.ssl.create_default_context",
+        return_value=mock_ctx,
+    ):
+        _probe_databricks_reachability("example.cloud.databricks.com")
+
+    mock_conn.assert_called_once_with(("example.cloud.databricks.com", 443), timeout=10.0)
+    mock_ctx.wrap_socket.assert_called_once()
+    assert mock_ctx.wrap_socket.call_args.kwargs["server_hostname"] == "example.cloud.databricks.com"
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        socket.gaierror("Name or service not known"),
+        socket.timeout("timed out"),
+        ConnectionRefusedError("connection refused"),
+        OSError("network unreachable"),
+    ],
+    ids=["dns_failure", "tcp_timeout", "tcp_refused", "network_unreachable"],
+)
+def test_probe_fails_fast_on_connect_phase_errors(raised):
+    with patch(
+        "soda_databricks.common.data_sources.databricks_data_source_connection.socket.create_connection",
+        side_effect=raised,
+    ):
+        with pytest.raises(ConnectionError):
+            _probe_databricks_reachability("bad-host.example.com")
+
+
+def test_probe_fails_fast_on_tls_handshake_error():
+    mock_sock = MagicMock()
+    mock_sock.__enter__.return_value = mock_sock
+    mock_ctx = MagicMock()
+    mock_ctx.wrap_socket.side_effect = ssl.SSLError("bad certificate")
+
+    with patch(
+        "soda_databricks.common.data_sources.databricks_data_source_connection.socket.create_connection",
+        return_value=mock_sock,
+    ), patch(
+        "soda_databricks.common.data_sources.databricks_data_source_connection.ssl.create_default_context",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(ConnectionError):
+            _probe_databricks_reachability("example.cloud.databricks.com")


### PR DESCRIPTION
## Human-authored summary

Databricks connections can take a long time to establish while the cluster warms up.  For that reason default timeout is 15 minutes.   A few months back we greatly shortened timeout because customers were waiting 15 minutes to discover their connection params were wrong (e.g. incorrect URL).  But now we're timing out before clusters come online. 

This PR adds a fast probe to see if the host is reachable and fail quickly if not, before attempting to connect with the full default timeout.   

See also: https://github.com/sodadata/soda-library/pull/726 


## Summary

- Adds a TCP+TLS pre-flight probe before `sql.connect()` for Databricks connections in soda-core v4. Fast-fails connect-phase errors (DNS, TCP refused, TLS handshake) in ~10s instead of retrying with exponential backoff for up to ~15 min.
- v4 never had PR #563's retry caps, so this is a proactive improvement — same category of hang was possible on misconfigured hostnames, just not yet reported.
- Companion to sodadata/soda-library#726 which fixes the active SCS-884 regression.

## Context

- **SCS-884:** Nubank — Databricks connection failures after agent upgrade. Root cause (in soda-library) was overly aggressive retry caps. This PR brings the same probe defense to soda-core v4 for consistency.
- **OBSL-445:** Original wrong-URL 15-min hang issue. Confirmed by Michaël as connect-phase (incorrect URL), which the probe addresses.

## Test plan

- [x] 6 new unit tests: probe success, DNS failure, TCP timeout, TCP refused, network unreachable, TLS handshake error
- [x] 15/15 full soda-databricks test suite passing (including 4 real-Databricks integration tests — probe is transparent for healthy hosts)
- [ ] End-to-end: wrong hostname confirms fast-fail (~10s instead of ~15 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)