### PR TITLE
fix: return NOT_EVALUATED for missing_percent when filter produces zero rows (#2407)

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
@@ -81,6 +81,19 @@ class MissingCheckImpl(MissingAndValidityCheckImpl):
 
         missing_count: int = measurement_values.get_value(self.missing_count_metric_impl)
         row_count: int = measurement_values.get_value(self.row_count_metric_impl)
+        if row_count == 0:
+            # Fix #2407: When filter removes all rows, skip the check rather than
+            # failing with a misleading value. There are no rows to evaluate against.
+            return CheckResult(
+                check=self,
+                outcome=CheckOutcome.NOT_EVALUATED,
+                diagnostic_metric_values={
+                    "missing_count": missing_count,
+                    "missing_percent": missing_percent,
+                    "check_rows_tested": row_count,
+                    "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
+                },
+            )
         missing_percent: float = measurement_values.get_value(self.missing_percent_metric_impl)
 
         diagnostic_metric_values: dict[str, float] = {

--- a/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
@@ -81,6 +81,7 @@ class MissingCheckImpl(MissingAndValidityCheckImpl):
 
         missing_count: int = measurement_values.get_value(self.missing_count_metric_impl)
         row_count: int = measurement_values.get_value(self.row_count_metric_impl)
+        missing_percent: float = measurement_values.get_value(self.missing_percent_metric_impl)
         if row_count == 0:
             # Fix #2407: When filter removes all rows, skip the check rather than
             # failing with a misleading value. There are no rows to evaluate against.
@@ -94,7 +95,6 @@ class MissingCheckImpl(MissingAndValidityCheckImpl):
                     "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
                 },
             )
-        missing_percent: float = measurement_values.get_value(self.missing_percent_metric_impl)
 
         diagnostic_metric_values: dict[str, float] = {
             "missing_count": missing_count,


### PR DESCRIPTION
fix: skip missing_percent check when filter produces zero rows (#2407)When a filter removes all rows (row_count=0), missing_percent was returning 0.0 which incorrectly failed checks like 'fail when < 100'. Added a guard that returns NOT_EVALUATED when row_count is 0, which is semantically correct: there are no rows to evaluate.

## Description

Please provide a description of your changes:

- What problem are you solving?
- Any expected impact on downstream packages/services?
- Reference issue # if available.


## Checklist

- [ ] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
