### PR TITLE
Feat: Add internal streaming support

### DIFF
--- a/soda-core/src/soda_core/common/streaming/__init__.py
+++ b/soda-core/src/soda_core/common/streaming/__init__.py
@@ -1,0 +1,11 @@
+from soda_core.common.streaming.streaming_action_handle import StreamingActionHandle
+from soda_core.common.streaming.streaming_consumer import StreamingConsumer
+from soda_core.common.streaming.streaming_orchestrator import StreamingOrchestrator
+from soda_core.common.streaming.streaming_producer import StreamingProducer
+
+__all__ = [
+    "StreamingConsumer",
+    "StreamingProducer",
+    "StreamingActionHandle",
+    "StreamingOrchestrator",
+]

--- a/soda-core/src/soda_core/common/streaming/streaming_action_handle.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_action_handle.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from soda_core.common.logging_constants import soda_logger
+from soda_core.common.streaming.streaming_consumer import StreamingConsumer
+
+logger = soda_logger
+
+
+class StreamingActionHandle:
+    """Handle returned to producers for streaming data to consumers.
+
+    Supports context manager usage to ensure finish() is always called.
+    Consumer failures are logged but never raised to the producer.
+    """
+
+    def __init__(self, action: str, consumers: list[StreamingConsumer]):
+        self._action = action
+        self._consumers = consumers
+        self._finished = False
+
+    def new_data(self, data: Any) -> None:
+        """Dispatch data to all active consumers. Failures are logged, not raised."""
+        for consumer in self._consumers:
+            try:
+                consumer.process_data(self._action, data)
+            except Exception:
+                logger.warning(
+                    f"Streaming consumer {type(consumer).__name__} failed during process_data for action '{self._action}'",
+                    exc_info=True,
+                )
+
+    def finish(self) -> None:
+        """Signal completion to all consumers. Idempotent."""
+        if self._finished:
+            return
+        self._finished = True
+        for consumer in self._consumers:
+            try:
+                consumer.finish(self._action)
+            except Exception:
+                logger.warning(
+                    f"Streaming consumer {type(consumer).__name__} failed during finish for action '{self._action}'",
+                    exc_info=True,
+                )
+
+    def __enter__(self) -> StreamingActionHandle:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self.finish()
+        # Never suppress the producer's exception
+        return False

--- a/soda-core/src/soda_core/common/streaming/streaming_consumer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_consumer.py
@@ -16,19 +16,15 @@ class StreamingConsumer(ABC):
     @abstractmethod
     def supported_actions(self) -> list[str]:
         """Return the action names this consumer handles (e.g. "recon_check_differences")."""
-        pass
 
     @abstractmethod
     def initialize(self, action: str, context: dict[str, Any]) -> None:
         """Set up for receiving data (e.g. open connection, create table)."""
-        pass
 
     @abstractmethod
     def process_data(self, action: str, data: Any) -> None:
         """Handle one piece of data from a producer."""
-        pass
 
     @abstractmethod
     def finish(self, action: str) -> None:
         """Clean up after streaming is done (e.g. flush, close connection)."""
-        pass

--- a/soda-core/src/soda_core/common/streaming/streaming_consumer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_consumer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class StreamingConsumer(ABC):
+    """Abstract base class for streaming consumers.
+
+    Consumers register with the StreamingOrchestrator and receive data
+    from producers during check execution. This allows post-processing
+    handlers (like DWH) to receive data in-flight without re-executing
+    the check.
+    """
+
+    @abstractmethod
+    def supported_actions(self) -> list[str]:
+        """Return the action names this consumer handles (e.g. "recon_check_differences")."""
+        pass
+
+    @abstractmethod
+    def initialize(self, action: str, context: dict[str, Any]) -> None:
+        """Set up for receiving data (e.g. open connection, create table)."""
+        pass
+
+    @abstractmethod
+    def process_data(self, action: str, data: Any) -> None:
+        """Handle one piece of data from a producer."""
+        pass
+
+    @abstractmethod
+    def finish(self, action: str) -> None:
+        """Clean up after streaming is done (e.g. flush, close connection)."""
+        pass

--- a/soda-core/src/soda_core/common/streaming/streaming_orchestrator.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_orchestrator.py
@@ -10,9 +10,18 @@ logger = soda_logger
 
 
 class StreamingOrchestrator:
-    """Singleton (class-level state) that manages streaming consumer registration and action dispatch.
+    """Module-level registry of streaming consumers (class-level mutable state).
 
