### PR TITLE
feat(DES-294): validate column type parameters at contract parse time

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -79,6 +79,12 @@ class ContractYaml:
         self.contract_yaml_source: ContractYamlSource = contract_yaml_source
         self.contract_yaml_object: YamlObject = contract_yaml_source.parse()
         self.primary_data_source_impl: Optional[DataSourceImpl] = primary_data_source_impl
+        # Cache the dialect's native→canonical data type mapping once — dialects construct this dict fresh on every call.
+        self._native_to_soda_data_type_mapping: Optional[dict[str, SodaDataTypeName]] = (
+            primary_data_source_impl.sql_dialect.get_soda_data_type_name_by_data_source_data_type_names()
+            if primary_data_source_impl is not None
+            else None
+        )
 
         self.variables: list[VariableYaml] = self._parse_variable_yamls(contract_yaml_source, provided_variable_values)
 
@@ -435,13 +441,16 @@ _DATETIME_PRECISION_FAMILY: frozenset[SodaDataTypeName] = frozenset(
 )
 
 
-def _resolve_to_soda_type(data_type: Optional[str], sql_dialect: Optional["SqlDialect"]) -> Optional[SodaDataTypeName]:
+def _resolve_to_soda_type(
+    data_type: Optional[str],
+    native_to_soda_mapping: Optional[dict[str, SodaDataTypeName]],
+) -> Optional[SodaDataTypeName]:
     """
     Resolve a raw YAML data_type string to a canonical SodaDataTypeName.
 
     Order:
-    1. Direct match against SodaDataTypeName values (no dialect needed).
-    2. Dialect-aware resolution via native→canonical mapping (e.g. Databricks "string" → TEXT).
+    1. Direct match against SodaDataTypeName values (no mapping needed).
+    2. Dialect-aware resolution via the provided native→canonical mapping (e.g. Databricks "string" → TEXT).
     3. Give up (return None) — caller skips type-param validation for unknown types.
     """
     if not data_type:
