### PR TITLE
fix: override supports_regex_advanced to False in RedshiftDataSource (#2269)

### DIFF
--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -205,5 +205,16 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
     def build_columns_metadata_from_clause(self, table_namespace: DataSourceNamespace) -> FROM:
         return FROM(self.table_columns()).IN(self._pg_catalog_schema())
 
+    def supports_regex_advanced(self) -> bool:
+        """
+        Redshift uses POSIX regex (~ operator) which does NOT support advanced
+        regex features like lookaheads/lookbehinds (e.g., (?!...), (?=...)).
+        Returning False signals soda-core to raise InvalidRegexException
+        rather than generating a query that Redshift will reject.
+        Fixes: https://github.com/sodadata/soda-core/issues/2269
+        """
+        return False
+
+
     def _pg_catalog_schema(self) -> str:
         return "pg_catalog"


### PR DESCRIPTION
fix: return False for supports_regex_advanced in RedshiftDataSource (#2269)Redshift POSIX regex (~) doesn't support lookaheads/lookbehinds like (?!...). Added supports_regex_advanced() override returning False so soda-core raises InvalidRegexException instead of generating broken SQL.

## Description

Please provide a description of your changes:

- What problem are you solving?
- Any expected impact on downstream packages/services?
- Reference issue # if available.


## Checklist

- [ ] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
