### PR TITLE
Feat: add DB2 test dispatch + per-db guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ reports/*
 # keys
 *.pem
 *.jks
+logs/

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -150,6 +150,12 @@ class DataSourceTestHelper:
             )
 
             return TrinoDataSourceTestHelper(name)
+        elif test_datasource == "db2":
+            from soda_db2.test_helpers.db2_data_source_test_helper import (
+                Db2DataSourceTestHelper,
+            )
+
+            return Db2DataSourceTestHelper(name)
         else:
             raise AssertionError(f"Unknown test data source {test_datasource}")
 

--- a/soda-tests/tests/integration/test_query_result_iterator.py
+++ b/soda-tests/tests/integration/test_query_result_iterator.py
@@ -40,6 +40,7 @@ def test_data_source_query_result_iterator(data_source_test_helper: DataSourceTe
                 "databricks",
                 "athena",
                 "dremio",
+                "db2",
             ):
                 expected_row_count = -1
             # Other datasources should correctly return row count

--- a/soda-tests/tests/integration/test_sql_ast_inserts.py
+++ b/soda-tests/tests/integration/test_sql_ast_inserts.py
@@ -231,10 +231,24 @@ def test_full_create_insert_drop_ast(data_source_test_helper: DataSourceTestHelp
         assert result.rows[2][4] is None
 
         # Check that the timezone is correctly set, otherwise assume utc.
-        assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
-            2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
-        )
-        assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(datetime.datetime(2021, 1, 2, 10, 0, 0))
+        # DB2 LUW v11.5 (and others without TIMESTAMP WITH TIME ZONE)
+        # store the wall-clock value tz-naive; the inserted Pacific tz value
+        # comes back as the unconverted local time interpreted as UTC.
+        tz_unaware_data_sources = ("db2",)
+        if data_source_impl.type_name in tz_unaware_data_sources:
+            assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
+                2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            )
+            assert interpret_datetime_as_utc(result.rows[1][5]) == datetime.datetime(
+                2021, 1, 2, 10, 0, 0, tzinfo=datetime.timezone.utc
+            )
+        else:
+            assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
+                2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            )
+            assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(
+                datetime.datetime(2021, 1, 2, 10, 0, 0)
+            )
         assert result.rows[2][5] is None
 
         assert result.rows[0][6] == 100

--- a/soda-tests/tests/integration/test_sql_ast_inserts.py
+++ b/soda-tests/tests/integration/test_sql_ast_inserts.py
@@ -231,22 +231,10 @@ def test_full_create_insert_drop_ast(data_source_test_helper: DataSourceTestHelp
         assert result.rows[2][4] is None
 
         # Check that the timezone is correctly set, otherwise assume utc.
-        # DB2 LUW v11.5 (and others without TIMESTAMP WITH TIME ZONE)
-        # store the wall-clock value tz-naive; the inserted Pacific tz value
-        # comes back as the unconverted local time interpreted as UTC.
-        tz_unaware_data_sources = ("db2",)
-        if data_source_impl.type_name in tz_unaware_data_sources:
-            assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
-                2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
-            )
-            assert interpret_datetime_as_utc(result.rows[1][5]) == datetime.datetime(
-                2021, 1, 2, 10, 0, 0, tzinfo=datetime.timezone.utc
-            )
-        else:
-            assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
-                2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
-            )
-            assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(datetime.datetime(2021, 1, 2, 10, 0, 0))
+        assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
+            2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(datetime.datetime(2021, 1, 2, 10, 0, 0))
         assert result.rows[2][5] is None
 
         assert result.rows[0][6] == 100

--- a/soda-tests/tests/integration/test_sql_ast_inserts.py
+++ b/soda-tests/tests/integration/test_sql_ast_inserts.py
@@ -246,9 +246,7 @@ def test_full_create_insert_drop_ast(data_source_test_helper: DataSourceTestHelp
             assert interpret_datetime_as_utc(result.rows[0][5]) == datetime.datetime(
                 2021, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
             )
-            assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(
-                datetime.datetime(2021, 1, 2, 10, 0, 0)
-            )
+            assert interpret_datetime_as_utc(result.rows[1][5]) == tz.localize(datetime.datetime(2021, 1, 2, 10, 0, 0))
         assert result.rows[2][5] is None
 
         assert result.rows[0][6] == 100


### PR DESCRIPTION
## Summary
- Add `db2` branch in `DataSourceTestHelper.create()` for test dispatch
- Add `db2` to `cursor.rowcount = -1` list in `test_query_result_iterator`
- Add `tz_unaware_data_sources` branch in `test_full_create_insert_drop_ast` for DB2's lack of TIMESTAMP WITH TIME ZONE

## Context
These are test-only changes needed to run the canonical soda-tests suite against DB2 LUW. The adapter itself lives in soda-extensions (sodadata/soda-extensions#346).

## Test plan
- [ ] Verify no regressions on existing adapters (postgres, snowflake, etc.)
- [ ] CI run with `TEST_DATASOURCE=db2` once soda-extensions adapter is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)