### PR TITLE
DES-291: Support numeric precision/scale and datetime precision in schema checks

### DIFF
--- a/soda-core/src/soda_core/contracts/contract_generator.py
+++ b/soda-core/src/soda_core/contracts/contract_generator.py
@@ -33,5 +33,6 @@ class IContractGenerator:
         soda_cloud: Optional[SodaCloud],
         use_agent: bool,
         generate_checks: bool = True,
+        include_type_parameters: bool = True,
     ):
         raise NotImplementedError("No implementation for create_skeleton() yet. Please install an appropriate plugin.")

--- a/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
@@ -62,41 +62,22 @@ class ColumnDataTypeMismatch:
     actual_datetime_precision: Optional[int]
 
     def get_expected(self) -> str:
-        return self._format_data_type(
-            self.expected_data_type,
-            self.expected_character_maximum_length,
-            self.expected_numeric_precision,
-            self.expected_numeric_scale,
-            self.expected_datetime_precision,
-        )
+        return SqlDataType(
+            name=self.expected_data_type,
+            character_maximum_length=self.expected_character_maximum_length,
+            numeric_precision=self.expected_numeric_precision,
+            numeric_scale=self.expected_numeric_scale,
+            datetime_precision=self.expected_datetime_precision,
+        ).get_sql_data_type_str_with_parameters()
 
     def get_actual(self) -> str:
-        return self._format_data_type(
-            self.actual_data_type,
-            self.actual_character_maximum_length,
-            self.actual_numeric_precision,
-            self.actual_numeric_scale,
-            self.actual_datetime_precision,
-        )
-
-    @classmethod
-    def _format_data_type(
-        cls,
-        name: str,
-        character_maximum_length: Optional[int],
-        numeric_precision: Optional[int],
-        numeric_scale: Optional[int],
-        datetime_precision: Optional[int],
-    ) -> str:
-        if isinstance(character_maximum_length, int):
-            return f"{name}({character_maximum_length})"
-        if isinstance(numeric_precision, int) and isinstance(numeric_scale, int):
-            return f"{name}({numeric_precision},{numeric_scale})"
-        if isinstance(numeric_precision, int):
-            return f"{name}({numeric_precision})"
-        if isinstance(datetime_precision, int):
-            return f"{name}({datetime_precision})"
-        return name
+        return SqlDataType(
+            name=self.actual_data_type,
+            character_maximum_length=self.actual_character_maximum_length,
+            numeric_precision=self.actual_numeric_precision,
+            numeric_scale=self.actual_numeric_scale,
+            datetime_precision=self.actual_datetime_precision,
+        ).get_sql_data_type_str_with_parameters()
 
 
 class SchemaCheckImpl(CheckImpl):

--- a/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
@@ -52,18 +52,51 @@ class ColumnDataTypeMismatch:
     column: str
     expected_data_type: str
     expected_character_maximum_length: Optional[int]
+    expected_numeric_precision: Optional[int]
+    expected_numeric_scale: Optional[int]
+    expected_datetime_precision: Optional[int]
     actual_data_type: str
     actual_character_maximum_length: Optional[int]
+    actual_numeric_precision: Optional[int]
+    actual_numeric_scale: Optional[int]
+    actual_datetime_precision: Optional[int]
 
     def get_expected(self) -> str:
-        return f"{self.expected_data_type}{self.get_optional_length_str(self.expected_character_maximum_length)}"
+        return self._format_data_type(
+            self.expected_data_type,
+            self.expected_character_maximum_length,
+            self.expected_numeric_precision,
+            self.expected_numeric_scale,
+            self.expected_datetime_precision,
+        )
 
     def get_actual(self) -> str:
-        return f"{self.actual_data_type}{self.get_optional_length_str(self.actual_character_maximum_length)}"
+        return self._format_data_type(
+            self.actual_data_type,
+            self.actual_character_maximum_length,
+            self.actual_numeric_precision,
+            self.actual_numeric_scale,
+            self.actual_datetime_precision,
+        )
 
     @classmethod
