### PR TITLE
feat: add mysql test dispatch

### DIFF
--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -335,6 +335,12 @@ class DataSourceTestHelper:
             )
 
             return HanaDataSourceTestHelper(name)
+        elif test_datasource == "mysql":
+            from soda_mysql.test_helpers.mysql_data_source_test_helper import (
+                MySqlDataSourceTestHelper,
+            )
+
+            return MySqlDataSourceTestHelper(name)
         else:
             raise AssertionError(f"Unknown test data source {test_datasource}")
 


### PR DESCRIPTION
## Summary

Wires the test framework dispatch for the MySQL v4 adapter (soda-mysql, landing in soda-extensions). Adds a single `elif test_datasource == "mysql"` branch in `data_source_test_helper.py` that imports `MySqlDataSourceTestHelper` from the new soda-extensions package.

This is the smallest of three companion PRs — merge order is soda-core first, then soda-extensions, then soda-library. All three branches share the name `feature/mysql-support` so the CI cross-resolution works.

## Companion PRs

- soda-extensions: `feature/mysql-support` — the v4 `soda-mysql/` adapter package, dialect, DWH extension, CI workflow updates.
- soda-library: `feature/mysql-support` — modernized v3 adapter (driver swap from mysql-connector-python to PyMySQL for license correctness; bug fixes; v4 bridge factory).

## Test plan

- [ ] CI green on this branch (no MySQL container needed; this PR is dispatch-only).
- [ ] Once merged, soda-extensions CI for `mysql` matrix entry uses this dispatch.
- [ ] Conformance suite under `soda-tests/tests/integration/test_conformance_*.py` runs against `TEST_DATASOURCE=mysql` after the soda-extensions PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)