@@ -451,8 +460,8 @@ def _resolve_to_soda_type(data_type: Optional[str], sql_dialect: Optional["SqlDi
         return SodaDataTypeName(normalized)
     except ValueError:
         pass
-    if sql_dialect is not None:
-        return sql_dialect.get_soda_data_type_name_by_data_source_data_type_names().get(normalized)
+    if native_to_soda_mapping is not None:
+        return native_to_soda_mapping.get(normalized)
     return None
 
 
@@ -469,29 +478,28 @@ class ColumnYaml(MissingAndValidityYaml):
         if self.column_expression:
             self.column_expression = self.column_expression.strip()
 
-        sql_dialect = (
-            contract_yaml.primary_data_source_impl.sql_dialect
-            if contract_yaml.primary_data_source_impl is not None
-            else None
-        )
-        self._validate_type_parameters(column_yaml_object, sql_dialect)
+        self._validate_type_parameters(column_yaml_object, contract_yaml._native_to_soda_data_type_mapping)
 
         super().__init__(column_yaml_object)
         self.check_yamls: Optional[list[CheckYaml]] = contract_yaml._parse_checks(
             checks_containing_yaml_object=column_yaml_object, column_yaml=self
         )
 
-    def _validate_type_parameters(self, column_yaml_object: YamlObject, sql_dialect: Optional["SqlDialect"]) -> None:
-        soda_type = _resolve_to_soda_type(self.data_type, sql_dialect)
+    def _validate_type_parameters(
+        self,
+        column_yaml_object: YamlObject,
+        native_to_soda_mapping: Optional[dict[str, SodaDataTypeName]],
+    ) -> None:
+        soda_type = _resolve_to_soda_type(self.data_type, native_to_soda_mapping)
         if soda_type is None:
             return
-        checks = [
+        type_param_validations = [
             ("character_maximum_length", self.character_maximum_length, _CHAR_LENGTH_FAMILY),
             ("numeric_precision", self.numeric_precision, _NUMERIC_PRECISION_FAMILY),
             ("numeric_scale", self.numeric_scale, _NUMERIC_PRECISION_FAMILY),
             ("datetime_precision", self.datetime_precision, _DATETIME_PRECISION_FAMILY),
         ]
-        for key, value, allowed_types in checks:
+        for key, value, allowed_types in type_param_validations:
             if value is not None and soda_type not in allowed_types:
                 allowed_values = sorted(t.value for t in allowed_types)
                 logger.error(

--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -16,6 +16,7 @@ from soda_core.common.exceptions import ContractParserException
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location
 from soda_core.common.metadata_types import SodaDataTypeName
+from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.yaml import (
     ContractYamlSource,
     VariableResolver,
@@ -419,26 +420,51 @@ class MissingAndValidityYaml:
             self.valid_reference_data = ValidReferenceDataYaml(valid_reference_data_yaml)
 
 
-_CHAR_LENGTH_FAMILY: frozenset[SodaDataTypeName] = frozenset(
-    {
-        SodaDataTypeName.VARCHAR,
-        SodaDataTypeName.CHAR,
-        SodaDataTypeName.TEXT,
-    }
-)
-_NUMERIC_PRECISION_FAMILY: frozenset[SodaDataTypeName] = frozenset(
-    {
-        SodaDataTypeName.DECIMAL,
-        SodaDataTypeName.NUMERIC,
-    }
-)
-_DATETIME_PRECISION_FAMILY: frozenset[SodaDataTypeName] = frozenset(
-    {
-        SodaDataTypeName.TIMESTAMP,
-        SodaDataTypeName.TIMESTAMP_TZ,
-        SodaDataTypeName.TIME,
-    }
-)
+class _DefaultSqlDialect(SqlDialect, sqlglot_dialect="default"):
+    """Permissive fallback dialect used by parse-time type-parameter validation
+    when no concrete dialect is bound (e.g. ``contract publish`` and any
+    ``contract verify`` invocation that doesn't carry a data source).
+
+    Why this exists rather than only using a bound dialect: parse-time
+    validation needs to run on those non-dialect paths too — otherwise
+    contracts could be published with obvious mismatches (e.g.
+    ``numeric_precision`` on a VARCHAR) that only surface later at scan time.
+    Concrete dialects remain authoritative when bound; this fallback simply
+    keeps validation alive when no dialect is available, using SqlDialect's
+    base method lists (which cover canonical Soda type values like ``varchar``,
+    ``decimal``, ``timestamp``) plus a couple of aliases for canonical-only
+    values that the standard-SQL base lists don't include verbatim.
+    """
+
+    def get_data_source_data_type_name_by_soda_data_type_names(self) -> dict[SodaDataTypeName, str]:
+        return {}
+
+    def get_soda_data_type_name_by_data_source_data_type_names(self) -> dict[str, SodaDataTypeName]:
+        return {}
+
+    def data_type_has_parameter_character_maximum_length(self, data_type_name) -> bool:
+        return (
+            super().data_type_has_parameter_character_maximum_length(data_type_name) or data_type_name.lower() == "text"
+        )
+
+    def data_type_has_parameter_datetime_precision(self, data_type_name) -> bool:
+        return (
+            super().data_type_has_parameter_datetime_precision(data_type_name)
+            or data_type_name.lower() == "timestamp_tz"
+        )
+
+
+_DEFAULT_SQL_DIALECT: SqlDialect = _DefaultSqlDialect()
+
+# Human-readable allowed-types list per type-param, used only for error messages.
+# The actual yes/no on whether a param applies to a data_type is delegated to the
+# dialect's data_type_has_parameter_* methods.
+_TYPE_PARAM_ALLOWED_TYPES_FOR_MESSAGE: dict[str, list[str]] = {
+    "character_maximum_length": ["char", "text", "varchar"],
+    "numeric_precision": ["decimal", "numeric"],
+    "numeric_scale": ["decimal", "numeric"],
+    "datetime_precision": ["time", "timestamp", "timestamp_tz"],
+}
 
 
 def _resolve_to_soda_type(
@@ -447,6 +473,10 @@ def _resolve_to_soda_type(
 ) -> Optional[SodaDataTypeName]:
     """
     Resolve a raw YAML data_type string to a canonical SodaDataTypeName.
+
+    Used as the "is this type recognized" gate before parse-time type-param
+    validation. If the type can't be resolved we skip validation and let the
+    schema check catch real DB mismatches at scan time.
 
     Order:
     1. Direct match against SodaDataTypeName values (no mapping needed).
@@ -478,7 +508,15 @@ class ColumnYaml(MissingAndValidityYaml):
         if self.column_expression:
             self.column_expression = self.column_expression.strip()
 
-        self._validate_type_parameters(column_yaml_object, contract_yaml._native_to_soda_data_type_mapping)
+        self._validate_type_parameters(
+            column_yaml_object,
+            sql_dialect=(
+                contract_yaml.primary_data_source_impl.sql_dialect
+                if contract_yaml.primary_data_source_impl is not None
+                else None
+            ),
+            native_to_soda_mapping=contract_yaml._native_to_soda_data_type_mapping,
+        )
 
         super().__init__(column_yaml_object)
         self.check_yamls: Optional[list[CheckYaml]] = contract_yaml._parse_checks(
@@ -488,23 +526,40 @@ class ColumnYaml(MissingAndValidityYaml):
     def _validate_type_parameters(
         self,
         column_yaml_object: YamlObject,
+        sql_dialect: Optional[SqlDialect],
         native_to_soda_mapping: Optional[dict[str, SodaDataTypeName]],
     ) -> None:
-        soda_type = _resolve_to_soda_type(self.data_type, native_to_soda_mapping)
-        if soda_type is None:
+        # Skip validation for unrecognized data_types — the schema check catches real DB
+        # mismatches at scan time. Recognized = a SodaDataTypeName enum value or a key in
+        # the bound dialect's native→canonical mapping.
+        if _resolve_to_soda_type(self.data_type, native_to_soda_mapping) is None:
             return
+
+        # Defer to the bound dialect's data_type_has_parameter_* methods as the source of
+        # truth (they're already used by extract_* on info_schema). When no dialect is
+        # bound — e.g. contract publish, contract verify without a data source — fall back
+        # to _DEFAULT_SQL_DIALECT so those paths still get parse-time validation rather
+        # than silently skipping it.
+        dialect: SqlDialect = sql_dialect if sql_dialect is not None else _DEFAULT_SQL_DIALECT
+        data_type_name: str = self.data_type.split("(", 1)[0].strip()
+
         type_param_validations = [
-            ("character_maximum_length", self.character_maximum_length, _CHAR_LENGTH_FAMILY),
-            ("numeric_precision", self.numeric_precision, _NUMERIC_PRECISION_FAMILY),
-            ("numeric_scale", self.numeric_scale, _NUMERIC_PRECISION_FAMILY),
-            ("datetime_precision", self.datetime_precision, _DATETIME_PRECISION_FAMILY),
+            (
+                "character_maximum_length",
+                self.character_maximum_length,
+                dialect.data_type_has_parameter_character_maximum_length,
+            ),
+            ("numeric_precision", self.numeric_precision, dialect.data_type_has_parameter_numeric_precision),
+            ("numeric_scale", self.numeric_scale, dialect.data_type_has_parameter_numeric_scale),
+            ("datetime_precision", self.datetime_precision, dialect.data_type_has_parameter_datetime_precision),
         ]
-        for key, value, allowed_types in type_param_validations:
-            if value is not None and soda_type not in allowed_types:
-                allowed_values = sorted(t.value for t in allowed_types)
+        for key, value, has_parameter in type_param_validations:
+            if value is None:
+                continue
+            if not has_parameter(data_type_name):
                 logger.error(
                     msg=(
-                        f"'{key}' is only valid for data types {allowed_values}, "
+                        f"'{key}' is only valid for data types {_TYPE_PARAM_ALLOWED_TYPES_FOR_MESSAGE[key]}, "
                         f"but was set on column '{self.name}' with data_type '{self.data_type}'"
                     ),
                     extra={ExtraKeys.LOCATION: column_yaml_object.create_location_from_yaml_dict_key(key)},

--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -15,6 +15,7 @@ from soda_core.common.datetime_conversions import (
 from soda_core.common.exceptions import ContractParserException
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location
+from soda_core.common.metadata_types import SodaDataTypeName
 from soda_core.common.yaml import (
     ContractYamlSource,
     VariableResolver,
@@ -77,6 +78,7 @@ class ContractYaml:
     ):
         self.contract_yaml_source: ContractYamlSource = contract_yaml_source
         self.contract_yaml_object: YamlObject = contract_yaml_source.parse()
+        self.primary_data_source_impl: Optional[DataSourceImpl] = primary_data_source_impl
 
         self.variables: list[VariableYaml] = self._parse_variable_yamls(contract_yaml_source, provided_variable_values)
 
@@ -411,6 +413,49 @@ class MissingAndValidityYaml:
             self.valid_reference_data = ValidReferenceDataYaml(valid_reference_data_yaml)
 
 
+_CHAR_LENGTH_FAMILY: frozenset[SodaDataTypeName] = frozenset(
+    {
+        SodaDataTypeName.VARCHAR,
+        SodaDataTypeName.CHAR,
+        SodaDataTypeName.TEXT,
+    }
+)
+_NUMERIC_PRECISION_FAMILY: frozenset[SodaDataTypeName] = frozenset(
+    {
+        SodaDataTypeName.DECIMAL,
+        SodaDataTypeName.NUMERIC,
+    }
+)
+_DATETIME_PRECISION_FAMILY: frozenset[SodaDataTypeName] = frozenset(
+    {
+        SodaDataTypeName.TIMESTAMP,
+        SodaDataTypeName.TIMESTAMP_TZ,
+        SodaDataTypeName.TIME,
+    }
+)
+
+
+def _resolve_to_soda_type(data_type: Optional[str], sql_dialect: Optional["SqlDialect"]) -> Optional[SodaDataTypeName]:
+    """
+    Resolve a raw YAML data_type string to a canonical SodaDataTypeName.
+
+    Order:
+    1. Direct match against SodaDataTypeName values (no dialect needed).
+    2. Dialect-aware resolution via native→canonical mapping (e.g. Databricks "string" → TEXT).
+    3. Give up (return None) — caller skips type-param validation for unknown types.
+    """
+    if not data_type:
+        return None
+    normalized = data_type.split("(", 1)[0].strip().lower()
+    try:
+        return SodaDataTypeName(normalized)
+    except ValueError:
+        pass
+    if sql_dialect is not None:
+        return sql_dialect.get_soda_data_type_name_by_data_source_data_type_names().get(normalized)
+    return None
+
+
 class ColumnYaml(MissingAndValidityYaml):
     def __init__(self, contract_yaml: ContractYaml, column_yaml_object: YamlObject):
         self.column_yaml_object: YamlObject = column_yaml_object
@@ -424,10 +469,38 @@ class ColumnYaml(MissingAndValidityYaml):
         if self.column_expression:
             self.column_expression = self.column_expression.strip()
 
+        sql_dialect = (
+            contract_yaml.primary_data_source_impl.sql_dialect
+            if contract_yaml.primary_data_source_impl is not None
+            else None
+        )
+        self._validate_type_parameters(column_yaml_object, sql_dialect)
+
         super().__init__(column_yaml_object)
         self.check_yamls: Optional[list[CheckYaml]] = contract_yaml._parse_checks(
             checks_containing_yaml_object=column_yaml_object, column_yaml=self
         )
+
+    def _validate_type_parameters(self, column_yaml_object: YamlObject, sql_dialect: Optional["SqlDialect"]) -> None:
+        soda_type = _resolve_to_soda_type(self.data_type, sql_dialect)
+        if soda_type is None:
+            return
+        checks = [
+            ("character_maximum_length", self.character_maximum_length, _CHAR_LENGTH_FAMILY),
+            ("numeric_precision", self.numeric_precision, _NUMERIC_PRECISION_FAMILY),
+            ("numeric_scale", self.numeric_scale, _NUMERIC_PRECISION_FAMILY),
+            ("datetime_precision", self.datetime_precision, _DATETIME_PRECISION_FAMILY),
+        ]
+        for key, value, allowed_types in checks:
+            if value is not None and soda_type not in allowed_types:
+                allowed_values = sorted(t.value for t in allowed_types)
+                logger.error(
+                    msg=(
+                        f"'{key}' is only valid for data types {allowed_values}, "
+                        f"but was set on column '{self.name}' with data_type '{self.data_type}'"
+                    ),
+                    extra={ExtraKeys.LOCATION: column_yaml_object.create_location_from_yaml_dict_key(key)},
+                )
 
 
 class RangeYaml:

--- a/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
+++ b/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
@@ -27,6 +27,18 @@ class _FakeSqlDialect:
             "clob": SodaDataTypeName.TEXT,
         }
 
+    def data_type_has_parameter_character_maximum_length(self, data_type_name) -> bool:
+        return data_type_name.lower() in ["varchar", "char", "string", "clob"]
+
+    def data_type_has_parameter_numeric_precision(self, data_type_name) -> bool:
+        return data_type_name.lower() in ["numeric", "number", "decimal"]
+
+    def data_type_has_parameter_numeric_scale(self, data_type_name) -> bool:
+        return data_type_name.lower() in ["numeric", "number", "decimal"]
+
+    def data_type_has_parameter_datetime_precision(self, data_type_name) -> bool:
+        return data_type_name.lower() in ["timestamp", "timestamp_tz", "time"]
+
 
 class _FakeDataSourceImpl:
     sql_dialect = _FakeSqlDialect()

--- a/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
+++ b/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
@@ -2,9 +2,43 @@
 Unit tests for ContractYaml parsing of basic dataset and column structures.
 """
 
+from helpers.test_functions import dedent_and_strip
 from helpers.yaml_parsing_helpers import parse_column_check, parse_contract
+from soda_core.common.datetime_conversions import (
+    convert_datetime_to_str,
+    convert_str_to_datetime,
+)
 from soda_core.common.exceptions import ContractParserException
 from soda_core.common.logs import Logs
+from soda_core.common.metadata_types import SodaDataTypeName
+from soda_core.common.yaml import ContractYamlSource
+from soda_core.contracts.impl.contract_yaml import ContractYaml
+
+
+class _FakeSqlDialect:
+    """Minimal dialect stub exposing only what ContractYaml parsing calls."""
+
+    convert_str_to_datetime = staticmethod(convert_str_to_datetime)
+    convert_datetime_to_str = staticmethod(convert_datetime_to_str)
+
+    def get_soda_data_type_name_by_data_source_data_type_names(self) -> dict[str, SodaDataTypeName]:
+        return {
+            "string": SodaDataTypeName.TEXT,
+            "clob": SodaDataTypeName.TEXT,
+        }
+
+
+class _FakeDataSourceImpl:
+    sql_dialect = _FakeSqlDialect()
+
+
+def _parse_with_dialect(yaml_str: str) -> ContractYaml:
+    source = ContractYamlSource.from_str(yaml_str=dedent_and_strip(yaml_str))
+    return ContractYaml.parse(
+        contract_yaml_source=source,
+        provided_variable_values={},
+        primary_data_source_impl=_FakeDataSourceImpl(),
+    )
 
 
 def test_parse_dataset_qualified_name():
@@ -189,3 +223,193 @@ def test_parse_name_and_qualifier():
 
     assert check_yaml.name == "Status should not be missing"
     assert check_yaml.qualifier == "important_column"
+
+
+def test_parse_character_maximum_length_valid_on_varchar():
+    """Test that character_maximum_length is accepted on character types without errors."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: email
+            data_type: VARCHAR
+            character_maximum_length: 255
+    """
+    contract_yaml = parse_contract(yaml_str)
+
+    assert contract_yaml.columns[0].character_maximum_length == 255
+
+
+def test_parse_character_maximum_length_accepts_parenthesized_type():
+    """Test that data_type with parenthesized suffix like 'varchar(255)' is normalized for validation."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: email
+            data_type: varchar(255)
+            character_maximum_length: 255
+    """
+    contract_yaml = parse_contract(yaml_str)
+
+    assert contract_yaml.columns[0].character_maximum_length == 255
+
+
+def test_parse_character_maximum_length_invalid_on_decimal(logs: Logs):
+    """Test that character_maximum_length on DECIMAL logs an error."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: amount
+            data_type: DECIMAL
+            character_maximum_length: 255
+    """
+    parse_contract(yaml_str)
+
+    assert "'character_maximum_length' is only valid for data types" in logs.get_errors_str()
+    assert "amount" in logs.get_errors_str()
+
+
+def test_parse_numeric_precision_valid_on_decimal():
+    """Test that numeric_precision/scale are accepted on DECIMAL without errors."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: amount
+            data_type: DECIMAL
+            numeric_precision: 10
+            numeric_scale: 2
+    """
+    contract_yaml = parse_contract(yaml_str)
+
+    assert contract_yaml.columns[0].numeric_precision == 10
+    assert contract_yaml.columns[0].numeric_scale == 2
+
+
+def test_parse_numeric_precision_invalid_on_varchar(logs: Logs):
+    """Test that numeric_precision on VARCHAR logs an error."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: name
+            data_type: VARCHAR
+            numeric_precision: 10
+    """
+    parse_contract(yaml_str)
+
+    assert "'numeric_precision' is only valid for data types" in logs.get_errors_str()
+
+
+def test_parse_numeric_scale_invalid_on_timestamp(logs: Logs):
+    """Test that numeric_scale on TIMESTAMP logs an error."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: created_at
+            data_type: TIMESTAMP
+            numeric_scale: 2
+    """
+    parse_contract(yaml_str)
+
+    assert "'numeric_scale' is only valid for data types" in logs.get_errors_str()
+
+
+def test_parse_datetime_precision_valid_on_timestamp():
+    """Test that datetime_precision is accepted on TIMESTAMP without errors."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: created_at
+            data_type: TIMESTAMP
+            datetime_precision: 6
+    """
+    contract_yaml = parse_contract(yaml_str)
+
+    assert contract_yaml.columns[0].datetime_precision == 6
+
+
+def test_parse_datetime_precision_invalid_on_integer(logs: Logs):
+    """Test that datetime_precision on INTEGER logs an error."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: id
+            data_type: INTEGER
+            datetime_precision: 6
+    """
+    parse_contract(yaml_str)
+
+    assert "'datetime_precision' is only valid for data types" in logs.get_errors_str()
+
+
+def test_parse_type_params_without_data_type_skipped(logs: Logs):
+    """Test that missing data_type skips type-param validation (other validators handle it)."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: mystery
+            character_maximum_length: 255
+    """
+    parse_contract(yaml_str)
+
+    assert "character_maximum_length" not in logs.get_errors_str()
+
+
+def test_parse_numeric_family_switch_preserves_params():
+    """Test that DECIMAL and NUMERIC are in the same family — params are valid for both."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: a
+            data_type: DECIMAL
+            numeric_precision: 10
+            numeric_scale: 2
+          - name: b
+            data_type: NUMERIC
+            numeric_precision: 10
+            numeric_scale: 2
+    """
+    contract_yaml = parse_contract(yaml_str)
+
+    assert contract_yaml.columns[0].numeric_precision == 10
+    assert contract_yaml.columns[1].numeric_precision == 10
+
+
+def test_parse_dialect_unknown_type_without_dialect_is_skipped(logs: Logs):
+    """Without a dialect, native types like 'string' are unresolvable — validation skipped."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: s
+            data_type: string
+            numeric_precision: 10
+    """
+    parse_contract(yaml_str)
+
+    assert "numeric_precision" not in logs.get_errors_str()
+
+
+def test_parse_dialect_resolves_native_string_valid_char_param():
+    """With a dialect, 'string' resolves to TEXT → character_maximum_length is valid."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: s
+            data_type: string
+            character_maximum_length: 255
+    """
+    contract_yaml = _parse_with_dialect(yaml_str)
+
+    assert contract_yaml.columns[0].character_maximum_length == 255
+
+
+def test_parse_dialect_resolves_native_string_invalid_numeric_param(logs: Logs):
+    """With a dialect, 'string' resolves to TEXT → numeric_precision on it is flagged."""
+    yaml_str = """
+        dataset: ds/db/schema/table
+        columns:
+          - name: s
+            data_type: string
+            numeric_precision: 10
+    """
+    _parse_with_dialect(yaml_str)
+
+    assert "'numeric_precision' is only valid for data types" in logs.get_errors_str()


### PR DESCRIPTION
## Summary
- Adds parse-time validation in `ColumnYaml` rejecting type params that don't match the column's data_type family (e.g. `numeric_precision` on VARCHAR, `character_maximum_length` on DECIMAL).
- Two-tier resolution: direct match against `SodaDataTypeName` enum values (tolerates parenthesized suffixes like `varchar(255)`), then dialect-aware fallback via `SqlDialect.get_soda_data_type_name_by_data_source_data_type_names()` when a `primary_data_source_impl` is provided (so Databricks `string` resolves to canonical TEXT).
- The yes/no on whether a param applies to a data_type is delegated to the bound `SqlDialect.data_type_has_parameter_*` methods (already used by `extract_*` on info_schema), not a hardcoded list — one override per dialect now drives both schema-check extraction *and* contract validation.
- For non-dialect paths (`contract publish`, `contract verify` without a data source), a private `_DefaultSqlDialect` fallback keeps parse-time validation alive so contracts with obvious mismatches still get flagged before publish.
- Types that resolve to neither are skipped — the schema check still catches real DB mismatches at scan time.

## Why
Before this change, contracts like

```yaml
columns:
  - name: amount
    data_type: DECIMAL
    character_maximum_length: 255
```

were silently accepted at parse time and only surfaced at scan time as a confusing "data type mismatch" against the live DB. Follow-up to sodadata/soda#12029 where we added form-side sanitization — this closes the CLI gap.

## Test plan
- [x] Added 13 unit tests in `test_contract_yaml_parsing.py` covering:
  - Valid params on each family (VARCHAR, DECIMAL/NUMERIC, TIMESTAMP) — no error
  - Parenthesized `varchar(255)` normalized before lookup
  - Invalid mismatches log an error naming the param, the column, and the offending data_type
  - DECIMAL↔NUMERIC same-family passes
  - Missing data_type skips validation (parser handles that elsewhere)
  - Dialect-aware: Databricks-style `string` resolves to TEXT — valid char param passes, numeric param flagged
  - No dialect + unknown native type (`string`) is skipped
- [x] `pytest soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py` → 23/23 passed
- [x] `pre-commit run` → all hooks pass (isort, black, autoflake, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)