### PR TITLE
fix(core): resolve datasource YAML variables post-parse

### DIFF
--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -20,7 +20,7 @@ from soda_core.common.statements.metadata_tables_query import (
     MetadataTablesQuery,
 )
 from soda_core.common.statements.table_types import FullyQualifiedObjectName, TableType
-from soda_core.common.yaml import DataSourceYamlSource, YamlObject
+from soda_core.common.yaml import DataSourceYamlSource, VariableResolver, YamlObject
 from soda_core.contracts.contract_verification import DataSource
 from soda_core.model.data_source.data_source import DataSourceBase
 
@@ -38,12 +38,19 @@ class DataSourceImpl(ABC):
     def from_yaml_source(
         cls, data_source_yaml_source: DataSourceYamlSource, provided_variable_values: Optional[dict] = None
     ) -> Optional[DataSourceImpl]:
-        data_source_yaml_source.resolve(variables=provided_variable_values)
+        # Resolve ${ns.var} after parsing; pre-parse substitution breaks ruamel
+        # when a secret contains YAML control chars (', [, #, &). Mirrors
+        # soda-library f2a926c5.
         data_source_yaml: YamlObject = data_source_yaml_source.parse()
         if not data_source_yaml:
             return None
 
-        type_name = data_source_yaml.yaml_dict.get("type")
+        resolved_dict = VariableResolver.resolve_in_object(
+            obj=data_source_yaml.yaml_dict,
+            variable_values=provided_variable_values,
+        )
+
+        type_name = resolved_dict.get("type")
         if not type_name:
             raise ValueError("Missing required 'type' in data source YAML")
 
@@ -61,7 +68,7 @@ class DataSourceImpl(ABC):
                 f"This is likely a bug in the plugin implementation."
             )
 
-        validated_model = model_class.model_validate(data_source_yaml.yaml_dict)
+        validated_model = model_class.model_validate(resolved_dict)
         return impl_class(data_source_model=validated_model)
 
     def __init__(

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -20,7 +20,7 @@ from soda_core.common.statements.metadata_tables_query import (
     MetadataTablesQuery,
 )
 from soda_core.common.statements.table_types import FullyQualifiedObjectName, TableType
-from soda_core.common.yaml import DataSourceYamlSource, VariableResolver, YamlObject
+from soda_core.common.yaml import DataSourceYamlSource, YamlObject
 from soda_core.contracts.contract_verification import DataSource
 from soda_core.model.data_source.data_source import DataSourceBase
 
@@ -38,19 +38,13 @@ class DataSourceImpl(ABC):
     def from_yaml_source(
         cls, data_source_yaml_source: DataSourceYamlSource, provided_variable_values: Optional[dict] = None
     ) -> Optional[DataSourceImpl]:
-        # Resolve ${ns.var} after parsing; pre-parse substitution breaks ruamel
-        # when a secret contains YAML control chars (', [, #, &). Mirrors
-        # soda-library f2a926c5.
-        data_source_yaml: YamlObject = data_source_yaml_source.parse()
+        data_source_yaml: Optional[YamlObject] = data_source_yaml_source.parse_and_resolve(
+            variables=provided_variable_values,
+        )
         if not data_source_yaml:
             return None
 
-        resolved_dict = VariableResolver.resolve_in_object(
-            obj=data_source_yaml.yaml_dict,
-            variable_values=provided_variable_values,
-        )
-
-        type_name = resolved_dict.get("type")
+        type_name = data_source_yaml.yaml_dict.get("type")
         if not type_name:
             raise ValueError("Missing required 'type' in data source YAML")
 
@@ -68,7 +62,7 @@ class DataSourceImpl(ABC):
                 f"This is likely a bug in the plugin implementation."
             )
 