-    Follows the ContractVerificationHandlerRegistry pattern.
+    Same shape as `ContractVerificationHandlerRegistry`: consumers register at plugin-load
+    time and stay registered for the process lifetime; producers ask the orchestrator to
+    initialize an action and receive a handle that dispatches data to all matching consumers.
+
+    Concurrency: consumers carry per-instance state (e.g. `ReconRowsDiffDwhConsumer` holds
+    `_pending_rows`, `_dwh_data_source_impl`, `_context`). The current contract-verification
+    flow is sequential, so a single consumer instance is reused across actions without
+    overlap. If/when verifications run concurrently, this design must change — either
+    consumers must be stateless and key all per-action state on the action handle, or each
+    `initialize_action` must hand out fresh consumer instances.
     """
 
     _consumers: list[StreamingConsumer] = []
@@ -57,6 +66,10 @@ class StreamingOrchestrator:
 
     @classmethod
     def reset(cls) -> None:
-        """Clear all state. Used in tests."""
+        """Clear all registered consumers.
+
+        Primarily used by test fixtures to isolate consumer registration between tests, but
+        also valid in any setup that tears down and re-initializes the plugin layer.
+        """
         cls._consumers = []
         cls._action_consumers = {}

--- a/soda-core/src/soda_core/common/streaming/streaming_orchestrator.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_orchestrator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from soda_core.common.logging_constants import soda_logger
+from soda_core.common.streaming.streaming_action_handle import StreamingActionHandle
+from soda_core.common.streaming.streaming_consumer import StreamingConsumer
+
+logger = soda_logger
+
+
+class StreamingOrchestrator:
+    """Singleton (class-level state) that manages streaming consumer registration and action dispatch.
+
+    Follows the ContractVerificationHandlerRegistry pattern.
+    """
+
+    _consumers: list[StreamingConsumer] = []
+    _action_consumers: dict[str, list[StreamingConsumer]] = {}
+
+    @classmethod
+    def register_consumer(cls, consumer: StreamingConsumer) -> None:
+        cls._consumers.append(consumer)
+        cls._rebuild_action_map()
+
+    @classmethod
+    def _rebuild_action_map(cls) -> None:
+        action_map: dict[str, list[StreamingConsumer]] = {}
+        for consumer in cls._consumers:
+            for action in consumer.supported_actions():
+                action_map.setdefault(action, []).append(consumer)
+        cls._action_consumers = action_map
+
+    @classmethod
+    def initialize_action(cls, action: str, context: dict[str, Any] | None = None) -> StreamingActionHandle:
+        """Initialize matching consumers and return a handle for streaming data.
+
+        Consumers that fail to initialize are excluded from the handle.
+        """
+        if context is None:
+            context = {}
+
+        matching_consumers = cls._action_consumers.get(action, [])
+        active_consumers: list[StreamingConsumer] = []
+
+        for consumer in matching_consumers:
+            try:
+                consumer.initialize(action, context)
+                active_consumers.append(consumer)
+            except Exception:
+                logger.warning(
+                    f"Streaming consumer {type(consumer).__name__} failed to initialize for action '{action}'",
+                    exc_info=True,
+                )
+
+        return StreamingActionHandle(action=action, consumers=active_consumers)
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear all state. Used in tests."""
+        cls._consumers = []
+        cls._action_consumers = {}

--- a/soda-core/src/soda_core/common/streaming/streaming_producer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_producer.py
@@ -23,6 +23,6 @@ class StreamingProducer(ABC):
         produced_actions = self.produced_actions()
         if action not in produced_actions:
             raise ValueError(
-                f"{type(self).__name__} does not produce action '{action}'. " f"Produced actions: {produced_actions}"
+                f"{type(self).__name__} does not produce action '{action}'. Produced actions: {produced_actions}"
             )
         return StreamingOrchestrator.initialize_action(action, context)

--- a/soda-core/src/soda_core/common/streaming/streaming_producer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_producer.py
@@ -20,9 +20,10 @@ class StreamingProducer(ABC):
 
     def initialize_action(self, action: str, context: dict[str, Any] | None = None) -> StreamingActionHandle:
         """Convenience method that validates the action and delegates to StreamingOrchestrator."""
-        if action not in self.produced_actions():
+        produced_actions = self.produced_actions()
+        if action not in produced_actions:
             raise ValueError(
                 f"{type(self).__name__} does not produce action '{action}'. "
-                f"Produced actions: {self.produced_actions()}"
+                f"Produced actions: {produced_actions}"
             )
         return StreamingOrchestrator.initialize_action(action, context)

--- a/soda-core/src/soda_core/common/streaming/streaming_producer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_producer.py
@@ -17,7 +17,6 @@ class StreamingProducer(ABC):
     @abstractmethod
     def produced_actions(self) -> list[str]:
         """Declare what actions this producer generates."""
-        pass
 
     def initialize_action(self, action: str, context: dict[str, Any] | None = None) -> StreamingActionHandle:
         """Convenience method that validates the action and delegates to StreamingOrchestrator."""

