### PR TITLE
feat: add ODPS (MaxCompute) data source support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ members = [
     "soda-sqlserver",
     "soda-synapse",
     "soda-tests", 
-    "soda-trino"
+    "soda-trino",
+    "soda-odps",
 ]
 
 [dependency-groups]
@@ -58,6 +59,7 @@ soda-sqlserver = { workspace = true }
 soda-synapse = { workspace = true }
 soda-tests = { workspace = true }
 soda-trino = { workspace = true }
+soda-odps = { workspace = true }
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/soda-odps/pyproject.toml
+++ b/soda-odps/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "soda-odps"
+version = "4.7.1rc0"
+description = "Soda ODPS (MaxCompute) V4"
+requires-python = ">=3.10"
+license = {text = "Proprietary"}
+authors = [
+    {name = "Soda Data N.V.", email = "info@soda.io"}
+]
+dependencies = [
+    "soda-core==4.7.1rc0",
+    "pyodps>=0.4.0",
+    "setuptools>=60",
+]
+
+[project.entry-points."soda.plugins.data_source.odps"]
+OdpsDataSourceImpl = "soda_odps.common.data_sources.odps_data_source:OdpsDataSourceImpl"
+
+[tool.uv.sources]
+soda-core = { workspace = true }
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}

--- a/soda-odps/src/soda_odps/__init__.py
+++ b/soda-odps/src/soda_odps/__init__.py
@@ -1,0 +1,1 @@
+# Empty init file for soda_odps package

--- a/soda-odps/src/soda_odps/common/__init__.py
+++ b/soda-odps/src/soda_odps/common/__init__.py
@@ -1,0 +1,1 @@
+# Soda ODPS common package

--- a/soda-odps/src/soda_odps/common/data_sources/__init__.py
+++ b/soda-odps/src/soda_odps/common/data_sources/__init__.py
@@ -1,0 +1,1 @@
+# Soda ODPS data sources