-    def get_optional_length_str(cls, character_maximum_length: Optional[int]) -> str:
-        return f"({character_maximum_length})" if isinstance(character_maximum_length, int) else ""
+    def _format_data_type(
+        cls,
+        name: str,
+        character_maximum_length: Optional[int],
+        numeric_precision: Optional[int],
+        numeric_scale: Optional[int],
+        datetime_precision: Optional[int],
+    ) -> str:
+        if isinstance(character_maximum_length, int):
+            return f"{name}({character_maximum_length})"
+        if isinstance(numeric_precision, int) and isinstance(numeric_scale, int):
+            return f"{name}({numeric_precision},{numeric_scale})"
+        if isinstance(numeric_precision, int):
+            return f"{name}({numeric_precision})"
+        if isinstance(datetime_precision, int):
+            return f"{name}({datetime_precision})"
+        return name
 
 
 class SchemaCheckImpl(CheckImpl):
@@ -87,6 +120,9 @@ class SchemaCheckImpl(CheckImpl):
                     SqlDataType(
                         name=column_impl.column_yaml.data_type,
                         character_maximum_length=column_impl.column_yaml.character_maximum_length,
+                        numeric_precision=column_impl.column_yaml.numeric_precision,
+                        numeric_scale=column_impl.column_yaml.numeric_scale,
+                        datetime_precision=column_impl.column_yaml.datetime_precision,
                     )
                     if column_impl.column_yaml.data_type
                     else None
@@ -187,13 +223,18 @@ class SchemaCheckImpl(CheckImpl):
                     continue
                 if not is_same_data_type:
                     column_data_type_mismatches.append(
-                        # TODO add numeric_scale, numeric_precision & datetime_precision to the ColumnDataTypeMismatch
                         ColumnDataTypeMismatch(
                             column=expected_column.column_name,
                             expected_data_type=expected_column.sql_data_type.name,
                             expected_character_maximum_length=expected_column.sql_data_type.character_maximum_length,
+                            expected_numeric_precision=expected_column.sql_data_type.numeric_precision,
+                            expected_numeric_scale=expected_column.sql_data_type.numeric_scale,
+                            expected_datetime_precision=expected_column.sql_data_type.datetime_precision,
                             actual_data_type=actual_column_metadata.sql_data_type.name,
                             actual_character_maximum_length=actual_column_metadata.sql_data_type.character_maximum_length,
+                            actual_numeric_precision=actual_column_metadata.sql_data_type.numeric_precision,
+                            actual_numeric_scale=actual_column_metadata.sql_data_type.numeric_scale,
+                            actual_datetime_precision=actual_column_metadata.sql_data_type.datetime_precision,
                         )
                     )
             logger.info(f"Found {len(column_data_type_mismatches)} data type mismatches.")

--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -417,6 +417,9 @@ class ColumnYaml(MissingAndValidityYaml):
         self.name: Optional[str] = column_yaml_object.read_string("name")
         self.data_type: Optional[str] = column_yaml_object.read_string_opt("data_type")
         self.character_maximum_length: Optional[int] = column_yaml_object.read_number_opt("character_maximum_length")
