### PR TITLE
Chore/spark4 compatibility

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",


### PR DESCRIPTION
# Description

## What problem are you solving?

`soda-sparkdf` was not verified to work with PySpark 4.0+. The `uv.lock` was
resolving to PySpark 3.x, meaning CI was never testing against PySpark 4.x.

## Changes

- Update `uv.lock` to resolve `pyspark` to 4.1.1 (latest), while keeping the
  package requirement at `pyspark>=3.5.0` for backward compatibility with
  existing Spark 3.5 users

## Expected impact on downstream packages/services

- No functional code changes — existing Spark 3.5 users are unaffected
- Spark 4.0+ users gain verified compatibility via CI
- No foreseeable impact on `soda-extensions`. No extension code references
  spark, pyspark, or sparkdf. The only mentions are CI workflow options for
  manual runs, which delegate entirely to soda-core's soda-sparkdf. No changes
  needed there.

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