--- a/soda-odps/src/soda_odps/common/data_sources/odps_data_source.py
+++ b/soda-odps/src/soda_odps/common/data_sources/odps_data_source.py
@@ -1,0 +1,216 @@
+import logging
+import re
+from typing import Optional
+
+from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_impl import DataSourceImpl, FullyQualifiedTableName
+from soda_core.common.logging_constants import soda_logger
+from soda_core.common.sql_ast import FROM
+from soda_core.common.sql_dialect import SqlDialect
+from soda_odps.common.data_sources.odps_data_source_model import (
+    OdpsDataSource as OdpsDataSourceModel,
+)
+
+logger: logging.Logger = soda_logger
+
+
+class OdpsDataSourceImpl(DataSourceImpl, model_class=OdpsDataSourceModel):
+    def __init__(self, data_source_model: OdpsDataSourceModel, connection: Optional[DataSourceConnection] = None):
+        super().__init__(data_source_model=data_source_model, connection=connection)
+
+    def _create_sql_dialect(self) -> SqlDialect:
+        return OdpsSqlDialect()
+
+    def _create_data_source_connection(self) -> DataSourceConnection:
+        from soda_odps.common.data_sources.odps_data_source_connection import (
+            OdpsDataSourceConnection,
+        )
+
+        return OdpsDataSourceConnection(
+            name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
+        )
+
+    def verify_if_table_exists(self, prefixes: list[str], table_name: str) -> bool:
+        fully_qualified_table_names: list[FullyQualifiedTableName] = self._get_fully_qualified_table_names(
+            prefixes=prefixes, table_name=table_name
+        )
+        return any(
+            fully_qualified_table_name.table_name.lower() == table_name.lower()
+            for fully_qualified_table_name in fully_qualified_table_names
+        )
+
+
+class OdpsSqlDialect(SqlDialect, sqlglot_dialect=None):
+    """SQL dialect for ODPS (MaxCompute).
+
+    MaxCompute uses a PostgreSQL-like SQL dialect with some extensions.
+    Uses backticks for identifier quoting and rlike for regex matching.
+    """
+
+    DEFAULT_QUOTE_CHAR = "`"
+    SUPPORTS_DROP_TABLE_CASCADE = False
+    # Class variable to persist partition info across method calls
+    _odps_partition: Optional[str] = None
+
+    def __init__(self):
+        """Initialize ODPS dialect, reset partition state."""
+        super().__init__()
+        # Reset partition for new query
+        OdpsSqlDialect._odps_partition = None
+
+    def quote_for_ddl(self, identifier: Optional[str]) -> Optional[str]:
+        """MaxCompute DDL uses backticks."""
+        return f"`{identifier}`" if isinstance(identifier, str) and len(identifier) > 0 else None
+
+    def quote_default(self, identifier: Optional[str]) -> Optional[str]:
+        """MaxCompute uses backticks for identifier quoting."""
+        return f"`{identifier}`" if isinstance(identifier, str) and len(identifier) > 0 else None
+
+    def quote_column(self, column_name: str) -> str:
+        """MaxCompute uses backticks for column names."""
+        return f"`{column_name}`"
+
+    def supports_regex_advanced(self) -> bool:
+        """ODPS/MaxCompute supports regex with rlike operator."""
+        return True
+
+    def _build_regex_like_sql(self, matches: "REGEX_LIKE") -> str:
+        """ODPS uses rlike operator for regex matching instead of REGEXP_LIKE function."""
+        expression: str = self.build_expression_sql(matches.expression)
+        # Escape single quotes in the regex pattern
+        escaped_pattern = matches.regex_pattern.replace("'", "'")
+        return f"{expression} RLIKE '{escaped_pattern}'"
+
+    def _build_string_hash_sql(self, string_hash) -> str:
+        """ODPS uses MD5 for string hashing."""
+        return f"to_hex(md5(to_utf8({self.build_expression_sql(string_hash.expression)})))"
+
+    def _build_columns_metadata_namespace(self, prefixes: list) -> "DataSourceNamespace":
+        """Override to handle ODPS table naming."""
+        from soda_core.common.sql_dialect import SchemaDataSourceNamespace
+
+        # ODPS uses project.schema.table, where schema is the "project" in ODPS terms
+        if prefixes and len(prefixes) > 0:
+            # prefixes[0] should be the ODPS project
+            return SchemaDataSourceNamespace(schema=prefixes[0] if prefixes else None)
+        return SchemaDataSourceNamespace(schema=None)
+
+    def build_columns_metadata_query_str(self, table_namespace, table_name: str) -> str:
+        """ODPS uses DESCRIBE TABLE instead of information_schema."""
+        # Table name from contract: zhidou_hz.test_ksf.mid_ksf_sales_detail_m_v2
+        # We need to pass the full path so ODPS can determine the schema
+        # DESCRIBE will be handled via Table API, not SQL
+        return f"DESCRIBE {table_name};"
+
+    def _build_cte_sql_lines(self, select_elements: list) -> list[str]:
+        """Build CTE with ODPS partition support.
+
+        Override to extract partition filters from WHERE and add them to FROM PARTITION clause.
+        """
+
+        from soda_core.common.sql_dialect import CTE
+
+        # Reset partition state at start
+        OdpsSqlDialect._odps_partition = None
+
+        # First, let parent build CTE normally
+        cte_sql_lines = super()._build_cte_sql_lines(select_elements)
+
+        # Find the CTE and its filter
+        for select_element in select_elements:
+            if isinstance(select_element, CTE) and select_element.filter:
+                filter_str = select_element.filter
+                logger.info(f"Found CTE filter: {filter_str}")
+                # Check if this is a partition filter like "ds = '20260101'"
+                partition_match = re.search(r"(\w+)\s*=\s*'([^']+)'", filter_str)
+                if partition_match:
+                    partition_col = partition_match.group(1)
+                    partition_value = partition_match.group(2)
+                    # Store partition info in class variable for use in FROM clause
+                    OdpsSqlDialect._odps_partition = f"PARTITION({partition_col}='{partition_value}')"
+                    logger.info(f"Extracted ODPS partition: {OdpsSqlDialect._odps_partition}")
+                else:
+                    logger.info(f"Filter is not a partition filter: {filter_str}")
+
+        return cte_sql_lines
+
+    def _build_from_part(self, from_part: FROM) -> str:
+        """Build FROM clause with ODPS partition support.
+
+        ODPS requires partition conditions in FROM clause using PARTITION clause,
+        e.g., `table_name` PARTITION(ds='20260101')
+        """
+        from_parts: list[str] = [
+            self._build_qualified_quoted_dataset_name(
+                dataset_name=from_part.table_name, dataset_prefix=from_part.table_prefix
+            )
+        ]
+
+        # Add partition from class variable if available
+        if OdpsSqlDialect._odps_partition:
+            from_parts.append(OdpsSqlDialect._odps_partition)
+
+        if from_part.sampler_type is not None and isinstance(from_part.sample_size, Number):
+            from_parts.append(self._build_sample_sql(from_part.sampler_type, from_part.sample_size))
+
+        if isinstance(from_part.alias, str):
+            from_parts.append(self._alias_format(from_part.alias))
+
+        return " ".join(from_parts)
+
+    def _build_from_sql_lines(self, select_elements: list) -> list[str]:
+        """Build FROM clause - extract partition filter from CTE."""
+        from soda_core.common.sql_dialect import CTE
+
+        # First, build the basic FROM lines
+        from_lines = super()._build_from_sql_lines(select_elements)
+
+        # Debug: Find CTE and see if it has filter
+        for select_element in select_elements:
+            if isinstance(select_element, CTE):
+                logger.info(f"Found CTE: {select_element.alias}")
+                # CTE is a CTE object, let's see its contents
+                logger.info(f"CTE content: {select_element}")
+                # Check if CTE query is a list with filter
+                if isinstance(select_element.cte_query, list):
+                    for item in select_element.cte_query:
+                        if item is not None:
+                            logger.info(f"  CTE query item: {type(item).__name__} = {item}")
+
+        return from_lines
+
+    def _build_where_sql_lines(self, select_elements: list) -> list[str]:
+        """Build WHERE clause, skipping partition filters that are handled in FROM PARTITION.
+
+        Partition filters like "ds = '20260101'" are moved to FROM PARTITION clause in ODPS.
+        """
+        from soda_core.common.sql_ast import AND, WHERE
+
+        and_expressions = []
+        for select_element in select_elements:
+            if isinstance(select_element, WHERE):
+                and_expressions.append(select_element.condition)
+            elif isinstance(select_element, AND):
+                and_expressions.extend(select_element._get_clauses_as_list())
+
+        # Filter out partition-only filters (they go to FROM PARTITION clause)
+        filtered_expressions = []
+        for expr in and_expressions:
+            if expr:
+                expr_str = self.build_expression_sql(expr)
+                # Check if this is a pure partition filter like "`ds` = '20260101'" or "ds = '20260101'"
+                if re.match(r"^`?\w+`?\s*=\s*'[^']+'$", expr_str):
+                    logger.info(f"Skipping partition filter in WHERE: {expr_str}")
+                    continue
+                filtered_expressions.append(expr)
+
+        where_parts = [self.build_expression_sql(and_expression) for and_expression in filtered_expressions]
+
+        where_sql_lines = []
+        for i in range(0, len(where_parts)):
+            if i == 0:
+                sql_line = f"WHERE {where_parts[0]}"
+            else:
+                sql_line = f"  AND {where_parts[i]}"
+            where_sql_lines.append(sql_line)
+        return where_sql_lines