+        self.numeric_precision: Optional[int] = column_yaml_object.read_number_opt("numeric_precision")
+        self.numeric_scale: Optional[int] = column_yaml_object.read_number_opt("numeric_scale")
+        self.datetime_precision: Optional[int] = column_yaml_object.read_number_opt("datetime_precision")
         self.column_expression: Optional[str] = column_yaml_object.read_string_opt("column_expression")
         if self.column_expression:
             self.column_expression = self.column_expression.strip()

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -16,7 +16,11 @@ from helpers.test_table import TestColumn, TestTable, TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logs import Logs
-from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
+from soda_core.common.metadata_types import (
+    ColumnMetadata,
+    SodaDataTypeName,
+    SqlDataType,
+)
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.sql_ast import (
     COLUMN,
@@ -591,6 +595,14 @@ class DataSourceTestHelper:
             logger.debug(f"Test table {test_table.unique_name} already exists")
 
         return test_table
+
+    def get_actual_column_metadata(self, test_table: TestTable) -> dict[str, ColumnMetadata]:
+        """Fetch actual column metadata from the DB for a test table, keyed by column name."""
+        columns = self.data_source_impl.get_columns_metadata(
+            dataset_prefixes=self.dataset_prefix,
+            dataset_name=test_table.unique_name,
+        )
+        return {c.column_name: c for c in columns}
 
     def verify_test_table_row_count(self, test_table_specification: TestTableSpecification) -> bool:
         expected_row_values = test_table_specification.row_values

--- a/soda-tests/tests/integration/test_schema_check.py
+++ b/soda-tests/tests/integration/test_schema_check.py
@@ -13,6 +13,9 @@ test_table_specification = (
     .column_varchar("id")
     .column_integer("size")
     .column_date("created")
+    .column_varchar("label", character_maximum_length=100)
+    .column_numeric("score", numeric_precision=10, numeric_scale=2)
+    .column_timestamp("created_at", datetime_precision=3)
     .build()
 )
 
@@ -49,6 +52,12 @@ def test_schema(data_source_test_helper: DataSourceTestHelper, table_type: Table
               - name: size
                 data_type: {test_table.data_type('size')}
               - name: created
+              - name: label
+                data_type: {test_table.data_type('label')}
+              - name: score
+                data_type: {test_table.data_type('score')}
+              - name: created_at
+                data_type: {test_table.data_type('created_at')}
         """,
     )
 
@@ -60,11 +69,17 @@ def test_schema(data_source_test_helper: DataSourceTestHelper, table_type: Table
         "id",
         "size",
         "created",
+        "label",
+        "score",
+        "created_at",
     }
     assert set([c["name"] for c in schema_diagnostics["expected"]]) == {
         "id",
         "size",
         "created",
+        "label",
+        "score",
+        "created_at",
     }
 
 
@@ -101,6 +116,9 @@ def test_schema_warn_not_supported(data_source_test_helper: DataSourceTestHelper
         "id",
         "size",
         "created",
+        "label",
+        "score",
+        "created_at",
     }
     assert set([c["name"] for c in schema_diagnostics["expected"]]) == {"id"}
 
@@ -135,6 +153,12 @@ def test_schema_errors(data_source_test_helper: DataSourceTestHelper):
               - name: sizzze
               - name: created
                 data_type: {test_table.data_type('id')}
+              - name: label
+                data_type: {test_table.data_type('label')}
+              - name: score
+                data_type: {test_table.data_type('score')}
+              - name: created_at
+                data_type: {test_table.data_type('created_at')}
         """,
     )
 
@@ -154,6 +178,9 @@ def test_schema_default_order(data_source_test_helper: DataSourceTestHelper):
               - name: id
               - name: created
               - name: size
+              - name: label
+              - name: score
+              - name: created_at
         """,
     )
 
@@ -174,6 +201,9 @@ def test_schema_allow_out_of_order(data_source_test_helper: DataSourceTestHelper
               - name: id
               - name: created
               - name: size
+              - name: label
+              - name: score
+              - name: created_at
         """,
     )
 
@@ -196,7 +226,7 @@ def test_schema_extra_columns_default(data_source_test_helper: DataSourceTestHel
     )
 
     schema_check_result: SchemaCheckResult = contract_verification_result.check_results[0]
-    assert schema_check_result.actual_column_names_not_expected == ["created"]
+    assert schema_check_result.actual_column_names_not_expected == ["created", "label", "score", "created_at"]
 
 
 def test_schema_allow_extra_columns(data_source_test_helper: DataSourceTestHelper):