--- a/soda-core/src/soda_core/common/streaming/streaming_producer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_producer.py
@@ -23,7 +23,6 @@ class StreamingProducer(ABC):
         produced_actions = self.produced_actions()
         if action not in produced_actions:
             raise ValueError(
-                f"{type(self).__name__} does not produce action '{action}'. "
-                f"Produced actions: {produced_actions}"
+                f"{type(self).__name__} does not produce action '{action}'. " f"Produced actions: {produced_actions}"
             )
         return StreamingOrchestrator.initialize_action(action, context)

--- a/soda-core/src/soda_core/common/streaming/streaming_producer.py
+++ b/soda-core/src/soda_core/common/streaming/streaming_producer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from soda_core.common.streaming.streaming_action_handle import StreamingActionHandle
+from soda_core.common.streaming.streaming_orchestrator import StreamingOrchestrator
+
+
+class StreamingProducer(ABC):
+    """Abstract base class for streaming producers (mixin).
+
+    Producers are NOT registered with the orchestrator. This ABC exists for
+    self-documentation, validation, and generalizability. Checks use it as a mixin.
+    """
+
+    @abstractmethod
+    def produced_actions(self) -> list[str]:
+        """Declare what actions this producer generates."""
+        pass
+
+    def initialize_action(self, action: str, context: dict[str, Any] | None = None) -> StreamingActionHandle:
+        """Convenience method that validates the action and delegates to StreamingOrchestrator."""
+        if action not in self.produced_actions():
+            raise ValueError(
+                f"{type(self).__name__} does not produce action '{action}'. "
+                f"Produced actions: {self.produced_actions()}"
+            )
+        return StreamingOrchestrator.initialize_action(action, context)

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.dataset_identifier import DatasetIdentifier
@@ -32,13 +32,17 @@ class SynapseDataSourceImpl(SqlServerDataSourceImpl, model_class=SynapseDataSour
         super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
-        # Hand the dialect a back-reference to this data source impl so its paginator can
-        # resolve the table's column list via INFORMATION_SCHEMA when the caller didn't
-        # enumerate columns. This is Synapse-specific because the ROW_NUMBER()-based
-        # paginator below needs explicit columns to avoid leaking the synthetic rn column.
-        dialect = SynapseSqlDialect()
-        dialect._data_source_impl = self
-        return dialect
+        # Inject a column-name resolver so the ROW_NUMBER paginator can fall back to the
+        # table's column list when the caller didn't supply an explicit `columns`. The
+        # callable pattern (as used by Athena's `get_table_storage_location`) keeps the
+        # dialect decoupled from `DataSourceImpl` per PR #2600.
+        return SynapseSqlDialect(get_column_names=self._get_column_names_for_pagination)
+
+    def _get_column_names_for_pagination(self, dataset_prefixes: list[str], dataset_name: str) -> list[str]:
+        return [
+            cm.column_name
+            for cm in self.get_columns_metadata(dataset_prefixes=dataset_prefixes, dataset_name=dataset_name)
+        ]
 
     def _create_data_source_connection(self) -> DataSourceConnection:
         return SynapseDataSourceConnection(
@@ -47,6 +51,19 @@ class SynapseDataSourceImpl(SqlServerDataSourceImpl, model_class=SynapseDataSour
 
 
 class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
+    def __init__(self, get_column_names: Optional[Callable[[list[str], str], list[str]]] = None):
+        super().__init__()
+        # Optional callable that resolves a table's column names from `(prefixes, name)`. Used
+        # by `select_all_paginated_sql` when the caller didn't supply an explicit `columns`.
+        # Mirrors Athena's `get_table_storage_location` injection pattern from PR #2600 — the
+        # dialect stays decoupled from `DataSourceImpl` and just has a function it can call.
+        # Optional so the dialect can still be constructed in tests / contexts that don't
+        # paginate or always pass explicit columns.
+        self._get_column_names: Optional[Callable[[list[str], str], list[str]]] = get_column_names
+        # Cache of resolved column lists keyed by (prefixes_tuple, dataset_name) so we don't
+        # issue a metadata round-trip per page during a paginated scan.
+        self._columns_cache: dict[tuple[tuple[str, ...], str], list[str]] = {}
+
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True
     ) -> str:
@@ -108,24 +125,20 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         # outer SELECT, so rn never leaks and no JOIN is needed.
         #
         # We need an explicit column list to project rn out. When the caller doesn't supply
-        # one (e.g. rows_diff with no `source_columns`/`target_columns` in YAML), we resolve
-        # the table's columns via INFORMATION_SCHEMA using the back-reference set by
-        # `SynapseDataSourceImpl._create_sql_dialect`. Other dialects don't need this because
-        # they paginate with native OFFSET/LIMIT and `SELECT *` works fine.
+        # one (e.g. rows_diff with no `source_columns`/`target_columns` in YAML), the dialect
+        # falls back to the injected `get_column_names` callable. Other dialects don't need
+        # this because they paginate with native OFFSET/LIMIT and `SELECT *` works fine.
         if not columns:
-            data_source_impl = getattr(self, "_data_source_impl", None)
-            if data_source_impl is None:
-                raise ValueError(
-                    "Synapse paginator requires explicit `columns` (or a SynapseDataSourceImpl "
-                    "back-reference) to avoid leaking the synthetic rn column into the result set."
-                )
-            columns = [
-                cm.column_name
-                for cm in data_source_impl.get_columns_metadata(
-                    dataset_prefixes=dataset_identifier.prefixes,
-                    dataset_name=dataset_identifier.dataset_name,
-                )
-            ]
+            assert self._get_column_names is not None, (
+                "SynapseSqlDialect needs `get_column_names` to be supplied at construction "
+                "(via `SynapseDataSourceImpl._create_sql_dialect`) or an explicit `columns` list."
+            )
+            cache_key = (tuple(dataset_identifier.prefixes), dataset_identifier.dataset_name)
+            cached = self._columns_cache.get(cache_key)
+            if cached is None:
+                cached = self._get_column_names(dataset_identifier.prefixes, dataset_identifier.dataset_name)
+                self._columns_cache[cache_key] = cached
+            columns = cached
         qualified_table = self.build_fully_qualified_sql_name(dataset_identifier)
         # Use the safe quoter so column / order-by identifiers can't break out of `[...]`.
         quoted_columns = [self._quote_identifier_safe(c) for c in columns]

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -81,32 +81,32 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         limit: int,
         offset: int,
     ) -> str:
-        """TODO: Synapse uses completely different pagination syntax, AST does not have enough flexibility for this yet."""
-        where_clauses = []
+        # Synapse Dedicated SQL Pool does not support OFFSET ... FETCH NEXT, so we paginate via
+        # ROW_NUMBER() over the key columns and INNER JOIN back to the original table. Joining
+        # rather than wrapping in a CTE keeps the row-shape clean (no synthetic rn column leaks
+        # into the result set, which would otherwise be mistaken for a real column by the
+        # downstream rows_diff comparator).
+        qualified_table = self.build_fully_qualified_sql_name(dataset_identifier)
+        quoted_keys = [self.quote_default(c) for c in order_by]
+        keys_csv = ", ".join(quoted_keys)
+        order_by_csv = ", ".join(f"{c} ASC" for c in quoted_keys)
+        join_condition = " AND ".join(f"t.{c} = p.{c}" for c in quoted_keys)
+        where_sql = f"WHERE {filter}" if filter else ""
 
-        if filter:
-            where_clauses.append(SqlExpressionStr(filter))
+        if columns:
+            select_clause = "SELECT " + ", ".join(f"t.{self.quote_default(c)}" for c in columns)
+        else:
+            select_clause = "SELECT t.*"
 
-        select_statements = self._build_select_sql_lines([SELECT(columns or [STAR()])])
-        select = ", ".join(select_statements)
-        order_by_statements = self._build_order_by_lines([ORDER_BY_ASC(c) for c in order_by])
-        order_by = ", ".join(order_by_statements)
-        where_statements = self._build_where_sql_lines([WHERE.optional(AND.optional(where_clauses))])
-        where = ", ".join(where_statements)
-
-        query = f"""WITH src AS (
-        {select}, ROW_NUMBER()
-            OVER (
-                {order_by}
-            ) AS rn
-        FROM {self.build_fully_qualified_sql_name(dataset_identifier)} AS t
-        {where}
+        return (
+            f"WITH paginated_keys AS (\n"
+            f"    SELECT {keys_csv}, ROW_NUMBER() OVER (ORDER BY {order_by_csv}) AS rn\n"
+            f"    FROM {qualified_table}\n"
+            f"    {where_sql}\n"
+            f")\n"
+            f"{select_clause}\n"
+            f"FROM {qualified_table} AS t\n"
+            f"INNER JOIN paginated_keys AS p ON {join_condition}\n"
+            f"WHERE p.rn > {offset} AND p.rn <= {offset + limit}\n"
+            f"ORDER BY p.rn;"
         )
-        SELECT *
-            FROM src
-            WHERE rn > {offset}
-            AND rn <= {offset + limit}
-        ORDER BY rn;
-        """
-
-        return query

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -78,6 +78,18 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
     def build_cte_values_sql(self, values: VALUES, alias_columns: list[COLUMN] | None) -> str:
         return "\nUNION ALL\n".join(["SELECT " + self.build_expression_sql(value) for value in values.values])
 
+    def _quote_identifier_safe(self, identifier: str) -> str:
+        """T-SQL-safe identifier quoting that escapes closing brackets.
+
+        `quote_default` (inherited from SqlServerSqlDialect) wraps in `[...]` without escaping
+        any `]` characters embedded in the identifier — fine in practice for trusted
+        identifiers, but allows SQL injection if the identifier is not pre-validated. The
+        Synapse paginator below interpolates column names directly into a hand-built SQL
+        string (rather than going through the AST), so it must defend against this. The T-SQL
+        rule for bracket-quoted identifiers is to double any embedded `]`.
+        """
+        return f"[{identifier.replace(']', ']]')}]"
+
     def select_all_paginated_sql(
         self,
         dataset_identifier: DatasetIdentifier,
@@ -115,9 +127,10 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
                 )
             ]
         qualified_table = self.build_fully_qualified_sql_name(dataset_identifier)