--- a/soda-odps/src/soda_odps/common/data_sources/odps_data_source_connection.py
+++ b/soda-odps/src/soda_odps/common/data_sources/odps_data_source_connection.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.logging_constants import soda_logger
+from soda_core.model.data_source.data_source_connection_properties import (
+    DataSourceConnectionProperties,
+)
+
+logger = soda_logger
+
+
+def _get_odps_class():
+    """Lazy import of ODPS class to avoid early initialization issues."""
+    from odps import ODPS
+
+    return ODPS
+
+
+class OdpsDataSourceConnection(DataSourceConnection):
+    """Connection handler for ODPS (MaxCompute)."""
+
+    def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
+        super().__init__(name, connection_properties)
+        self._odps_client = None
+        self._cursor = None
+
+    def _create_connection(
+        self,
+        config,
+    ):
+        ODPS = _get_odps_class()
+        # Resolve environment variables
+        access_id = config.access_id
+        secret_access_key = (
+            config.secret_access_key.get_secret_value()
+            if hasattr(config.secret_access_key, "get_secret_value")
+            else str(config.secret_access_key)
+        )
+        project = config.project
+        endpoint = config.endpoint
+        tunnel_endpoint = config.tunnel_endpoint if hasattr(config, "tunnel_endpoint") else None
+
+        # Simple env var resolution
+        import os
+
+        for attr_name, attr_val in [
+            ("access_id", access_id),
+            ("secret_access_key", secret_access_key),
+            ("project", project),
+            ("endpoint", endpoint),
+            ("tunnel_endpoint", tunnel_endpoint),
+        ]:
+            if attr_val and isinstance(attr_val, str) and attr_val.startswith("${"):
+                # Extract env var name from ${env.VAR} or ${env.VAR:-default}
+                import re
+
+                match = re.search(r"\$\{env\.(\w+)(?::-)?([^}]*?)\}", attr_val)
+                if match:
+                    env_var = match.group(1)
+                    default_val = match.group(2) if match.group(2) else None
+                    resolved = os.getenv(env_var) or default_val or ""
+                    if attr_name == "access_id":
+                        access_id = resolved
+                    elif attr_name == "secret_access_key":
+                        secret_access_key = resolved
+                    elif attr_name == "project":
+                        project = resolved
+                    elif attr_name == "endpoint":
+                        endpoint = resolved
+                    elif attr_name == "tunnel_endpoint":
+                        tunnel_endpoint = resolved
+
+        self._odps_client = ODPS(
+            access_id=access_id,
+            secret_access_key=secret_access_key,
+            project=project,
+            endpoint=endpoint,
+            tunnel_endpoint=tunnel_endpoint,
+        )
+        # Create a cursor-like wrapper for compatibility
+        self._cursor = OdpsCursor(self._odps_client)
+        return self._cursor
+
+    def _execute_query_get_result_row_column_name(self, column) -> str:
+        """Extract column name from query result."""
+        return column[0]  # Column names are in the first element of the tuple
+
+    def close(self):
+        """Close the ODPS connection."""
+        if self._cursor:
+            self._cursor.close()
+        self._cursor = None
+        self._odps_client = None
+
+
+class OdpsCursor:
+    """Cursor wrapper for ODPS to provide DB-API compatibility."""
+
+    def __init__(self, odps_client):
+        self._odps_client = odps_client
+        self._last_result = None
+        self._description = None
+        self._is_open = True
+
+    def cursor(self):
+        """Return self as the cursor (DB-API compatibility)."""
+        return self
+
+    def execute(self, sql: str):
+        """Execute SQL via ODPS."""
+        logger.info(f"Executing ODPS SQL: {sql}")
+
+        # Check if this is a DESCRIBE query
+        sql_upper = sql.strip().upper()
+        is_describe = sql_upper.startswith("DESCRIBE") or sql_upper.startswith("DESC")
+
+        if is_describe:
+            # For DESCRIBE queries, use ODPS Table API instead of SQL
+            self._execute_describe_via_table_api(sql)
+            return
+
+        # Use ODPS run_sql API for regular queries
+        try:
+            # Enable full table scan on partitioned tables
+            hints = {"odps.sql.allow.fullscan": "true"}
+
+            # Create an instance for SQL execution
+            instance = self._odps_client.run_sql(sql, hints=hints)
+            # Wait for completion
+            instance.wait_for_success()
+            # Get reader to fetch results
+            try:
+                with instance.open_reader() as reader:
+                    # For regular queries, get rows from reader
+                    self._last_result = list(reader)
+                    # Get schema from first record if available
+                    if self._last_result and len(self._last_result) > 0:
+                        # PEP-249 format: (name, type_code, display_size, internal_size, precision, scale, null_ok)
+                        self._description = [
+                            (str(i), "string", None, None, None, None, None) for i in range(len(self._last_result[0]))
+                        ]
+                    else:
+                        self._description = []
+            except Exception as e:
+                logger.warning(f"ODPS reader error: {e}")
+                self._last_result = []
+                self._description = []
+        except Exception as e:
+            logger.warning(f"ODPS SQL execution error: {e}")
+            self._last_result = []
+            self._description = []
+
+    def _execute_describe_via_table_api(self, sql: str):
+        """Execute DESCRIBE query using ODPS Table API instead of SQL."""
+        try:
+            # Parse table name from DESCRIBE sql
+            # Format: DESCRIBE table_name or DESC table_name
+            sql_upper = sql.strip().upper()
+            if sql_upper.startswith("DESCRIBE"):
+                table_expr = sql[8:].strip().rstrip(";").strip()
+            else:
+                table_expr = sql[4:].strip().rstrip(";").strip()
+
+            # Parse the table name - could be project.schema.table, schema.table, or just table_name
+            # In ODPS, the table name is in format: project.schema.table
+            parts = table_expr.split(".")
+            if len(parts) == 3:
+                # project.schema.table - use as is for ODPS Table API
+                full_table_name = table_expr
+            elif len(parts) == 2:
+                # schema.table - prepend current ODPS project
+                project = self._odps_client.project
+                full_table_name = f"{project}.{table_expr}"
+            else:
+                # Just table_name - cannot describe without schema info
+                raise ValueError(f"Cannot determine schema for table: {table_expr}")
+
+            # Use ODPS Table API to get table schema
+            table = self._odps_client.get_table(full_table_name)
+            if table is None:
+                raise ValueError(f"Table not found: {full_table_name}")
+
+            # Build result from table schema
+            # ODPS DESCRIBE returns: column_name, column_type, comment
+            self._last_result = []
+            self._description = []
+
+            # Add data columns (excluding partition columns)
+            for col in table.schema:
+                col_name = col.name
+                col_type = str(col.type).lower()
+                self._last_result.append((col_name, col_type))
+                # PEP-249 format: (name, type_code, display_size, internal_size, precision, scale, null_ok)
+                self._description.append((col_name, col_type, None, None, None, None, None))
+
+            # Add partition columns from schema.partitions
+            for part_col in table.schema.partitions:
+                col_name = part_col.name
+                col_type = str(part_col.type).lower()
+                self._last_result.append((col_name, col_type))
+                self._description.append((col_name, col_type, None, None, None, None, None))
+
+            logger.info(f"DESCRIBE returned {len(self._description)} columns")
+        except Exception as e:
+            logger.warning(f"ODPS DESCRIBE error: {e}")
+            self._last_result = []
+            self._description = []
+
+    def fetchone(self):
+        """Fetch one row."""
+        if self._last_result and len(self._last_result) > 0:
+            return self._last_result.pop(0)
+        return None
+
+    def fetchall(self):
+        """Fetch all rows."""
+        result = self._last_result if self._last_result else []
+        self._last_result = []
+        return result
+
+    @property
+    def description(self):
+        """Return cursor description (column info)."""
+        return self._description if self._description else []
+
+    def close(self):
+        """Close cursor."""
+        self._last_result = None
+        self._description = None