@@ -216,6 +246,110 @@ def test_schema_allow_extra_columns(data_source_test_helper: DataSourceTestHelpe
 
     schema_check_result: SchemaCheckResult = contract_verification_result.check_results[0]
     assert schema_check_result.actual_column_names_not_expected == []
+
+
+def test_schema_precision_pass(data_source_test_helper: DataSourceTestHelper):
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+    sql_dialect = data_source_test_helper.data_source_impl.sql_dialect
+
+    label_extras = ""
+    if sql_dialect.supports_data_type_character_maximum_length():
+        label_extras = "character_maximum_length: 100"
+
+    score_extras = ""
+    if sql_dialect.supports_data_type_numeric_precision():
+        score_extras = "numeric_precision: 10"
+        if sql_dialect.supports_data_type_numeric_scale():
+            score_extras += "\n                numeric_scale: 2"
+
+    ts_extras = ""
+    if sql_dialect.supports_data_type_datetime_precision():
+        ts_extras = "datetime_precision: 3"
+
+    data_source_test_helper.assert_contract_pass(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - schema:
+            columns:
+              - name: id
+                data_type: {test_table.data_type('id')}
+              - name: size
+                data_type: {test_table.data_type('size')}
+              - name: created
+              - name: label
+                data_type: {test_table.data_type('label')}
+                {label_extras}
+              - name: score
+                data_type: {test_table.data_type('score')}
+                {score_extras}
+              - name: created_at
+                data_type: {test_table.data_type('created_at')}
+                {ts_extras}
+        """,
+    )
+
+
+def test_schema_precision_mismatch(data_source_test_helper: DataSourceTestHelper):
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+    sql_dialect = data_source_test_helper.data_source_impl.sql_dialect
+
+    # Build wrong precision values for each supported type and count expected mismatches
+    n_expected_mismatches = 0
+
+    label_extras = ""
+    if sql_dialect.supports_data_type_character_maximum_length():
+        # Table has character_maximum_length=100, specify 200
+        label_extras = "character_maximum_length: 200"
+        length_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
+            expected=SqlDataType(name=test_table.data_type("label"), character_maximum_length=200),
+            actual=SqlDataType(name=test_table.data_type("label"), character_maximum_length=100),
+        )
+        if length_mismatch_detected:
+            n_expected_mismatches += 1
+
+    score_extras = ""
+    if sql_dialect.supports_data_type_numeric_precision():
+        # Table has numeric_precision=10, numeric_scale=2, specify 15 and 5
+        score_extras = "numeric_precision: 15"
+        if sql_dialect.supports_data_type_numeric_scale():
+            score_extras += "\n                numeric_scale: 5"
+        n_expected_mismatches += 1
+
+    ts_extras = ""
+    if sql_dialect.supports_data_type_datetime_precision():
+        # Table has datetime_precision=3, specify 6
+        ts_extras = "datetime_precision: 6"
+        n_expected_mismatches += 1
+
+    if n_expected_mismatches == 0:
+        pytest.skip("Dialect does not support any precision types")
+
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - schema:
+            columns:
+              - name: id
+                data_type: {test_table.data_type('id')}
+              - name: size
+                data_type: {test_table.data_type('size')}
+              - name: created
+              - name: label
+                data_type: {test_table.data_type('label')}
+                {label_extras}
+              - name: score
+                data_type: {test_table.data_type('score')}
+                {score_extras}
+              - name: created_at
+                data_type: {test_table.data_type('created_at')}
+                {ts_extras}
+        """,
+    )
+
+    schema_check_result: SchemaCheckResult = contract_verification_result.check_results[0]
+    assert len(schema_check_result.column_data_type_mismatches) == n_expected_mismatches
 
 
 def test_schema_metadata_query_exists(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_schema_check.py
+++ b/soda-tests/tests/integration/test_schema_check.py
@@ -252,19 +252,34 @@ def test_schema_precision_pass(data_source_test_helper: DataSourceTestHelper):
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
     sql_dialect = data_source_test_helper.data_source_impl.sql_dialect
 
+    # Use actual DB metadata values — dialects may adjust precision from what was requested
+    # in the table spec (e.g. Trino normalizes datetime_precision=3 to 6).
+    actual_by_name = data_source_test_helper.get_actual_column_metadata(test_table)
+
+    n_precision_fields_tested = 0
+
     label_extras = ""
-    if sql_dialect.supports_data_type_character_maximum_length():
-        label_extras = "character_maximum_length: 100"
+    actual_label = actual_by_name["label"].sql_data_type
+    if actual_label.character_maximum_length is not None:
+        label_extras = f"character_maximum_length: {actual_label.character_maximum_length}"
+        n_precision_fields_tested += 1
 
     score_extras = ""
-    if sql_dialect.supports_data_type_numeric_precision():
-        score_extras = "numeric_precision: 10"
-        if sql_dialect.supports_data_type_numeric_scale():
-            score_extras += "\n                numeric_scale: 2"
+    actual_score = actual_by_name["score"].sql_data_type
+    if actual_score.numeric_precision is not None:
+        score_extras = f"numeric_precision: {actual_score.numeric_precision}"
+        n_precision_fields_tested += 1
+        if actual_score.numeric_scale is not None:
+            score_extras += f"\n                numeric_scale: {actual_score.numeric_scale}"
 
     ts_extras = ""
-    if sql_dialect.supports_data_type_datetime_precision():
-        ts_extras = "datetime_precision: 3"
+    actual_ts = actual_by_name["created_at"].sql_data_type
+    if actual_ts.datetime_precision is not None:
+        ts_extras = f"datetime_precision: {actual_ts.datetime_precision}"
+        n_precision_fields_tested += 1
+
+    if n_precision_fields_tested == 0:
+        pytest.skip("Dialect does not return any precision metadata")
 
     data_source_test_helper.assert_contract_pass(
         test_table=test_table,
@@ -294,44 +309,47 @@ def test_schema_precision_mismatch(data_source_test_helper: DataSourceTestHelper
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
     sql_dialect = data_source_test_helper.data_source_impl.sql_dialect
 
-    # Build wrong precision values for each supported type and count expected mismatches
+    # Use actual DB metadata — dialects may adjust precision from what was requested.
+    # Derive "wrong" values from actuals to guarantee they differ.
+    actual_by_name = data_source_test_helper.get_actual_column_metadata(test_table)
     n_expected_mismatches = 0
 
     label_extras = ""
-    if sql_dialect.supports_data_type_character_maximum_length():
-        # Table has character_maximum_length=100, specify 200
-        label_extras = "character_maximum_length: 200"
+    actual_label = actual_by_name["label"].sql_data_type
+    if actual_label.character_maximum_length is not None:
+        wrong_length = actual_label.character_maximum_length + 100
+        label_extras = f"character_maximum_length: {wrong_length}"
         length_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
-            expected=SqlDataType(name=test_table.data_type("label"), character_maximum_length=200),
-            actual=SqlDataType(name=test_table.data_type("label"), character_maximum_length=100),
+            expected=SqlDataType(name=actual_label.name, character_maximum_length=wrong_length),
+            actual=actual_label,
         )
         if length_mismatch_detected:
             n_expected_mismatches += 1
 
     score_extras = ""
-    if sql_dialect.supports_data_type_numeric_precision():
-        # Table has numeric_precision=10, numeric_scale=2, specify 15 and 5
-        score_extras = "numeric_precision: 15"
-        expected_scale = None
-        if sql_dialect.supports_data_type_numeric_scale():
-            score_extras += "\n                numeric_scale: 5"
-            expected_scale = 5
+    actual_score = actual_by_name["score"].sql_data_type
+    if actual_score.numeric_precision is not None:
+        wrong_precision = actual_score.numeric_precision + 5
+        score_extras = f"numeric_precision: {wrong_precision}"
+        wrong_scale = None
+        if actual_score.numeric_scale is not None:
+            wrong_scale = actual_score.numeric_scale + 3
+            score_extras += f"\n                numeric_scale: {wrong_scale}"
         numeric_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
-            expected=SqlDataType(
-                name=test_table.data_type("score"), numeric_precision=15, numeric_scale=expected_scale
-            ),
-            actual=SqlDataType(name=test_table.data_type("score"), numeric_precision=10, numeric_scale=2),
+            expected=SqlDataType(name=actual_score.name, numeric_precision=wrong_precision, numeric_scale=wrong_scale),
+            actual=actual_score,
         )
         if numeric_mismatch_detected:
             n_expected_mismatches += 1
 
     ts_extras = ""
-    if sql_dialect.supports_data_type_datetime_precision():
-        # Table has datetime_precision=3, specify 6
-        ts_extras = "datetime_precision: 6"
+    actual_ts = actual_by_name["created_at"].sql_data_type
+    if actual_ts.datetime_precision is not None:
+        wrong_dt_precision = actual_ts.datetime_precision + 1
+        ts_extras = f"datetime_precision: {wrong_dt_precision}"
         datetime_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
-            expected=SqlDataType(name=test_table.data_type("created_at"), datetime_precision=6),
-            actual=SqlDataType(name=test_table.data_type("created_at"), datetime_precision=3),
+            expected=SqlDataType(name=actual_ts.name, datetime_precision=wrong_dt_precision),
+            actual=actual_ts,
         )
         if datetime_mismatch_detected:
             n_expected_mismatches += 1

--- a/soda-tests/tests/integration/test_schema_check.py
+++ b/soda-tests/tests/integration/test_schema_check.py
@@ -312,15 +312,29 @@ def test_schema_precision_mismatch(data_source_test_helper: DataSourceTestHelper
     if sql_dialect.supports_data_type_numeric_precision():
         # Table has numeric_precision=10, numeric_scale=2, specify 15 and 5
         score_extras = "numeric_precision: 15"
+        expected_scale = None
         if sql_dialect.supports_data_type_numeric_scale():
             score_extras += "\n                numeric_scale: 5"
-        n_expected_mismatches += 1
+            expected_scale = 5
+        numeric_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
+            expected=SqlDataType(
+                name=test_table.data_type("score"), numeric_precision=15, numeric_scale=expected_scale
+            ),
+            actual=SqlDataType(name=test_table.data_type("score"), numeric_precision=10, numeric_scale=2),
+        )
+        if numeric_mismatch_detected:
+            n_expected_mismatches += 1
 
     ts_extras = ""
     if sql_dialect.supports_data_type_datetime_precision():
         # Table has datetime_precision=3, specify 6
         ts_extras = "datetime_precision: 6"
-        n_expected_mismatches += 1
+        datetime_mismatch_detected = not sql_dialect.is_same_data_type_for_schema_check(
+            expected=SqlDataType(name=test_table.data_type("created_at"), datetime_precision=6),
+            actual=SqlDataType(name=test_table.data_type("created_at"), datetime_precision=3),
+        )
+        if datetime_mismatch_detected:
+            n_expected_mismatches += 1
 
     if n_expected_mismatches == 0:
         pytest.skip("Dialect does not support any precision types")

--- a/soda-tests/tests/unit/check_types/impl/test_schema_check_impl.py
+++ b/soda-tests/tests/unit/check_types/impl/test_schema_check_impl.py
@@ -211,6 +211,38 @@ def test_schema_evaluate_passes_with_allow_extra_columns():
     assert result.actual_column_names_not_expected == []
 
 
+def test_schema_expected_columns_with_numeric_precision():
+    """expected_columns should include numeric_precision and numeric_scale when specified."""
+    contract_yaml = """
+    dataset: my_data_source/my_dataset
+    columns:
+      - name: score
+        data_type: numeric
+        numeric_precision: 10
+        numeric_scale: 2
+    checks:
+      - schema:
+    """
+    check = get_check_impl(contract_yaml)
+    assert check.expected_columns[0].sql_data_type.numeric_precision == 10
+    assert check.expected_columns[0].sql_data_type.numeric_scale == 2
+
+
+def test_schema_expected_columns_with_datetime_precision():
+    """expected_columns should include datetime_precision when specified."""
+    contract_yaml = """
+    dataset: my_data_source/my_dataset
+    columns:
+      - name: created_at
+        data_type: timestamp
+        datetime_precision: 6
+    checks:
+      - schema:
+    """
+    check = get_check_impl(contract_yaml)
+    assert check.expected_columns[0].sql_data_type.datetime_precision == 6
+
+
 def test_schema_evaluate_schema_events_count():
     """SchemaCheckResult.diagnostic_metric_values should include schema_events_count."""
     contract_yaml = """


### PR DESCRIPTION
## Summary
- Wire `numeric_precision`, `numeric_scale`, and `datetime_precision` through from contract YAML parsing → schema check expected columns → mismatch reporting
- Add `include_type_parameters` param to `IContractGenerator` interface (default `True`)
- Extend `ColumnDataTypeMismatch` to report precision/scale/datetime mismatches with proper formatting
- Integration tests verify precision match/mismatch across all data sources
- Unit tests verify YAML parsing populates precision fields on expected columns

## Context
Schema checks silently ignored precision parameters because the YAML parser and expected-column builder only wired through `character_maximum_length`. The comparison engine (`is_same_data_type_for_schema_check`) already supported all five parameters. HelloFresh flagged this as a blocker — their generated contracts included precision but schema checks ignored it, causing false passes.

## Test plan
- [x] Unit tests: `test_schema_expected_columns_with_numeric_precision`, `test_schema_expected_columns_with_datetime_precision`
- [x] Integration tests: `test_schema_precision_pass`, `test_schema_precision_mismatch` (dialect-aware)
- [x] Manual testing against Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)