-        quoted_columns = [self.quote_default(c) for c in columns]
+        # Use the safe quoter so column / order-by identifiers can't break out of `[...]`.
+        quoted_columns = [self._quote_identifier_safe(c) for c in columns]
         columns_csv = ", ".join(quoted_columns)
-        order_by_csv = ", ".join(f"{self.quote_default(c)} ASC" for c in order_by)
+        order_by_csv = ", ".join(f"{self._quote_identifier_safe(c)} ASC" for c in order_by)
         where_sql = f"WHERE {filter}" if filter else ""
 
         return (

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -130,17 +130,25 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         # Use the safe quoter so column / order-by identifiers can't break out of `[...]`.
         quoted_columns = [self._quote_identifier_safe(c) for c in columns]
         columns_csv = ", ".join(quoted_columns)
-        order_by_csv = ", ".join(f"{self._quote_identifier_safe(c)} ASC" for c in order_by)
+        # An empty `order_by` is allowed by the base `SqlDialect.select_all_paginated_sql`
+        # contract — produce a deterministic-enough fallback that T-SQL accepts inside the
+        # OVER(...) clause. `(SELECT NULL)` is the standard idiom for "any order".
+        order_by_csv = (
+            ", ".join(f"{self._quote_identifier_safe(c)} ASC" for c in order_by) if order_by else "(SELECT NULL)"
+        )
         where_sql = f"WHERE {filter}" if filter else ""
+        # Use a `__soda_`-prefixed alias so we don't collide with a real column named `rn`
+        # (possible when `columns` was resolved from the table's metadata).
+        rn_alias = "__soda_rn"
 
         return (
             f"WITH paginated AS (\n"
-            f"    SELECT {columns_csv}, ROW_NUMBER() OVER (ORDER BY {order_by_csv}) AS rn\n"
+            f"    SELECT {columns_csv}, ROW_NUMBER() OVER (ORDER BY {order_by_csv}) AS {rn_alias}\n"
             f"    FROM {qualified_table}\n"
             f"    {where_sql}\n"
             f")\n"
             f"SELECT {columns_csv}\n"
             f"FROM paginated\n"
-            f"WHERE rn > {offset} AND rn <= {offset + limit}\n"
-            f"ORDER BY rn;"
+            f"WHERE {rn_alias} > {offset} AND {rn_alias} <= {offset + limit}\n"
+            f"ORDER BY {rn_alias};"
         )

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -32,7 +32,13 @@ class SynapseDataSourceImpl(SqlServerDataSourceImpl, model_class=SynapseDataSour
         super().__init__(data_source_model=data_source_model, connection=connection)
 
     def _create_sql_dialect(self) -> SqlDialect:
-        return SynapseSqlDialect()
+        # Hand the dialect a back-reference to this data source impl so its paginator can
+        # resolve the table's column list via INFORMATION_SCHEMA when the caller didn't
+        # enumerate columns. This is Synapse-specific because the ROW_NUMBER()-based
+        # paginator below needs explicit columns to avoid leaking the synthetic rn column.
+        dialect = SynapseSqlDialect()
+        dialect._data_source_impl = self
+        return dialect
 
     def _create_data_source_connection(self) -> DataSourceConnection:
         return SynapseDataSourceConnection(
@@ -82,31 +88,46 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         offset: int,
     ) -> str:
         # Synapse Dedicated SQL Pool does not support OFFSET ... FETCH NEXT, so we paginate via
-        # ROW_NUMBER() over the key columns and INNER JOIN back to the original table. Joining
-        # rather than wrapping in a CTE keeps the row-shape clean (no synthetic rn column leaks
-        # into the result set, which would otherwise be mistaken for a real column by the
-        # downstream rows_diff comparator).
+        # ROW_NUMBER(). The earlier implementation joined `t.<key> = p.<key>` to drop the rn
+        # column from the result set, but `NULL = NULL` is false and duplicate keys amplify
+        # rows past the page size — both diverge from native OFFSET/LIMIT semantics on other
+        # data sources and break the rows_diff merge join. Instead we compute rn inside an
+        # inner CTE alongside the requested columns and select only those columns from the
+        # outer SELECT, so rn never leaks and no JOIN is needed.
+        #
+        # We need an explicit column list to project rn out. When the caller doesn't supply
+        # one (e.g. rows_diff with no `source_columns`/`target_columns` in YAML), we resolve
+        # the table's columns via INFORMATION_SCHEMA using the back-reference set by
+        # `SynapseDataSourceImpl._create_sql_dialect`. Other dialects don't need this because
+        # they paginate with native OFFSET/LIMIT and `SELECT *` works fine.
+        if not columns:
+            data_source_impl = getattr(self, "_data_source_impl", None)
+            if data_source_impl is None:
+                raise ValueError(
+                    "Synapse paginator requires explicit `columns` (or a SynapseDataSourceImpl "
+                    "back-reference) to avoid leaking the synthetic rn column into the result set."
+                )
+            columns = [
+                cm.column_name
+                for cm in data_source_impl.get_columns_metadata(
+                    dataset_prefixes=dataset_identifier.prefixes,
+                    dataset_name=dataset_identifier.dataset_name,
+                )
+            ]
         qualified_table = self.build_fully_qualified_sql_name(dataset_identifier)
-        quoted_keys = [self.quote_default(c) for c in order_by]
-        keys_csv = ", ".join(quoted_keys)
-        order_by_csv = ", ".join(f"{c} ASC" for c in quoted_keys)
-        join_condition = " AND ".join(f"t.{c} = p.{c}" for c in quoted_keys)
+        quoted_columns = [self.quote_default(c) for c in columns]
+        columns_csv = ", ".join(quoted_columns)
+        order_by_csv = ", ".join(f"{self.quote_default(c)} ASC" for c in order_by)
         where_sql = f"WHERE {filter}" if filter else ""
 
-        if columns:
-            select_clause = "SELECT " + ", ".join(f"t.{self.quote_default(c)}" for c in columns)
-        else:
-            select_clause = "SELECT t.*"
-
         return (
-            f"WITH paginated_keys AS (\n"
-            f"    SELECT {keys_csv}, ROW_NUMBER() OVER (ORDER BY {order_by_csv}) AS rn\n"
+            f"WITH paginated AS (\n"
+            f"    SELECT {columns_csv}, ROW_NUMBER() OVER (ORDER BY {order_by_csv}) AS rn\n"
             f"    FROM {qualified_table}\n"
             f"    {where_sql}\n"
             f")\n"
-            f"{select_clause}\n"
-            f"FROM {qualified_table} AS t\n"
-            f"INNER JOIN paginated_keys AS p ON {join_condition}\n"
-            f"WHERE p.rn > {offset} AND p.rn <= {offset + limit}\n"
-            f"ORDER BY p.rn;"
+            f"SELECT {columns_csv}\n"
+            f"FROM paginated\n"
+            f"WHERE rn > {offset} AND rn <= {offset + limit}\n"
+            f"ORDER BY rn;"
         )

--- a/soda-tests/tests/conftest.py
+++ b/soda-tests/tests/conftest.py
@@ -4,6 +4,7 @@ import freezegun
 import pytest
 from helpers.test_fixtures import *  # noqa: F401
 from soda_core.common.logging_configuration import configure_logging
+from soda_core.common.streaming import StreamingOrchestrator
 from soda_core.contracts.impl.contract_verification_impl import (
     ContractVerificationHandlerRegistry,
 )
@@ -86,3 +87,10 @@ def clear_contract_verification_handlers():
     yield
     ContractVerificationHandlerRegistry.contract_verification_handlers.clear()
     ContractVerificationHandlerRegistry.post_processing_stages.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_streaming_consumers():
+    StreamingOrchestrator.reset()
+    yield
+    StreamingOrchestrator.reset()

--- a/soda-tests/tests/unit/test_streaming.py
+++ b/soda-tests/tests/unit/test_streaming.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from soda_core.common.streaming import (

--- a/soda-tests/tests/unit/test_streaming.py
+++ b/soda-tests/tests/unit/test_streaming.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from soda_core.common.streaming import (
+    StreamingActionHandle,
+    StreamingConsumer,
+    StreamingOrchestrator,
+    StreamingProducer,
+)
+
+
+class MockConsumer(StreamingConsumer):
+    def __init__(self, actions: list[str]):
+        self._actions = actions
+        self.initialized: list[tuple[str, dict]] = []
+        self.received_data: list[tuple[str, Any]] = []
+        self.finished_actions: list[str] = []
+
+    def supported_actions(self) -> list[str]:
+        return self._actions
+
+    def initialize(self, action: str, context: dict[str, Any]) -> None:
+        self.initialized.append((action, context))
+
+    def process_data(self, action: str, data: Any) -> None:
+        self.received_data.append((action, data))
+
+    def finish(self, action: str) -> None:
+        self.finished_actions.append(action)
+
+
+class FailingConsumer(StreamingConsumer):
+    """Consumer that fails at a configurable stage."""
+
+    def __init__(self, actions: list[str], fail_on: str = ""):
+        self._actions = actions
+        self._fail_on = fail_on
+
+    def supported_actions(self) -> list[str]:
+        return self._actions
+
+    def initialize(self, action: str, context: dict[str, Any]) -> None:
+        if self._fail_on == "initialize":
+            raise RuntimeError("initialize failed")
+
+    def process_data(self, action: str, data: Any) -> None:
+        if self._fail_on == "process_data":
+            raise RuntimeError("process_data failed")
+
+    def finish(self, action: str) -> None:
+        if self._fail_on == "finish":
+            raise RuntimeError("finish failed")
+
+
+class MockProducer(StreamingProducer):
+    def __init__(self, actions: list[str]):
+        self._actions = actions
+
+    def produced_actions(self) -> list[str]:
+        return self._actions
+
+
+class TestStreamingNoConsumers:
+    def test_no_consumers_handle_works_as_noop(self):
+        handle = StreamingOrchestrator.initialize_action("some_action", {})
+        handle.new_data({"key": "value"})
+        handle.finish()
+
+
+class TestStreamingSingleConsumer:
+    def test_single_consumer_lifecycle(self):
+        consumer = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+
+        ctx = {"key": "val"}
+        handle = StreamingOrchestrator.initialize_action("my_action", ctx)
+        assert len(consumer.initialized) == 1
+        assert consumer.initialized[0] == ("my_action", ctx)
+
+        handle.new_data({"row": 1})
+        handle.new_data({"row": 2})
+        assert len(consumer.received_data) == 2
+        assert consumer.received_data[0] == ("my_action", {"row": 1})
+        assert consumer.received_data[1] == ("my_action", {"row": 2})
+
+        handle.finish()
+        assert consumer.finished_actions == ["my_action"]
+
+
+class TestStreamingMultipleConsumers:
+    def test_multiple_consumers_same_action(self):
+        consumer1 = MockConsumer(["shared_action"])
+        consumer2 = MockConsumer(["shared_action"])
+        StreamingOrchestrator.register_consumer(consumer1)
+        StreamingOrchestrator.register_consumer(consumer2)
+
+        handle = StreamingOrchestrator.initialize_action("shared_action", {})
+        handle.new_data("data1")
+        handle.finish()
+
+        assert len(consumer1.received_data) == 1
+        assert len(consumer2.received_data) == 1
+        assert consumer1.finished_actions == ["shared_action"]
+        assert consumer2.finished_actions == ["shared_action"]
+
+    def test_consumer_for_different_action_not_invoked(self):
+        consumer_a = MockConsumer(["action_a"])
+        consumer_b = MockConsumer(["action_b"])
+        StreamingOrchestrator.register_consumer(consumer_a)
+        StreamingOrchestrator.register_consumer(consumer_b)
+
+        handle = StreamingOrchestrator.initialize_action("action_a", {})
+        handle.new_data("data")
+        handle.finish()
+
+        assert len(consumer_a.received_data) == 1
+        assert len(consumer_b.received_data) == 0
+        assert consumer_b.initialized == []
+        assert consumer_b.finished_actions == []
+
+
+class TestStreamingConsumerFailures:
+    def test_consumer_fails_during_initialize_excluded(self):
+        failing = FailingConsumer(["my_action"], fail_on="initialize")
+        good = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(failing)
+        StreamingOrchestrator.register_consumer(good)
+
+        handle = StreamingOrchestrator.initialize_action("my_action", {})
+        handle.new_data("data")
+        handle.finish()
+
+        # Good consumer received data; failing one was excluded
+        assert len(good.received_data) == 1
+        assert good.finished_actions == ["my_action"]
+
+    def test_consumer_fails_during_process_data_others_proceed(self):
+        failing = FailingConsumer(["my_action"], fail_on="process_data")
+        good = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(failing)
+        StreamingOrchestrator.register_consumer(good)
+
+        handle = StreamingOrchestrator.initialize_action("my_action", {})
+        handle.new_data("data")
+        handle.finish()
+
+        assert len(good.received_data) == 1
+
+    def test_consumer_fails_during_finish_others_still_finished(self):
+        failing = FailingConsumer(["my_action"], fail_on="finish")
+        good = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(failing)
+        StreamingOrchestrator.register_consumer(good)
+
+        handle = StreamingOrchestrator.initialize_action("my_action", {})
+        handle.finish()
+
+        assert good.finished_actions == ["my_action"]
+
+
+class TestStreamingContextManager:
+    def test_context_manager_calls_finish(self):
+        consumer = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+
+        with StreamingOrchestrator.initialize_action("my_action", {}) as handle:
+            handle.new_data("data")
+
+        assert consumer.finished_actions == ["my_action"]
+
+    def test_context_manager_with_producer_exception(self):
+        consumer = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+
+        with pytest.raises(ValueError, match="producer error"):
+            with StreamingOrchestrator.initialize_action("my_action", {}) as handle:
+                handle.new_data("data")
+                raise ValueError("producer error")
+
+        # finish() was still called despite the exception
+        assert consumer.finished_actions == ["my_action"]
+
+
+class TestStreamingFinishIdempotent:
+    def test_finish_is_idempotent(self):
+        consumer = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+
+        handle = StreamingOrchestrator.initialize_action("my_action", {})
+        handle.finish()
+        handle.finish()
+
+        # finish called only once on consumer
+        assert consumer.finished_actions == ["my_action"]
+
+
+class TestStreamingReset:
+    def test_reset_clears_state(self):
+        consumer = MockConsumer(["my_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+        assert len(StreamingOrchestrator._consumers) == 1
+
+        StreamingOrchestrator.reset()
+        assert len(StreamingOrchestrator._consumers) == 0
+        assert len(StreamingOrchestrator._action_consumers) == 0
+
+        # After reset, no consumers receive data
+        handle = StreamingOrchestrator.initialize_action("my_action", {})
+        handle.new_data("data")
+        handle.finish()
+        assert len(consumer.received_data) == 0
+
+
+class TestStreamingProducer:
+    def test_producer_validates_action(self):
+        producer = MockProducer(["valid_action"])
+
+        with pytest.raises(ValueError, match="does not produce action 'invalid_action'"):
+            producer.initialize_action("invalid_action")
+
+    def test_producer_delegates_to_orchestrator(self):
+        consumer = MockConsumer(["valid_action"])
+        StreamingOrchestrator.register_consumer(consumer)
+
+        producer = MockProducer(["valid_action"])
+        ctx = {"info": "test"}
+        handle = producer.initialize_action("valid_action", ctx)
+
+        assert isinstance(handle, StreamingActionHandle)
+        assert len(consumer.initialized) == 1
+        assert consumer.initialized[0] == ("valid_action", ctx)
+
+        handle.new_data("producer_data")
+        handle.finish()
+        assert len(consumer.received_data) == 1


### PR DESCRIPTION
## Summary
Adds a generic streaming pipeline (`StreamingOrchestrator` / `StreamingProducer` / `StreamingConsumer`) so check implementations can push data to extension consumers as it's produced, decoupling check logic from any DWH-side persistence. Foundation for the reconciliation rows_diff DWH flow built in [soda-extensions #353](https://github.com/sodadata/soda-extensions/pull/353); this PR contains the core primitives, plus a Synapse pagination fix the recon flow needs.

## What's in scope

### Streaming infrastructure
New package `soda_core/common/streaming/`:
- `StreamingOrchestrator` — global registry; producers initialize an action and route data to all registered consumers without knowing about them.
- `StreamingProducer` / `StreamingActionHandle` — producer-side API. `initialize_action(...)` returns a context-manager handle whose `__exit__` always calls `finish()` (idempotent, never suppresses producer exceptions).
- `StreamingConsumer` — consumer interface (`initialize` / `process_data` / `finish`).
- Conftest hook in `soda-tests` resets the orchestrator between tests so consumers don't leak.

### Synapse pagination
Synapse Dedicated SQL Pool doesn't support `OFFSET ... FETCH NEXT`, so a custom paginator is required.
- `SynapseSqlDialect.select_all_paginated_sql` is now a `ROW_NUMBER()`-in-CTE paginator that **enumerates the column list inside the CTE** and selects only those columns from the outer query, so the synthetic `rn` column never leaks into `cursor.description` (which the rows_diff comparator inspects). Earlier iterations used a JOIN-back on key columns; that strategy was abandoned because `NULL = NULL` is false (drops rows with NULL keys silently) and non-unique keys amplify rows past the page size — both diverge from native OFFSET/LIMIT semantics on other dialects.
- When the caller doesn't pass an explicit column list (e.g. rows_diff with no `source_columns`/`target_columns` in YAML), Synapse resolves columns once via `INFORMATION_SCHEMA` using a back-reference set by `SynapseDataSourceImpl._create_sql_dialect`. No other dialect is touched — they paginate with native OFFSET/LIMIT and `SELECT *` works fine.

### SQL-injection defense in the Synapse paginator
`SynapseSqlDialect._quote_identifier_safe` performs the standard T-SQL `]` → `]]` escape inside `[...]`-quoted identifiers. The paginator's `columns_csv` / `order_by_csv` interpolations now use this helper instead of `quote_default`, closing the Aikido-flagged identifier injection vector without changing `SqlServerSqlDialect.quote_default` (which is shared by other dialects). Addresses Aikido findings on lines 125/129.

### Misc cleanups
- `StreamingProducer.initialize_action` caches `produced_actions()` once instead of calling it twice (Copilot review + SonarQube confusing-string-concat fix).

## Test plan
- [x] Streaming unit tests pass (`soda-tests/tests/unit/test_streaming.py`)
- [x] Synapse rows_diff e2e (in [soda-extensions #353](https://github.com/sodadata/soda-extensions/pull/353)) passes
- [x] Postgres + SqlServer DWH suites pass (no regression from quote_default scope)