--- a/soda-odps/src/soda_odps/common/data_sources/odps_data_source_model.py
+++ b/soda-odps/src/soda_odps/common/data_sources/odps_data_source_model.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import Literal, Optional, Union
+
+from pydantic import Field, SecretStr
+from soda_core.common.logging_constants import soda_logger
+from soda_core.model.data_source.data_source import DataSourceBase
+from soda_core.model.data_source.data_source_connection_properties import (
+    DataSourceConnectionProperties,
+)
+
+logger = soda_logger
+
+
+class OdpsConnectionProperties(DataSourceConnectionProperties, ABC):
+    """Connection properties for ODPS (MaxCompute)."""
+
+    access_id: str = Field(..., description="Aliyun Access Key ID")
+    secret_access_key: SecretStr = Field(..., description="Aliyun Secret Access Key")
+    project: str = Field(..., description="ODPS project name")
+    endpoint: str = Field(..., description="ODPS endpoint (e.g., https://service.odps.aliyun.com/api)")
+    tunnel_endpoint: Optional[str] = Field(None, description="ODPS tunnel endpoint")
+
+
+class OdpsDataSource(DataSourceBase, ABC):
+    """ODPS (MaxCompute) data source definition."""
+
+    type: Literal["odps"] = Field("odps")
+
+    connection_properties: Union[OdpsConnectionProperties] = Field(
+        ..., alias="connection", description="ODPS connection configuration"
+    )

