### PR TITLE
Normalize pyodbc.Row objects so downstream consumers see plain tuples.

### DIFF
--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -4,7 +4,7 @@ import logging
 import struct
 from abc import ABC
 from datetime import datetime, timedelta, timezone
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import pyodbc
 from pydantic import Field, SecretStr
@@ -108,6 +108,13 @@ def handle_datetimeoffset(dto_value):
 class SqlServerDataSourceConnection(DataSourceConnection):
     def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
         super().__init__(name, connection_properties)
+
+    # Normalize pyodbc.Row objects so downstream consumers see plain tuples.
+    def _format_rows(self, rows: list[tuple]) -> list[tuple]:
+        return [self._format_row(row) for row in rows]
+
+    def _format_row(self, row: Any) -> tuple:
+        return tuple(row)
 
     def build_connection_string(self, config: SqlServerConnectionProperties):
         conn_params = []


### PR DESCRIPTION
## Description
Normalize pyodbc.Row objects for SQL Server so downstream consumers see plain tuples.

## Checklist

- [ ] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