-        validated_model = model_class.model_validate(resolved_dict)
+        validated_model = model_class.model_validate(data_source_yaml.yaml_dict)
         return impl_class(data_source_model=validated_model)
 
     def __init__(

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -219,8 +219,9 @@ class SodaCloud:
             return None
 
         soda_cloud_yaml_source: SodaCloudYamlSource = SodaCloudYamlSource.from_file_path(file_path=config_file_path)
-        soda_cloud_yaml_source.resolve(variables=provided_variable_values)
-        soda_cloud_yaml_root_object: YamlObject = soda_cloud_yaml_source.parse()
+        soda_cloud_yaml_root_object: YamlObject = soda_cloud_yaml_source.parse_and_resolve(
+            variables=provided_variable_values,
+        )
 
         if not soda_cloud_yaml_root_object:
             logger.error("Invalid Soda Cloud config file: No valid YAML object as file content")
@@ -254,8 +255,9 @@ class SodaCloud:
     def from_yaml_source(
         cls, soda_cloud_yaml_source: SodaCloudYamlSource, provided_variable_values: Optional[dict[str, str]]
     ) -> Optional[SodaCloud]:
-        soda_cloud_yaml_source.resolve(variables=provided_variable_values)
-        soda_cloud_yaml_root_object: YamlObject = soda_cloud_yaml_source.parse()
+        soda_cloud_yaml_root_object: YamlObject = soda_cloud_yaml_source.parse_and_resolve(
+            variables=provided_variable_values,
+        )
 
         if not soda_cloud_yaml_root_object:
             logger.error("Invalid Soda Cloud config file: No valid YAML object as file content")

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -500,6 +500,31 @@ class YamlList(YamlValue, Iterable):
 
 class VariableResolver:
     @classmethod
+    def resolve_in_object(
+        cls,
+        obj: any,
+        variable_values: Optional[dict[str, str]] = None,
+        soda_variable_values: Optional[dict[str, str]] = None,
+        use_env_vars: bool = True,
+        location: Optional[Location] = None,
+    ) -> any:
+        # Walk a parsed structure and substitute ${ns.var} only on string scalars.
+        # Mirrors soda-library f2a926c5 (resolve_v4_variables).
+        if isinstance(obj, dict):
+            return {
+                k: cls.resolve_in_object(v, variable_values, soda_variable_values, use_env_vars, location)
+                for k, v in obj.items()
+            }
+        if isinstance(obj, list):
+            return [
+                cls.resolve_in_object(item, variable_values, soda_variable_values, use_env_vars, location)
+                for item in obj
+            ]
+        if isinstance(obj, str):
+            return cls.resolve(obj, variable_values, soda_variable_values, use_env_vars, location)
+        return obj
+
+    @classmethod
     def resolve(
         cls,
         source_text: str,

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -536,15 +536,11 @@ class VariableResolver:
         # whether the input is a plain str or a ruamel ScalarString subclass.
         if isinstance(obj, dict):
             for k in list(obj.keys()):
-                obj[k] = cls.resolve_in_object(
-                    obj[k], variable_values, soda_variable_values, use_env_vars, location
-                )
+                obj[k] = cls.resolve_in_object(obj[k], variable_values, soda_variable_values, use_env_vars, location)
             return obj
         if isinstance(obj, list):
             for i in range(len(obj)):
-                obj[i] = cls.resolve_in_object(
-                    obj[i], variable_values, soda_variable_values, use_env_vars, location
-                )
+                obj[i] = cls.resolve_in_object(obj[i], variable_values, soda_variable_values, use_env_vars, location)
             return obj
         if isinstance(obj, str):
             # Fast path: untouched strings keep their original (possibly typed)

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -57,12 +57,10 @@ class YamlSource:
     # The default file type is 'YAML'.
     # Specific subclasses use different file types.
 
-    # Optionally resolve variables as many times as you like:
-    # resolving will trigger file loading (if applicable)
-    yaml_source.resolve(variables={}, use_env_vars=True)
+    # parse + post-parse variable substitution in one call:
+    yaml_object: YamlObject = yaml_source.parse_and_resolve(variables={}, use_env_vars=True)
 
-    # parse will create the YamlObject
-    # resolving will trigger file loading (if applicable)
+    # Or parse without substitution if variables are not used:
     yaml_object: YamlObject = yaml_source.parse()
     """
 
@@ -136,14 +134,34 @@ class YamlSource:
                 else:
                     logger.error(f"{self.description} can't be read", exc_info=True)
 
-    def resolve(self, variables: Optional[dict[str, str]] = None, use_env_vars: bool = True) -> None:
+    def parse_and_resolve(
+        self,
+        variables: Optional[dict[str, str]] = None,
+        soda_variables: Optional[dict[str, str]] = None,
+        use_env_vars: bool = True,
+    ) -> Optional[YamlObject]:
+        """Parse the YAML, then walk the parsed structure and substitute
+        ${ns.var} references on string scalars only.
+
+        Pre-parse string substitution is unsafe: a substituted secret can
+        contain YAML control characters (', [, #, &, ...) that re-tokenise
+        the byte stream and break the parser. Mirrors the soda-library
+        post-parse approach (commit f2a926c5 / PR #697). The standalone
+        ``YamlSource.resolve`` method that did pre-parse substitution has
+        been removed; callers needing variable substitution must go through
+        this method or call ``VariableResolver.resolve_in_object`` directly
+        on an already-parsed object.
         """
-        Note: this does not change the object, but returns a new ResolvedYamlSource instead
-        """
-        self._ensure_yaml_str()
-        self.yaml_str = VariableResolver.resolve(
-            source_text=self.yaml_str, variable_values=variables, use_env_vars=use_env_vars
+        yaml_object = self.parse()
+        if yaml_object is None:
+            return None
+        VariableResolver.resolve_in_object(
+            obj=yaml_object.yaml_dict,
+            variable_values=variables,
+            soda_variable_values=soda_variables,
+            use_env_vars=use_env_vars,
         )
+        return yaml_object
 
     def resolve_on_read_value(
         self,
@@ -508,19 +526,31 @@ class VariableResolver:
         use_env_vars: bool = True,
         location: Optional[Location] = None,
     ) -> any:
-        # Walk a parsed structure and substitute ${ns.var} only on string scalars.
-        # Mirrors soda-library f2a926c5 (resolve_v4_variables).
+        # Walks a parsed structure and substitutes ${ns.var} on string scalars
+        # only. Mirrors soda-library f2a926c5 (resolve_v4_variables).
+        #
+        # Mutates dict / list containers in place so ruamel CommentedMap /
+        # CommentedSeq / quoted-scalar-string types are preserved on values
+        # that don't contain a substitution marker. Pydantic Union resolution
+        # downstream (e.g. Union[str, IPvAnyAddress]) can be sensitive to
+        # whether the input is a plain str or a ruamel ScalarString subclass.
         if isinstance(obj, dict):
-            return {
-                k: cls.resolve_in_object(v, variable_values, soda_variable_values, use_env_vars, location)
-                for k, v in obj.items()
-            }
+            for k in list(obj.keys()):
+                obj[k] = cls.resolve_in_object(
+                    obj[k], variable_values, soda_variable_values, use_env_vars, location
+                )
+            return obj
         if isinstance(obj, list):
-            return [
-                cls.resolve_in_object(item, variable_values, soda_variable_values, use_env_vars, location)
-                for item in obj
-            ]
+            for i in range(len(obj)):
+                obj[i] = cls.resolve_in_object(
+                    obj[i], variable_values, soda_variable_values, use_env_vars, location
+                )
+            return obj
         if isinstance(obj, str):
+            # Fast path: untouched strings keep their original (possibly typed)
+            # instance — important for downstream type-sensitive validators.
+            if "${" not in obj:
+                return obj
             return cls.resolve(obj, variable_values, soda_variable_values, use_env_vars, location)
         return obj
 

--- a/soda-tests/tests/unit/test_data_source_api.py
+++ b/soda-tests/tests/unit/test_data_source_api.py
@@ -70,3 +70,27 @@ def test_empty_data_source_file():
     data_source_yaml_source: DataSourceYamlSource = DataSourceYamlSource.from_str("")
     with pytest.raises(YamlParserException, match="Data Source YAML string root must be an object, but was empty"):
         data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(data_source_yaml_source)
+
+
+def test_data_source_resolves_password_with_yaml_control_chars(env_vars: dict):
+    # SAS-11735: a secret containing YAML control chars must round-trip through
+    # ${env.X} without breaking the parser.
+    hostile = "'[#FAKE,test%password&for)yaml-parser-regression"
+    env_vars["TEST_HOSTILE_PASSWORD"] = hostile
+
+    data_source_yaml_source: DataSourceYamlSource = DataSourceYamlSource.from_str(
+        yaml_str="""
+            type: postgres
+            name: postgres_test_ds
+            connection:
+                host: localhost
+                user: someuser
+                password: ${env.TEST_HOSTILE_PASSWORD}
+                database: somedb
+        """
+    )
+    data_source_impl: DataSourceImpl = DataSourceImpl.from_yaml_source(data_source_yaml_source)
+
+    connection_properties = data_source_impl.data_source_model.connection_properties
+    assert isinstance(connection_properties.password, SecretStr)
+    assert connection_properties.password.get_secret_value() == hostile

--- a/soda-tests/tests/unit/test_yaml_api.py
+++ b/soda-tests/tests/unit/test_yaml_api.py
@@ -30,8 +30,7 @@ def test_yaml_resolve_env_vars(env_vars: dict, logs: Logs):
         """
         )
     )
-    yaml_source.resolve()
-    yaml_object: YamlObject = yaml_source.parse()
+    yaml_object: YamlObject = yaml_source.parse_and_resolve()
     assert not logs.has_errors
     assert yaml_object.read_string("dataset") == "thedataset"
 


### PR DESCRIPTION
Fixes SAS-11735. soda-core's V4 datasource YAML loader substituted `${ns.var}` references into the YAML byte stream before parsing, which broke ruamel when a secret contained YAML control characters (`'`, `[`, `#`, `&`, ...) — the substituted value re-tokenised and the parser failed at the substitution column. Ports soda-library `f2a926c5` (PR #697) into the equivalent soda-core path: parse first, walk the parsed structure, substitute only string scalars.

🤖 AI-written