--- a/soda-odps/src/soda_odps/test_helpers/__init__.py
+++ b/soda-odps/src/soda_odps/test_helpers/__init__.py
@@ -1,0 +1,1 @@
+# Soda ODPS test helpers

--- a/soda-odps/tests/conftest.py
+++ b/soda-odps/tests/conftest.py
@@ -1,0 +1,5 @@
+from soda_core.common.logging_configuration import configure_logging
+
+
+def pytest_sessionstart(session) -> None:
+    configure_logging(verbose=True)

--- a/soda-odps/tests/data_sources/test_odps.py
+++ b/soda-odps/tests/data_sources/test_odps.py
@@ -1,0 +1,74 @@
+import os
+
+import pytest
+from helpers.test_connection import TestConnection
+
+# define environment variables used in test cases
+ODPS_ACCESS_ID = os.getenv("ODPS_ACCESS_ID", None)
+ODPS_SECRET_ACCESS_KEY = os.getenv("ODPS_SECRET_ACCESS_KEY", None)
+ODPS_PROJECT = os.getenv("ODPS_PROJECT", None)
+ODPS_ENDPOINT = os.getenv("ODPS_ENDPOINT", "https://service.odps.aliyun.com/api")
+ODPS_TUNNEL_ENDPOINT = os.getenv("ODPS_TUNNEL_ENDPOINT", None)
+
+# define test cases and expected behavior (passing unless otherwise specified)
+test_connections: list[TestConnection] = [
+    TestConnection(  # correct connection, should work
+        test_name="correct_odps_creds",
+        connection_yaml_str=f"""
+                type: odps
+                name: ODPS_TEST_DS
+                connection:
+                    access_id: {ODPS_ACCESS_ID}
+                    secret_access_key: {ODPS_SECRET_ACCESS_KEY}
+                    project: {ODPS_PROJECT}
+                    endpoint: {ODPS_ENDPOINT}
+                    {f"tunnel_endpoint: {ODPS_TUNNEL_ENDPOINT}" if ODPS_TUNNEL_ENDPOINT else ""}
+            """,
+    ),
+    TestConnection(
+        test_name="missing_credentials",
+        connection_yaml_str=f"""
+                type: odps
+                name: ODPS_TEST_DS
+                connection:
+                    access_id: {ODPS_ACCESS_ID}
+                    secret_access_keyssdfasdf: some_secret
+                    project: {ODPS_PROJECT}
+                    endpoint: {ODPS_ENDPOINT}
+            """,
+        valid_yaml=False,
+        expected_yaml_error="Field required [type=missing]",
+    ),
+    TestConnection(
+        test_name="missing_project",
+        connection_yaml_str=f"""
+                type: odps
+                name: ODPS_TEST_DS
+                connection:
+                    access_id: {ODPS_ACCESS_ID}
+                    secret_access_key: {ODPS_SECRET_ACCESS_KEY}
+                    endpoint: {ODPS_ENDPOINT}
+            """,
+        valid_yaml=False,
+        expected_yaml_error="Field required [type=missing",
+    ),
+    TestConnection(
+        test_name="missing_endpoint",
+        connection_yaml_str=f"""
+                type: odps
+                name: ODPS_TEST_DS
+                connection:
+                    access_id: {ODPS_ACCESS_ID}
+                    secret_access_key: {ODPS_SECRET_ACCESS_KEY}
+                    project: {ODPS_PROJECT}
+            """,
+        valid_yaml=False,
+        expected_yaml_error="Field required [type=missing",
+    ),
+]
+
+
+# run tests. parameterization means each test case will show up as an individual test
+@pytest.mark.parametrize("test_connection", test_connections, ids=[tc.test_name for tc in test_connections])
+def test_odps_connections(test_connection: TestConnection, monkeypatch: pytest.MonkeyPatch):
+    test_connection.test(monkeypatch=monkeypatch)

