### PR TITLE
Fix: Keep redshift connection alive during CI

### DIFF
--- a/soda-redshift/src/soda_redshift/test_helpers/redshift_data_source_test_helper.py
+++ b/soda-redshift/src/soda_redshift/test_helpers/redshift_data_source_test_helper.py
@@ -29,4 +29,7 @@ class RedshiftDataSourceTestHelper(DataSourceTestHelper):
                 database: '{REDSHIFT_DATABASE}'
                 user: '{REDSHIFT_USERNAME}'
                 password: '{REDSHIFT_PASSWORD}'
+                keepalives_idle: 60
+                keepalives_interval: 30
+                keepalives_count: 3
         """


### PR DESCRIPTION
## Description

Please provide a description of your changes:

- What problem are you solving?
  - In soda-extensions CI fails because secondary Redshift connection is killed too soon
- Any expected impact on downstream packages/services?
  - No


## Checklist

- [ ] I added a test to verify the new functionality.
  - [ ] This is basically extensions CI.
- [ ] I verified this PR does not break [soda-extensions][1].
  - [ ] I'm trying to fix this ;)

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