--- a/soda-odps/tests/unit/test_odps_dialect.py
+++ b/soda-odps/tests/unit/test_odps_dialect.py
@@ -1,0 +1,39 @@
+from soda_odps.common.data_sources.odps_data_source import OdpsSqlDialect
+
+
+class TestOdpsSqlDialect:
+    """Unit tests for ODPS SQL dialect."""
+
+    def test_quote_for_ddl_with_identifier(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.quote_for_ddl("my_table")
+        assert result == "`my_table`"
+
+    def test_quote_for_ddl_with_empty_string(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.quote_for_ddl("")
+        assert result is None
+
+    def test_quote_for_ddl_with_none(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.quote_for_ddl(None)
+        assert result is None
+
+    def test_default_casify(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.default_casify("MyTable")
+        assert result == "mytable"
+
+    def test_metadata_casify(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.metadata_casify("MyColumn")
+        assert result == "mycolumn"
+
+    def test_quote_column(self):
+        dialect = OdpsSqlDialect()
+        result = dialect.quote_column("my_column")
+        assert result == '"my_column"'
+
+    def test_supports_drop_table_cascade(self):
+        dialect = OdpsSqlDialect()
+        assert dialect.SUPPORTS_DROP_TABLE_CASCADE is False


### PR DESCRIPTION
Add soda-odps plugin for ODPS/MaxCompute data sources with:
- OdpsDataSource model with connection properties (access_id, secret_access_key, project, endpoint)
- OdpsSqlDialect with backtick quoting, RLIKE regex, and PARTITION clause support
- OdpsDataSourceConnection using pyodps SDK
- DESCRIBE TABLE via ODPS Table API instead of information_schema

## Description

Please provide a description of your changes:

- What problem are you solving?
- Any expected impact on downstream packages/services?
- Reference issue # if available.


## Checklist

- [ ] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
