### PR TITLE
feat: expose live session timezone on each DataSourceConnection

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
+from datetime import timezone, tzinfo
 from typing import Literal, Optional, Union
 
 import pyathena
@@ -80,3 +81,7 @@ class AthenaDataSourceConnection(DataSourceConnection):
 
     def _execute_query_get_result_row_column_name(self, column) -> str:
         return column[0]  # Column names are in the first element of the tuple
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        # Athena always operates in UTC; there is no per-session TZ knob.
+        return timezone.utc

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC
+from datetime import timezone, tzinfo
 from typing import Literal, Optional, Union
 
 from google.api_core.client_info import ClientInfo
@@ -152,3 +153,7 @@ class BigQueryDataSourceConnection(DataSourceConnection):
 
     def _format_row(self, row: Row) -> tuple:
         return tuple(row.values())
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        # BigQuery always operates in UTC; there is no per-session TZ knob.
+        return timezone.utc

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -81,9 +81,7 @@ class DataSourceConnection(ABC):
             try:
                 self._session_timezone_cache = self._fetch_session_timezone()
             except Exception as e:
-                logger.warning(
-                    f"Failed to query session timezone on '{self.name}'; defaulting to UTC: {e}"
-                )
+                logger.warning(f"Failed to query session timezone on '{self.name}'; defaulting to UTC: {e}")
                 self._session_timezone_cache = timezone.utc
         return self._session_timezone_cache
 

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from datetime import timedelta, timezone, tzinfo
 from typing import Any, Callable, Optional
+
+try:
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:
+    ZoneInfo = None
+    ZoneInfoNotFoundError = Exception
 
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator
 from soda_core.common.logging_constants import soda_logger
@@ -13,6 +21,35 @@ from soda_core.common.logging_constants import soda_logger
 logger: logging.Logger = soda_logger
 
 from tabulate import tabulate
+
+
+def parse_session_timezone(value: str) -> tzinfo:
+    """Parse a session-timezone string returned by a database driver into a tzinfo.
+
+    Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT', or numeric offsets like
+    '+00:00', '-08:00', '+0530', 'UTC+02:00'. Falls back to UTC if unparseable.
+    """
+    if not value:
+        return timezone.utc
+    text = value.strip().strip("'\"")
+    if text.upper() in ("UTC", "GMT", "Z"):
+        return timezone.utc
+
+    if ZoneInfo is not None:
+        try:
+            return ZoneInfo(text)
+        except (ZoneInfoNotFoundError, ValueError, OSError):
+            pass
+
+    match = re.match(r"^(?:UTC|GMT)?([+-])(\d{1,2}):?(\d{2})?$", text)
+    if match:
+        sign = -1 if match.group(1) == "-" else 1
+        hours = int(match.group(2))
+        minutes = int(match.group(3) or 0)
+        return timezone(sign * timedelta(hours=hours, minutes=minutes))
+
+    logger.warning(f"Could not parse session timezone {text!r}; defaulting to UTC")
+    return timezone.utc
 
 
 class DataSourceConnection(ABC):
@@ -29,9 +66,29 @@ class DataSourceConnection(ABC):
         self.name: str = name
         self.connection_properties: dict = connection_properties
         self.connection: Optional[object] = connection
+        self._session_timezone_cache: Optional[tzinfo] = None
 
         # Auto-open on creation if no connection already supplied. See DataSource.open_connection()
         self.open_connection()
+
+    def get_session_timezone(self) -> tzinfo:
+        """Return the live session timezone of this connection.
+
+        Result is cached for the connection's lifetime. Subclasses override
+        :meth:`_fetch_session_timezone` to query their backend; the default is UTC.
+        """
+        if self._session_timezone_cache is None:
+            try:
+                self._session_timezone_cache = self._fetch_session_timezone()
+            except Exception as e:
+                logger.warning(
+                    f"Failed to query session timezone on '{self.name}'; defaulting to UTC: {e}"
+                )
+                self._session_timezone_cache = timezone.utc
+        return self._session_timezone_cache
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        return timezone.utc
 
     def __enter__(self):
         pass

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -23,16 +23,25 @@ logger: logging.Logger = soda_logger
 from tabulate import tabulate
 
 
-def parse_session_timezone(value: str) -> tzinfo:
+# IANA names that mean "UTC, no DST, no historical offsets". When ZoneInfo returns one
+# of these, we collapse to ``timezone.utc`` so adapter outputs are uniform regardless of
+# whether the driver reports the literal string ``"UTC"`` or the IANA alias ``"Etc/UTC"``.
+_UTC_ALIAS_ZONE_KEYS = frozenset({"UTC", "Etc/UTC", "Universal", "Zulu", "Etc/Zulu"})
+
+
+def parse_session_timezone(value: Optional[str]) -> tzinfo:
     """Parse a session-timezone string returned by a database driver into a tzinfo.
 
-    Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT'/'Z', or numeric offsets like
-    '+00:00', '-08:00', '+0530', 'UTC+02:00'. Zero offsets ('+00:00', 'UTC+00:00', etc.)
-    are normalized to ``timezone.utc`` so adapter outputs are uniform across vendors
-    that report UTC by name vs by offset. No production code currently depends on this
-    by-identity (``is timezone.utc``) check — call it future-proofing for any
-    fast-path branches that may want to skip ``astimezone`` on a guaranteed-UTC tzinfo,
-    and treat it as cosmetic uniformity rather than a correctness fix.
+    Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT'/'Z', UTC-equivalent IANA
+    aliases (``'Etc/UTC'``, ``'Universal'``, ``'Zulu'``, ``'Etc/Zulu'``), or numeric
+    offsets like '+00:00', '-08:00', '+0530', 'UTC+02:00'. Every UTC-equivalent input
+    — the literal strings, the alias zones, and zero numeric offsets — is normalized
+    to ``timezone.utc`` (the singleton) so adapter outputs are uniform across vendors
+    that report UTC by name, by alias, or by offset. No production code currently
+    depends on this by-identity (``is timezone.utc``) check; treat the normalization
+    as future-proofing for any fast-path branches that may want to skip ``astimezone``
+    on a guaranteed-UTC tzinfo, and as cosmetic uniformity rather than a correctness
+    fix.
 
     Empty / None / whitespace-only input is treated as "no session TZ configured" and
     returns ``timezone.utc`` silently. This is the conventional fallback every adapter
@@ -59,24 +68,33 @@ def parse_session_timezone(value: str) -> tzinfo:
 
     if ZoneInfo is not None:
         try:
-            return ZoneInfo(text)
+            zi = ZoneInfo(text)
         except (ZoneInfoNotFoundError, ValueError, OSError):
-            pass
+            zi = None
+        if zi is not None:
+            # Collapse UTC-equivalent IANA aliases to ``timezone.utc`` so an adapter
+            # reporting ``"Etc/UTC"`` returns the same singleton as one reporting the
+            # literal ``"UTC"`` or the ``+00:00`` numeric offset. Without this, the
+            # docstring's identity-parity claim would be false for one specific input.
+            if zi.key in _UTC_ALIAS_ZONE_KEYS:
+                return timezone.utc
+            return zi
 
     match = re.match(r"^(?:UTC|GMT)?([+-])(\d{1,2}):?(\d{2})?$", text)
     if match:
         sign = -1 if match.group(1) == "-" else 1
         hours = int(match.group(2))
         minutes = int(match.group(3) or 0)
+        # Reject components out of range explicitly. The regex's ``\d{2}`` for the
+        # minutes group accepts up to ``99``, which would otherwise spill via timedelta
+        # arithmetic into a higher hour bucket — e.g. ``+05:99`` becomes ``06:39``,
+        # silently producing a real-but-wrong offset for what is actually junk input.
+        if hours >= 24 or minutes >= 60:
+            raise ValueError(f"could not parse session timezone {text!r}")
         offset = sign * timedelta(hours=hours, minutes=minutes)
         if offset == timedelta(0):
             return timezone.utc
-        try:
-            return timezone(offset)
-        except ValueError as e:
-            # ``datetime.timezone`` rejects offsets >= 24h; surface as our standard
-            # parse-failure message so callers see a uniform error shape.
-            raise ValueError(f"could not parse session timezone {text!r}") from e
+        return timezone(offset)
 
     raise ValueError(f"could not parse session timezone {text!r}")
 

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -9,11 +9,7 @@ from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any, Callable, Optional
 
-try:
-    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-except ImportError:
-    ZoneInfo = None
-    ZoneInfoNotFoundError = Exception
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator
 from soda_core.common.logging_constants import soda_logger
@@ -63,36 +59,31 @@ def parse_session_timezone(value: Optional[str]) -> tzinfo:
     """Parse a session-timezone string returned by a database driver into a tzinfo.
 
     Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT'/'Z', UTC-equivalent IANA
-    aliases (``'Etc/UTC'``, ``'Universal'``, ``'Zulu'``, ``'Etc/Zulu'``), or numeric
-    offsets like '+00:00', '-08:00', '+0530', 'UTC+02:00'. Every UTC-equivalent input
-    — the literal strings, the alias zones, and zero numeric offsets — is normalized
-    to ``timezone.utc`` (the singleton) so adapter outputs are uniform across vendors
-    that report UTC by name, by alias, or by offset. No production code currently
-    depends on this by-identity (``is timezone.utc``) check; treat the normalization
-    as future-proofing for any fast-path branches that may want to skip ``astimezone``
-    on a guaranteed-UTC tzinfo, and as cosmetic uniformity rather than a correctness
-    fix.
+    aliases ('Etc/UTC', 'Universal', 'Zulu', etc.), or numeric offsets like '+00:00',
+    '-08:00', '+0530', 'UTC+02:00'. Every UTC-equivalent input — the literal strings,
+    the alias zones, and zero numeric offsets — is normalized to ``timezone.utc`` (the
+    singleton) so adapter outputs are uniform across vendors that report UTC by name,
+    by alias, or by offset.
 
     Empty / None / whitespace-only input is treated as "no session TZ configured" and
-    returns ``timezone.utc`` silently. This is the conventional fallback every adapter
-    uses on a missing-row query result; promoting it to an error would emit warnings on
-    every cold start.
+    returns ``timezone.utc`` silently — the conventional fallback every adapter uses
+    on a missing-row query result.
 
-    Raises ``ValueError`` on non-empty unparseable input (the colleague-review concern
-    A2: junk like ``'Mars/Olympus'`` previously degraded to UTC with only a debug-level
-    log; now it surfaces clearly so adapter authors and operators see the problem). The
-    single legitimate fallback site is ``DataSourceConnection.get_session_timezone()``,
-    which catches and logs one warning before returning UTC.
+    Raises ``ValueError`` on non-empty unparseable input. The single legitimate
+    fallback site is ``DataSourceConnection.get_session_timezone()``, which catches
+    and logs one warning before returning UTC.
     """
-    if value is None or not str(value).strip():
+    if value is None:
         return timezone.utc
-    # Strip outer whitespace, outer quotes, then inner whitespace. Drivers may quote
-    # their result and the body of those quotes may also be empty / whitespace-only.
-    text = value.strip().strip("'\"").strip()
+    # Strip outer whitespace and quotes in a single pass — drivers may quote their
+    # result, and the body of those quotes may also be empty / whitespace-only.
+    text = value.strip(" \r\n\t'\"")
     if not text:
-        # Outer quotes wrapped an empty (or whitespace-only) string — same intent as
-        # a raw-empty input on the conventional empty-fallback path.
         return timezone.utc
+    # Case-insensitive match for the UTC literals. ZoneInfo lookup below is
+    # case-sensitive (``ZoneInfo("utc")`` raises ZoneInfoNotFoundError), so we
+    # have to normalize these here. ``Z`` is the ISO-8601 alias for UTC and is
+    # not in the IANA database at all, so it can only be caught at this stage.
     if text.upper() in ("UTC", "GMT", "Z"):
         return timezone.utc
 
@@ -104,19 +95,17 @@ def parse_session_timezone(value: Optional[str]) -> tzinfo:
         # canonicalization time is correct.
         return datetime.now().astimezone().tzinfo
 
-    if ZoneInfo is not None:
-        try:
-            zi = ZoneInfo(text)
-        except (ZoneInfoNotFoundError, ValueError, OSError):
-            zi = None
-        if zi is not None:
-            # Collapse UTC-equivalent IANA aliases to ``timezone.utc`` so an adapter
-            # reporting ``"Etc/UTC"`` returns the same singleton as one reporting the
-            # literal ``"UTC"`` or the ``+00:00`` numeric offset. Without this, the
-            # docstring's identity-parity claim would be false for one specific input.
-            if zi.key in _UTC_ALIAS_ZONE_KEYS:
-                return timezone.utc
-            return zi
+    try:
+        zi = ZoneInfo(text)
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        zi = None
+    if zi is not None:
+        # Collapse UTC-equivalent IANA aliases to ``timezone.utc`` so an adapter
+        # reporting ``"Etc/UTC"`` returns the same singleton as one reporting the
+        # literal ``"UTC"`` or the ``+00:00`` numeric offset.
+        if zi.key in _UTC_ALIAS_ZONE_KEYS:
+            return timezone.utc
+        return zi
 
     match = re.match(r"^(?:UTC|GMT)?([+-])(\d{1,2}):?(\d{2})?$", text)
     if match:

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -28,9 +28,11 @@ def parse_session_timezone(value: str) -> tzinfo:
 
     Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT'/'Z', or numeric offsets like
     '+00:00', '-08:00', '+0530', 'UTC+02:00'. Zero offsets ('+00:00', 'UTC+00:00', etc.)
-    are normalized to ``timezone.utc`` so that identity comparisons across adapters are
-    consistent — an adapter that reports '+00:00' produces the same tzinfo as one that
-    reports 'UTC' or 'Etc/UTC'.
+    are normalized to ``timezone.utc`` so adapter outputs are uniform across vendors
+    that report UTC by name vs by offset. No production code currently depends on this
+    by-identity (``is timezone.utc``) check — call it future-proofing for any
+    fast-path branches that may want to skip ``astimezone`` on a guaranteed-UTC tzinfo,
+    and treat it as cosmetic uniformity rather than a correctness fix.
 
     Empty / None / whitespace-only input is treated as "no session TZ configured" and
     returns ``timezone.utc`` silently. This is the conventional fallback every adapter
@@ -45,7 +47,13 @@ def parse_session_timezone(value: str) -> tzinfo:
     """
     if value is None or not str(value).strip():
         return timezone.utc
-    text = value.strip().strip("'\"")
+    # Strip outer whitespace, outer quotes, then inner whitespace. Drivers may quote
+    # their result and the body of those quotes may also be empty / whitespace-only.
+    text = value.strip().strip("'\"").strip()
+    if not text:
+        # Outer quotes wrapped an empty (or whitespace-only) string — same intent as
+        # a raw-empty input on the conventional empty-fallback path.
+        return timezone.utc
     if text.upper() in ("UTC", "GMT", "Z"):
         return timezone.utc
 

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -159,8 +159,12 @@ class DataSourceConnection(ABC):
     def get_session_timezone(self) -> tzinfo:
         """Return the live session timezone of this connection.
 
-        Result is cached for the connection's lifetime. Subclasses override
-        :meth:`_fetch_session_timezone` to query their backend; the default is UTC.
+        Result is cached for the connection's lifetime. Subclasses MUST override
+        :meth:`_fetch_session_timezone` to declare how their backend reports the
+        session TZ. If a subclass forgets to override (or the override raises
+        unexpectedly), this method catches the failure, logs a single warning,
+        and falls back to UTC — but the warning makes the missing implementation
+        visible rather than silently treating UTC as the global default.
         """
         if self._session_timezone_cache is None:
             try:
@@ -171,7 +175,38 @@ class DataSourceConnection(ABC):
         return self._session_timezone_cache
 
     def _fetch_session_timezone(self) -> tzinfo:
-        return timezone.utc
+        """Query the backend for the live session timezone and return as a ``tzinfo``.
+
+        Subclasses MUST override. Raising ``NotImplementedError`` here (rather than
+        silently returning UTC) makes the contract explicit for new adapters: a
+        contributor adding a new vendor will see an immediate failure if they
+        forget the override, instead of every cross-source DWH transfer through
+        their adapter silently treating session TZ as UTC.
+
+        Recommended implementation:
+        * Vendors with a single source of session-TZ truth (Postgres ``SHOW
+          timezone``, Snowflake ``SHOW PARAMETERS LIKE 'TIMEZONE'``, Trino /
+          Databricks ``current_timezone()``, DuckDB ``current_setting('TimeZone')``,
+          Oracle ``SESSIONTIMEZONE``, DB2 ``CURRENT TIMEZONE``): query, then route
+          the resulting string through ``parse_session_timezone`` for normalization.
+        * Vendors that are UTC-only by design (BigQuery, Athena, Dremio): return
+          ``timezone.utc`` directly.
+        * Vendors whose connection wraps a session that may be reconfigured by the
+          caller (SparkDF's ``from_existing_session``): query the live setting
+          (e.g. ``self.session.conf.get("spark.sql.session.timeZone")``) rather
+          than hard-coding UTC.
+
+        ``get_session_timezone`` (the public accessor) wraps this in a try/except
+        that logs a single warning and falls back to UTC, so a runtime failure of
+        an existing override (driver upgrade, permission change) won't crash the
+        caller — it surfaces as a single warning + UTC.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must override _fetch_session_timezone(). "
+            "See the docstring on DataSourceConnection._fetch_session_timezone for the "
+            "recommended pattern. Vendors that are UTC-only by design should explicitly "
+            "return timezone.utc."
+        )
 
     def __enter__(self):
         pass

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -26,10 +26,24 @@ from tabulate import tabulate
 def parse_session_timezone(value: str) -> tzinfo:
     """Parse a session-timezone string returned by a database driver into a tzinfo.
 
-    Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT', or numeric offsets like
-    '+00:00', '-08:00', '+0530', 'UTC+02:00'. Falls back to UTC if unparseable.
+    Accepts IANA names ('America/Los_Angeles'), 'UTC'/'GMT'/'Z', or numeric offsets like
+    '+00:00', '-08:00', '+0530', 'UTC+02:00'. Zero offsets ('+00:00', 'UTC+00:00', etc.)
+    are normalized to ``timezone.utc`` so that identity comparisons across adapters are
+    consistent — an adapter that reports '+00:00' produces the same tzinfo as one that
+    reports 'UTC' or 'Etc/UTC'.
+
+    Empty / None / whitespace-only input is treated as "no session TZ configured" and
+    returns ``timezone.utc`` silently. This is the conventional fallback every adapter
+    uses on a missing-row query result; promoting it to an error would emit warnings on
+    every cold start.
+
+    Raises ``ValueError`` on non-empty unparseable input (the colleague-review concern
+    A2: junk like ``'Mars/Olympus'`` previously degraded to UTC with only a debug-level
+    log; now it surfaces clearly so adapter authors and operators see the problem). The
+    single legitimate fallback site is ``DataSourceConnection.get_session_timezone()``,
+    which catches and logs one warning before returning UTC.
     """
-    if not value:
+    if value is None or not str(value).strip():
         return timezone.utc
     text = value.strip().strip("'\"")
     if text.upper() in ("UTC", "GMT", "Z"):
@@ -46,10 +60,17 @@ def parse_session_timezone(value: str) -> tzinfo:
         sign = -1 if match.group(1) == "-" else 1
         hours = int(match.group(2))
         minutes = int(match.group(3) or 0)
-        return timezone(sign * timedelta(hours=hours, minutes=minutes))
+        offset = sign * timedelta(hours=hours, minutes=minutes)
+        if offset == timedelta(0):
+            return timezone.utc
+        try:
+            return timezone(offset)
+        except ValueError as e:
+            # ``datetime.timezone`` rejects offsets >= 24h; surface as our standard
+            # parse-failure message so callers see a uniform error shape.
+            raise ValueError(f"could not parse session timezone {text!r}") from e
 
-    logger.warning(f"Could not parse session timezone {text!r}; defaulting to UTC")
-    return timezone.utc
+    raise ValueError(f"could not parse session timezone {text!r}")
 
 
 class DataSourceConnection(ABC):

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -22,7 +22,6 @@ logger: logging.Logger = soda_logger
 
 from tabulate import tabulate
 
-
 # IANA names that mean "UTC, no DST, no historical offsets". When ZoneInfo returns one
 # of these, we collapse to ``timezone.utc`` so adapter outputs are uniform regardless of
 # whether the driver reports the literal string ``"UTC"`` or the IANA alias ``"Etc/UTC"``.

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -8,7 +8,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any, Callable, Optional
-
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -6,7 +6,7 @@ import os
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from datetime import timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any, Callable, Optional
 
 try:
@@ -24,8 +24,39 @@ from tabulate import tabulate
 
 # IANA names that mean "UTC, no DST, no historical offsets". When ZoneInfo returns one
 # of these, we collapse to ``timezone.utc`` so adapter outputs are uniform regardless of
-# whether the driver reports the literal string ``"UTC"`` or the IANA alias ``"Etc/UTC"``.
-_UTC_ALIAS_ZONE_KEYS = frozenset({"UTC", "Etc/UTC", "Universal", "Zulu", "Etc/Zulu"})
+# whether the driver reports the literal string ``"UTC"`` or one of the IANA aliases
+# below. The Etc/GMT entries are tricky — note that Etc/GMT+0 / Etc/GMT-0 are both
+# zero-offset variants (Etc/GMT+N has *negative* offset N hours per POSIX inversion,
+# but +0/-0 collapse to UTC). GMT0 is a System V-style zero-offset zone alias.
+_UTC_ALIAS_ZONE_KEYS = frozenset(
+    {
+        "UTC",
+        "Etc/UTC",
+        "Universal",
+        "Etc/Universal",
+        "Zulu",
+        "Etc/Zulu",
+        "GMT",
+        "GMT0",
+        "GMT+0",
+        "GMT-0",
+        "Etc/GMT",
+        "Etc/GMT0",
+        "Etc/GMT+0",
+        "Etc/GMT-0",
+        "Greenwich",
+        "Etc/Greenwich",
+    }
+)
+
+# Driver outputs that mean "use the host's local TZ at the time of the query". Postgres
+# returns ``localtime`` from ``SHOW timezone`` when the server is configured that way.
+# Trino's ``current_timezone()`` can return ``system`` for a similar setup. Both should
+# resolve to the engine host's actual local TZ so naive returns from the source can be
+# canonicalized correctly. Without this, ``parse_session_timezone`` would reject the
+# literal as unparseable and the connection wrapper would fall back to UTC, silently
+# shifting wallclocks by the host's offset for every naive return from a TZ-aware column.
+_HOST_LOCAL_LITERAL_VALUES = frozenset({"localtime", "system"})
 
 
 def parse_session_timezone(value: Optional[str]) -> tzinfo:
@@ -64,6 +95,14 @@ def parse_session_timezone(value: Optional[str]) -> tzinfo:
         return timezone.utc
     if text.upper() in ("UTC", "GMT", "Z"):
         return timezone.utc
+
+    if text.lower() in _HOST_LOCAL_LITERAL_VALUES:
+        # Driver said "use the host local TZ". Resolve via the OS now. The result is a
+        # fixed-offset tzinfo derived from the current local time — DST drift across a
+        # long-lived connection is the same as for SQL Server / DB2 (out of scope per
+        # the team's "DWH connections are short-lived" stance), but the wallclock at
+        # canonicalization time is correct.
+        return datetime.now().astimezone().tzinfo
 
     if ZoneInfo is not None:
         try:

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -175,9 +175,17 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
             "double": SodaDataTypeName.DOUBLE,
             "double precision": SodaDataTypeName.DOUBLE,
             "float8": SodaDataTypeName.DOUBLE,
-            "timestamp": SodaDataTypeName.TIMESTAMP,
+            # Native ``timestamp`` in Databricks is TZ-aware in semantics (stored as
+            # an instant, displayed in session TZ — see Databricks "Timestamp" docs).
+            # The truly-naive variant is ``timestamp_ntz`` (Databricks Runtime 13.3+).
+            # Map ``timestamp`` to TIMESTAMP_TZ so cross-source DWH dispatch picks the
+            # TZ-aware value mapper for Databricks-as-source, otherwise driver-returned
+            # tz-aware values would be sent through the naive mapper which strips
+            # tzinfo, leaving a session-local wallclock in the warehouse instead of
+            # the canonical UTC instant.
+            "timestamp": SodaDataTypeName.TIMESTAMP_TZ,
             "timestamp without time zone": SodaDataTypeName.TIMESTAMP,
-            "timestamp_ntz": SodaDataTypeName.TIMESTAMP,  # If there is explicitly stated that the timestamp is without time zone, we consider it to be the same as TIMESTAMP
+            "timestamp_ntz": SodaDataTypeName.TIMESTAMP,
             "timestamptz": SodaDataTypeName.TIMESTAMP_TZ,
             "timestamp with time zone": SodaDataTypeName.TIMESTAMP_TZ,
             "date": SodaDataTypeName.DATE,

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+from datetime import tzinfo
 
 from databricks import sql
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
@@ -27,6 +28,12 @@ class DatabricksDataSourceConnection(DataSourceConnection):
             user_agent_entry="Soda Core",
             **config.to_connection_kwargs(),
         )
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT current_timezone()")
+            row = cursor.fetchone()
+        return parse_session_timezone(row[0] if row else "")
 
     def rollback(self) -> None:
         # We do not start any transactions, Databricks default is autocommit.

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -4,7 +4,10 @@ import logging
 from datetime import tzinfo
 
 from databricks import sql
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 
 from databricks import sql
 from soda_core.common.data_source_connection import (
@@ -36,7 +36,9 @@ class DatabricksDataSourceConnection(DataSourceConnection):
         with self.connection.cursor() as cursor:
             cursor.execute("SELECT current_timezone()")
             row = cursor.fetchone()
-        return parse_session_timezone(row[0] if row else "")
+        if not row:
+            return timezone.utc
+        return parse_session_timezone(row[0])
 
     def rollback(self) -> None:
         # We do not start any transactions, Databricks default is autocommit.

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -79,9 +79,7 @@ class TestTimestampReverseMapping:
             ("timestamp without time zone", SodaDataTypeName.TIMESTAMP),
         ],
     )
-    def test_reverse_map_resolves_correctly(
-        self, data_type_name: str, expected_canonical: SodaDataTypeName
-    ) -> None:
+    def test_reverse_map_resolves_correctly(self, data_type_name: str, expected_canonical: SodaDataTypeName) -> None:
         dialect = DatabricksSqlDialect()
         actual = dialect.get_soda_data_type_name_by_data_source_data_type_names().get(data_type_name)
         assert actual == expected_canonical, (

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -1,4 +1,5 @@
 import pytest
+from soda_core.common.metadata_types import SodaDataTypeName
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
 from soda_databricks.common.data_sources.databricks_data_source import (
     DatabricksSqlDialect,
@@ -53,3 +54,38 @@ def test_random():
     sql_dialect: DatabricksSqlDialect = DatabricksSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT RAND()\nFROM `a`;"
+
+
+class TestTimestampReverseMapping:
+    """Pin the cross-source DWH dispatch invariant for Databricks.
+
+    Native Databricks ``timestamp`` is TZ-aware in semantics (stored as an instant,
+    displayed in session TZ). The reverse map must therefore resolve ``timestamp`` to
+    ``SodaDataTypeName.TIMESTAMP_TZ`` so cross-source DWH transfer dispatches the
+    TZ-aware value mapper for Databricks-as-source. ``timestamp_ntz`` (the explicit
+    naive variant) resolves to ``SodaDataTypeName.TIMESTAMP``. A regression that
+    flipped these would silently drop tzinfo from Databricks-source rows on a
+    non-UTC Spark session and store a session-local wallclock instead of a UTC
+    instant in the warehouse.
+    """
+
+    @pytest.mark.parametrize(
+        "data_type_name, expected_canonical",
+        [
+            ("timestamp", SodaDataTypeName.TIMESTAMP_TZ),
+            ("timestamptz", SodaDataTypeName.TIMESTAMP_TZ),
+            ("timestamp with time zone", SodaDataTypeName.TIMESTAMP_TZ),
+            ("timestamp_ntz", SodaDataTypeName.TIMESTAMP),
+            ("timestamp without time zone", SodaDataTypeName.TIMESTAMP),
+        ],
+    )
+    def test_reverse_map_resolves_correctly(
+        self, data_type_name: str, expected_canonical: SodaDataTypeName
+    ) -> None:
+        dialect = DatabricksSqlDialect()
+        actual = dialect.get_soda_data_type_name_by_data_source_data_type_names().get(data_type_name)
+        assert actual == expected_canonical, (
+            f"Databricks reverse-map for {data_type_name!r} returned {actual!r}, expected "
+            f"{expected_canonical!r}. A regression here would silently dispatch the wrong "
+            "DWH value mapper for Databricks-as-source."
+        )

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -3,7 +3,10 @@ from datetime import tzinfo
 from pathlib import Path
 
 from duckdb import DuckDBPyConnection
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
+from datetime import tzinfo
 from pathlib import Path
 
 from duckdb import DuckDBPyConnection
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
@@ -252,6 +253,15 @@ class DuckDBDataSourceConnection(DataSourceConnection):
 
         except Exception as e:
             raise DataSourceConnectionException(e)
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute("SELECT current_setting('TimeZone')")
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        return parse_session_timezone(row[0] if row else "")
 
     def extract_format(self, config: DuckDBStandardConnectionProperties) -> str:
         return Path(config.database).suffix

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from pathlib import Path
 
 from duckdb import DuckDBPyConnection
@@ -258,13 +258,12 @@ class DuckDBDataSourceConnection(DataSourceConnection):
             raise DataSourceConnectionException(e)
 
     def _fetch_session_timezone(self) -> tzinfo:
-        cursor = self.connection.cursor()
-        try:
+        with self.connection.cursor() as cursor:
             cursor.execute("SELECT current_setting('TimeZone')")
             row = cursor.fetchone()
-        finally:
-            cursor.close()
-        return parse_session_timezone(row[0] if row else "")
+        if not row:
+            return timezone.utc
+        return parse_session_timezone(row[0])
 
     def extract_format(self, config: DuckDBStandardConnectionProperties) -> str:
         return Path(config.database).suffix

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -44,6 +44,21 @@ class DuckDBCursor:
         # we don't want to close it
         pass
 
+    def __enter__(self):
+        # ``__enter__`` / ``__exit__`` need to live on the type itself, not
+        # be reached via ``__getattr__`` — Python looks up dunder methods on
+        # the class, not the instance. Without these explicit definitions,
+        # ``with self.connection.cursor() as cursor:`` raises ``TypeError:
+        # ... does not support the context manager protocol``. ``close`` is a
+        # no-op for DuckDB (the cursor IS the connection), so __exit__ does
+        # nothing observable; the methods exist just to keep DuckDBCursor a
+        # drop-in for vendors that DO use ``with cursor`` semantics.
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return None
+
     @property
     def description(self):
         """

--- a/soda-duckdb/tests/unit/test_duckdb_session_timezone.py
+++ b/soda-duckdb/tests/unit/test_duckdb_session_timezone.py
@@ -1,0 +1,114 @@
+"""Unit tests for ``DuckDBDataSourceConnection._fetch_session_timezone`` and the
+``DuckDBCursor`` context-manager protocol.
+
+DuckDB ships a custom cursor wrapper (``DuckDBCursor``) that delegates most
+attribute access to the underlying connection via ``__getattr__``. Python looks
+up dunder methods on the *type*, not the instance, so ``__getattr__`` does not
+satisfy the ``with`` statement's protocol — the class itself must define
+``__enter__`` / ``__exit__``. CI surfaced this when the
+``_fetch_session_timezone`` implementation switched to ``with cursor`` syntax.
+
+These tests use an in-memory DuckDB connection (no credentials required) so the
+end-to-end ``with self.connection.cursor() as cursor:`` flow runs against a real
+connection, catching this class of failure before CI does.
+"""
+from __future__ import annotations
+
+from datetime import tzinfo
+
+import duckdb
+from soda_duckdb.common.data_sources.duckdb_data_source import (
+    DuckDBCursor,
+    DuckDBDataSourceConnectionWrapper,
+)
+
+
+class TestDuckDBCursorContextManager:
+    """Pin the context-manager contract on the wrapper class itself.
+
+    Without ``__enter__`` / ``__exit__`` defined directly on ``DuckDBCursor``,
+    ``with cursor`` raises ``TypeError`` even though attribute delegation
+    appears to expose the underlying connection — Python's dunder lookup
+    bypasses ``__getattr__``.
+    """
+
+    def test_cursor_supports_with_statement(self) -> None:
+        # In-memory connection: no credentials, no lifecycle, fully synchronous.
+        raw = duckdb.connect(":memory:")
+        cursor = DuckDBCursor(raw)
+        with cursor as ctx:
+            ctx.execute("SELECT 1")
+            row = ctx.fetchone()
+        assert row == (1,)
+
+    def test_with_statement_returns_self(self) -> None:
+        raw = duckdb.connect(":memory:")
+        cursor = DuckDBCursor(raw)
+        with cursor as ctx:
+            assert ctx is cursor
+
+    def test_close_remains_a_noop(self) -> None:
+        # DuckDB cursors share state with the connection; ``close()`` is a no-op
+        # to avoid breaking subsequent queries on the same connection. The
+        # context-manager exit must not regress that.
+        raw = duckdb.connect(":memory:")
+        cursor = DuckDBCursor(raw)
+        with cursor as ctx:
+            ctx.execute("SELECT 1")
+            ctx.fetchone()
+        # After the with-block, the underlying connection must still be usable.
+        cursor.execute("SELECT 2")
+        assert cursor.fetchone() == (2,)
+
+
+class TestDuckDBFetchSessionTimezone:
+    """Drive ``_fetch_session_timezone`` end-to-end against an in-memory DuckDB.
+
+    DuckDB inherits its session timezone from the host OS by default, so the
+    specific value depends on the runner — but the *shape* of the return
+    (a usable ``tzinfo``) is what this layer is responsible for.
+    """
+
+    def _make_connection_with_real_duckdb(self):
+        # Build a DuckDBDataSourceConnection skeleton with a real in-memory
+        # DuckDB connection so the with-cursor path runs end-to-end. The
+        # adapter doesn't need any other state to satisfy
+        # ``_fetch_session_timezone``.
+        from soda_duckdb.common.data_sources.duckdb_data_source import (
+            DuckDBDataSourceConnection,
+        )
+
+        instance = DuckDBDataSourceConnection.__new__(DuckDBDataSourceConnection)
+        raw = duckdb.connect(":memory:")
+        instance.connection = DuckDBDataSourceConnectionWrapper(raw)
+        return instance
+
+    def test_fetch_returns_tzinfo(self) -> None:
+        instance = self._make_connection_with_real_duckdb()
+
+        result = instance._fetch_session_timezone()
+
+        assert isinstance(result, tzinfo)
+        # The tzinfo must be usable to localize a naive datetime — that's the
+        # invariant the value-mapper layer relies on.
+        from datetime import datetime, timezone
+
+        naive = datetime(2024, 6, 15, 12, 0, 0)
+        aware = naive.replace(tzinfo=result)
+        aware.astimezone(timezone.utc)  # would raise if tzinfo is malformed
+
+    def test_with_cursor_context_manager_works_end_to_end(self) -> None:
+        # The point of this test is to catch the exact regression CI flagged:
+        # ``with self.connection.cursor() as cursor`` raising TypeError because
+        # DuckDBCursor doesn't expose ``__exit__``. If ``DuckDBCursor`` is ever
+        # refactored to drop the explicit dunders, this test fails immediately
+        # rather than the failure surfacing in an integration run.
+        instance = self._make_connection_with_real_duckdb()
+
+        # Exercise the same pattern the real method uses.
+        with instance.connection.cursor() as cursor:
+            cursor.execute("SELECT current_setting('TimeZone')")
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert isinstance(row[0], str)

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -8,7 +8,10 @@ from typing import Callable, ClassVar, Dict, Literal, Optional, Union
 
 import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr, field_validator
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
+from datetime import tzinfo
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, Literal, Optional, Union
 
 import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr, field_validator
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
@@ -85,6 +86,12 @@ class PostgresDataSourceConnection(DataSourceConnection):
         connection_kwargs = config.to_connection_kwargs()
         connection = psycopg.connect(**connection_kwargs)
         return connection
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        with self.connection.cursor() as cursor:
+            cursor.execute("SHOW timezone")
+            row = cursor.fetchone()
+        return parse_session_timezone(row[0] if row else "")
 
     def execute_query(self, sql: str, log_query: bool = True) -> QueryResult:
         try:

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, Literal, Optional, Union
 
@@ -94,7 +94,9 @@ class PostgresDataSourceConnection(DataSourceConnection):
         with self.connection.cursor() as cursor:
             cursor.execute("SHOW timezone")
             row = cursor.fetchone()
-        return parse_session_timezone(row[0] if row else "")
+        if not row:
+            return timezone.utc
+        return parse_session_timezone(row[0])
 
     def execute_query(self, sql: str, log_query: bool = True) -> QueryResult:
         try:

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
@@ -9,7 +9,10 @@ import boto3
 import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr
 from soda_core.common.aws_credentials import AwsCredentials
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from datetime import tzinfo
 from ipaddress import IPv4Address, IPv6Address
 from typing import Literal, Optional, Union
 
@@ -8,7 +9,7 @@ import boto3
 import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr
 from soda_core.common.aws_credentials import AwsCredentials
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
@@ -140,3 +141,9 @@ class RedshiftDataSourceConnection(DataSourceConnection):
         # Otherwise an `DEALLOCATE ALL` will be triggered, which is not supported.
         conn.prepare_threshold = None
         return conn
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        with self.connection.cursor() as cursor:
+            cursor.execute("SHOW timezone")
+            row = cursor.fetchone()
+        return parse_session_timezone(row[0] if row else "")

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from ipaddress import IPv4Address, IPv6Address
 from typing import Literal, Optional, Union
 
@@ -149,4 +149,6 @@ class RedshiftDataSourceConnection(DataSourceConnection):
         with self.connection.cursor() as cursor:
             cursor.execute("SHOW timezone")
             row = cursor.fetchone()
-        return parse_session_timezone(row[0] if row else "")
+        if not row:
+            return timezone.utc
+        return parse_session_timezone(row[0])

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
+from datetime import tzinfo
 from pathlib import Path
 from typing import Dict, Literal, Optional
 
@@ -9,7 +10,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from pydantic import Field, SecretStr, field_validator
 from snowflake import connector
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
@@ -145,3 +146,20 @@ class SnowflakeDataSourceConnection(DataSourceConnection):
             application="Soda",
             **config.to_connection_kwargs(),
         )
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION")
+            rows = cursor.fetchall()
+            description = cursor.description
+        finally:
+            cursor.close()
+        if not rows:
+            return parse_session_timezone("")
+        column_names = [col[0].lower() if col[0] else "" for col in description]
+        try:
+            value_index = column_names.index("value")
+        except ValueError:
+            value_index = 1  # Snowflake's SHOW PARAMETERS layout: key, value, default, level, description
+        return parse_session_timezone(rows[0][value_index])

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
@@ -10,7 +10,10 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from pydantic import Field, SecretStr, field_validator
 from snowflake import connector
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from pathlib import Path
 from typing import Dict, Literal, Optional
 
@@ -159,10 +159,23 @@ class SnowflakeDataSourceConnection(DataSourceConnection):
         finally:
             cursor.close()
         if not rows:
-            return parse_session_timezone("")
+            # SHOW PARAMETERS returned no row at all — treat as "no session TZ
+            # configured" rather than a parse failure (parse_session_timezone returns
+            # UTC silently for empty input but raises on truly junk values).
+            return timezone.utc
         column_names = [col[0].lower() if col[0] else "" for col in description]
         try:
             value_index = column_names.index("value")
         except ValueError:
-            value_index = 1  # Snowflake's SHOW PARAMETERS layout: key, value, default, level, description
+            # Defensive: a Snowflake driver / server upgrade has reshaped the SHOW
+            # PARAMETERS output. We refuse to guess a column index — the prior code
+            # silently fell back to ``column 1`` which would happen to be right today
+            # but would mask a real schema change tomorrow. Surface the situation as a
+            # warning and default to UTC; the connection-level wrapper will not log it
+            # again because we return rather than raise.
+            logger.warning(
+                "Snowflake SHOW PARAMETERS did not include a 'value' column "
+                f"(got {column_names!r}); defaulting session timezone to UTC"
+            )
+            return timezone.utc
         return parse_session_timezone(rows[0][value_index])

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
@@ -151,13 +151,10 @@ class SnowflakeDataSourceConnection(DataSourceConnection):
         )
 
     def _fetch_session_timezone(self) -> tzinfo:
-        cursor = self.connection.cursor()
-        try:
+        with self.connection.cursor() as cursor:
             cursor.execute("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION")
             rows = cursor.fetchall()
             description = cursor.description
-        finally:
-            cursor.close()
         if not rows:
             # SHOW PARAMETERS returned no row at all — treat as "no session TZ
             # configured" rather than a parse failure (parse_session_timezone returns

--- a/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
+++ b/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
@@ -13,7 +13,6 @@ import logging
 from datetime import timezone
 from unittest.mock import MagicMock
 
-import pytest
 from soda_core.common.logs import Logs
 from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
     SnowflakeDataSourceConnection,

--- a/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
+++ b/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
@@ -26,6 +26,8 @@ def _make_connection(rows, description):
     cursor.description = description
     cursor.execute.return_value = None
     cursor.close.return_value = None
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=None)
 
     snow_conn = MagicMock()
     snow_conn.cursor.return_value = cursor

--- a/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
+++ b/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``SnowflakeDataSourceConnection._fetch_session_timezone``.
+
+The Snowflake adapter previously fell back to a hard-coded magic index (``1``) when
+``SHOW PARAMETERS`` returned a row whose columns did not include ``value``. That
+worked under today's driver layout but would silently keep working — at the wrong
+column — if a future driver/server upgrade reshaped the response. After this
+change, the magic-index path is replaced with a logged UTC fallback so a real
+schema drift surfaces in operator logs instead of being hidden behind a coincidence.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timezone
+from unittest.mock import MagicMock
+
+import pytest
+from soda_core.common.logs import Logs
+from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
+    SnowflakeDataSourceConnection,
+)
+
+
+def _make_connection(rows, description):
+    instance = SnowflakeDataSourceConnection.__new__(SnowflakeDataSourceConnection)
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows
+    cursor.description = description
+    cursor.execute.return_value = None
+    cursor.close.return_value = None
+
+    snow_conn = MagicMock()
+    snow_conn.cursor.return_value = cursor
+    instance.connection = snow_conn
+    return instance
+
+
+class TestSnowflakeSessionTimezoneNoValueColumn:
+    def test_no_rows_returns_utc_silently(self) -> None:
+        instance = _make_connection(rows=[], description=[("key",), ("value",)])
+
+        result = instance._fetch_session_timezone()
+
+        assert result is timezone.utc
+
+    def test_value_column_present_parses_as_normal(self) -> None:
+        instance = _make_connection(
+            rows=[("TIMEZONE", "America/Los_Angeles", "America/Los_Angeles", "ACCOUNT", "")],
+            description=[("key",), ("value",), ("default",), ("level",), ("description",)],
+        )
+
+        result = instance._fetch_session_timezone()
+
+        # Returned tzinfo must produce the expected offset for an LA-summer instant.
+        from datetime import datetime
+
+        ldt = datetime(2024, 7, 1, 12, 0, 0)
+        assert result.utcoffset(ldt).total_seconds() == -7 * 3600  # PDT
+
+    def test_missing_value_column_logs_warning_and_falls_back_to_utc(self) -> None:
+        # Simulate a future Snowflake driver/server reshape: rows exist, but no
+        # column is named "value". The pre-fix code would silently fall back to
+        # ``rows[0][1]`` which would happen to be the right column today but would
+        # silently break when the layout changes — defeat the purpose of having a
+        # parser at all.
+        instance = _make_connection(
+            rows=[("TIMEZONE", "America/Los_Angeles", "ACCOUNT")],
+            description=[("name",), ("setting",), ("source",)],
+        )
+
+        captured = Logs()
+        try:
+            result = instance._fetch_session_timezone()
+        finally:
+            captured.remove_from_root_logger()
+
+        assert result is timezone.utc
+        warnings = [r for r in captured.get_log_records() if r.levelno >= logging.WARNING]
+        assert any(
+            "SHOW PARAMETERS" in r.getMessage() and "value" in r.getMessage() for r in warnings
+        ), f"Expected a warning naming SHOW PARAMETERS and 'value', got: {[r.getMessage() for r in warnings]}"

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import Any, Optional
 
 from freezegun import freeze_time
@@ -196,6 +196,13 @@ class SparkDataFrameDataSourceConnection(DataSourceConnection):
 
     def close_connection(self) -> None:
         "This is a no-op for SparkDataFrameDataSourceConnection, there is no connection to close."
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        # SparkDataFrameDataSourceConnection's _create_connection issues
+        # ``SET TIME ZONE 'UTC';`` for new sessions; existing sessions are caller-provided
+        # but the value mappers only ever need the *effective* TZ at read time, which we
+        # report as UTC since that's the only mode this adapter is configured for.
+        return timezone.utc
 
     def _execute_query_get_result_row_column_name(self, column) -> str:
         return column[0]  # The first element of the tuple is the column name

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -4,7 +4,10 @@ from typing import Any, Optional
 from freezegun import freeze_time
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import Row
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.data_source_impl import DataSourceImpl, MetadataTablesQuery
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName
@@ -198,11 +201,15 @@ class SparkDataFrameDataSourceConnection(DataSourceConnection):
         "This is a no-op for SparkDataFrameDataSourceConnection, there is no connection to close."
 
     def _fetch_session_timezone(self) -> tzinfo:
-        # SparkDataFrameDataSourceConnection's _create_connection issues
-        # ``SET TIME ZONE 'UTC';`` for new sessions; existing sessions are caller-provided
-        # but the value mappers only ever need the *effective* TZ at read time, which we
-        # report as UTC since that's the only mode this adapter is configured for.
-        return timezone.utc
+        # New sessions created by this adapter explicitly ``SET TIME ZONE 'UTC';``,
+        # but ``SparkDataFrameExistingSessionProperties`` lets a caller wrap an existing
+        # SparkSession that may have any configured zone. Read the live setting so the
+        # value mappers see the same zone the Spark engine will use to interpret
+        # naive returns. ``parse_session_timezone`` accepts Spark's reported value
+        # ('UTC', '+00:00', 'America/Los_Angeles', etc.) and the connection-level
+        # wrapper falls back to UTC if the call raises.
+        tz_value = self.session.conf.get("spark.sql.session.timeZone")
+        return parse_session_timezone(tz_value)
 
     def _execute_query_get_result_row_column_name(self, column) -> str:
         return column[0]  # The first element of the tuple is the column name

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import struct
 from abc import ABC
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any, Literal, Optional, Union
 
 import pyodbc
@@ -195,6 +195,24 @@ class SqlServerDataSourceConnection(DataSourceConnection):
 
     def _execute_query_get_result_row_column_name(self, column) -> str:
         return column[0]
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        # Use SYSDATETIMEOFFSET() instead of CURRENT_TIMEZONE_ID() so the same query works
+        # across the whole SQL Server family: SQL Server proper, Microsoft Fabric DW, Azure
+        # Synapse Dedicated/Serverless. CURRENT_TIMEZONE_ID is unsupported in Fabric and
+        # Synapse Dedicated; SYSDATETIMEOFFSET is universally supported.
+        # The connection registers ``handle_datetimeoffset`` as a pyodbc output converter for
+        # SQL_TYPE -155, so the returned value is a tz-aware ``datetime`` whose tzinfo is the
+        # exact offset reported by the server.
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute("SELECT SYSDATETIMEOFFSET()")
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        if row and isinstance(row[0], datetime) and row[0].tzinfo is not None:
+            return row[0].tzinfo
+        return timezone.utc
 
     def _get_autocommit_setting(self) -> bool:
         return False  # No need to set autocommit, as it is set to False by default.

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -204,12 +204,9 @@ class SqlServerDataSourceConnection(DataSourceConnection):
         # The connection registers ``handle_datetimeoffset`` as a pyodbc output converter for
         # SQL_TYPE -155, so the returned value is a tz-aware ``datetime`` whose tzinfo is the
         # exact offset reported by the server.
-        cursor = self.connection.cursor()
-        try:
+        with self.connection.cursor() as cursor:
             cursor.execute("SELECT SYSDATETIMEOFFSET()")
             row = cursor.fetchone()
-        finally:
-            cursor.close()
         if not row or not isinstance(row[0], datetime) or row[0].tzinfo is None:
             return timezone.utc
         offset = row[0].tzinfo.utcoffset(row[0])

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -9,10 +9,7 @@ from typing import Any, Literal, Optional, Union
 import pyodbc
 from pydantic import Field, SecretStr
 from soda_core.__version__ import SODA_CORE_VERSION
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
@@ -215,15 +212,15 @@ class SqlServerDataSourceConnection(DataSourceConnection):
             cursor.close()
         if not row or not isinstance(row[0], datetime) or row[0].tzinfo is None:
             return timezone.utc
-        # Format the live offset as a ±HH:MM string and route through parse_session_timezone
-        # so SQL Server returns the same shape of tzinfo as adapters that report IANA-named
-        # zones — in particular, +00:00 normalizes to ``timezone.utc`` (identity), matching
-        # Postgres / Snowflake / Databricks etc. on UTC sessions.
         offset = row[0].tzinfo.utcoffset(row[0])
-        total_minutes = int(offset.total_seconds() // 60)
-        sign = "-" if total_minutes < 0 else "+"
-        hours, minutes = divmod(abs(total_minutes), 60)
-        return parse_session_timezone(f"{sign}{hours:02d}:{minutes:02d}")
+        # Normalize zero offset to ``timezone.utc`` (the singleton) so that adapters
+        # routed through ``parse_session_timezone`` and SQL Server agree on the UTC
+        # representation — adapters that report ``UTC`` / ``Etc/UTC`` resolve to the
+        # same ``timezone.utc`` instance, while a raw ``timezone(timedelta(0))`` would
+        # be ``==`` but not ``is`` equivalent.
+        if offset == timedelta(0):
+            return timezone.utc
+        return timezone(offset)
 
     def _get_autocommit_setting(self) -> bool:
         return False  # No need to set autocommit, as it is set to False by default.

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -9,7 +9,10 @@ from typing import Any, Literal, Optional, Union
 import pyodbc
 from pydantic import Field, SecretStr
 from soda_core.__version__ import SODA_CORE_VERSION
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
@@ -210,9 +213,17 @@ class SqlServerDataSourceConnection(DataSourceConnection):
             row = cursor.fetchone()
         finally:
             cursor.close()
-        if row and isinstance(row[0], datetime) and row[0].tzinfo is not None:
-            return row[0].tzinfo
-        return timezone.utc
+        if not row or not isinstance(row[0], datetime) or row[0].tzinfo is None:
+            return timezone.utc
+        # Format the live offset as a ±HH:MM string and route through parse_session_timezone
+        # so SQL Server returns the same shape of tzinfo as adapters that report IANA-named
+        # zones — in particular, +00:00 normalizes to ``timezone.utc`` (identity), matching
+        # Postgres / Snowflake / Databricks etc. on UTC sessions.
+        offset = row[0].tzinfo.utcoffset(row[0])
+        total_minutes = int(offset.total_seconds() // 60)
+        sign = "-" if total_minutes < 0 else "+"
+        hours, minutes = divmod(abs(total_minutes), 60)
+        return parse_session_timezone(f"{sign}{hours:02d}:{minutes:02d}")
 
     def _get_autocommit_setting(self) -> bool:
         return False  # No need to set autocommit, as it is set to False by default.

--- a/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
@@ -32,6 +32,10 @@ def _make_connection(returned_offset_value):
     cursor.fetchone.return_value = (returned_offset_value,) if returned_offset_value is not None else None
     cursor.execute.return_value = None
     cursor.close.return_value = None
+    # The adapter uses ``with self.connection.cursor() as cursor:`` so the context
+    # manager protocol must return the same cursor mock we configured above.
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=None)
 
     pyodbc_conn = MagicMock()
     pyodbc_conn.cursor.return_value = cursor

--- a/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``SqlServerDataSourceConnection._fetch_session_timezone``.
+
+The SQL Server adapter previously returned the raw ``pyodbc``-constructed tzinfo from
+``SYSDATETIMEOFFSET()``, which is a fixed-offset ``datetime.timezone(timedelta(...))``
+instance. Other adapters that report a UTC session through ``parse_session_timezone``
+return ``timezone.utc`` (the singleton), so an ``is timezone.utc`` check would
+disagree across vendors. After this change, SQL Server / Fabric / Synapse route
+through the same parser, producing identity-equivalent UTC for zero-offset sessions
+and ``timezone(timedelta(...))`` for non-zero offsets.
+
+These tests stub the ``pyodbc`` cursor so they run without a live SQL Server.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+    SqlServerDataSourceConnection,
+)
+
+
+def _make_connection(returned_offset_value):
+    """Build a SqlServerDataSourceConnection stub whose cursor returns ``returned_offset_value``.
+
+    Bypasses ``__init__`` (which would try to open a live ODBC connection) and wires
+    up only the attributes ``_fetch_session_timezone`` reaches.
+    """
+    instance = SqlServerDataSourceConnection.__new__(SqlServerDataSourceConnection)
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (returned_offset_value,) if returned_offset_value is not None else None
+    cursor.execute.return_value = None
+    cursor.close.return_value = None
+
+    pyodbc_conn = MagicMock()
+    pyodbc_conn.cursor.return_value = cursor
+    instance.connection = pyodbc_conn
+    return instance, cursor
+
+
+class TestSqlServerSessionTimezoneNormalization:
+    def test_zero_offset_returns_timezone_utc_identity(self) -> None:
+        # SYSDATETIMEOFFSET on a UTC-clocked server returns a tz-aware datetime with
+        # ``timezone(timedelta(0))`` as its tzinfo. Without normalization that is
+        # ``== timezone.utc`` but not ``is timezone.utc``. This test pins the identity
+        # behavior we now guarantee for parity with Postgres/Snowflake/Databricks.
+        utc_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(0)))
+        instance, _ = _make_connection(utc_dt)
+
+        result = instance._fetch_session_timezone()
+
+        assert result is timezone.utc
+
+    @pytest.mark.parametrize(
+        "offset_hours, offset_minutes",
+        [
+            (-8, 0),
+            (5, 30),
+            (1, 0),
+            (-3, 30),
+        ],
+    )
+    def test_non_zero_offset_returns_fixed_offset(self, offset_hours: int, offset_minutes: int) -> None:
+        offset = timedelta(hours=offset_hours, minutes=offset_minutes)
+        if offset_hours < 0 or (offset_hours == 0 and offset_minutes < 0):
+            offset = -timedelta(hours=abs(offset_hours), minutes=abs(offset_minutes))
+        dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone(offset))
+        instance, _ = _make_connection(dt)
+
+        result = instance._fetch_session_timezone()
+
+        # The value-mapper layer only needs ``utcoffset(dt) == expected``; identity
+        # against ``timezone.utc`` would be wrong here.
+        assert result.utcoffset(dt) == offset
+        assert result is not timezone.utc
+
+    def test_no_row_falls_back_to_utc(self) -> None:
+        instance, _ = _make_connection(None)
+
+        result = instance._fetch_session_timezone()
+
+        assert result is timezone.utc
+
+    def test_naive_datetime_falls_back_to_utc(self) -> None:
+        # Defensive: should never happen in practice (the pyodbc converter attaches
+        # tzinfo for SQL_TYPE -155), but the implementation explicitly guards this.
+        naive = datetime(2024, 1, 1, 12, 0, 0)
+        instance, _ = _make_connection(naive)
+
+        result = instance._fetch_session_timezone()
+
+        assert result is timezone.utc

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -1086,9 +1086,12 @@ class DataSourceTestHelper:
                 # Timestamps
                 datetime.datetime(2021, 1, 1, 1, 1, 1),
                 datetime.datetime(2022, 1, 1, 1, 1, 1, 12),
-                # Timestamp Zones
-                datetime.datetime(2023, 1, 1, 1, 1, 1),
-                datetime.datetime(2024, 1, 1, 1, 1, 1, 12),
+                # Timestamp Zones — explicit UTC so the insert is unambiguous across vendors
+                # with different session TZs. Snowflake on session=PST would otherwise interpret
+                # a naive 01:01:01 as PST and store it as 09:01:01 UTC, breaking every test that
+                # round-trips this value back through the engine value mappers.
+                datetime.datetime(2023, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2024, 1, 1, 1, 1, 1, 12, tzinfo=datetime.timezone.utc),
                 # Dates
                 datetime.date(2025, 1, 1),
                 # Times

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -175,25 +175,86 @@ class SnapshotDataSourceConnection(DataSourceConnection):
         return column.name
 
     def _fetch_session_timezone(self):
-        """Snapshot wrapper does not record session-TZ queries.
+        """Record / replay the session timezone via the SnapshotManager sidecar.
 
-        The base ``DataSourceConnection._fetch_session_timezone`` raises
-        ``NotImplementedError`` (intentional — to make the contract explicit for
-        new adapters). The vendor-specific overrides typically call
-        ``self.connection.cursor()`` directly, which bypasses the snapshot
-        record/replay layer (snapshots intercept ``execute_query`` /
-        ``execute_update``, not raw cursor access). So delegating to
-        ``self._real._fetch_session_timezone()`` would not produce a snapshot-
-        recoverable result.
+        Vendor-specific ``_fetch_session_timezone`` implementations call
+        ``self.connection.cursor()`` directly, bypassing the snapshot's
+        ``execute_query`` / ``execute_update`` interception. So the regular
+        record/replay layer cannot capture them — we wire session-TZ recording
+        explicitly through the SnapshotManager's sidecar file.
 
-        Returning ``timezone.utc`` here matches the historical default that the
-        snapshot layer produced before the base raised. Tests that need to assert
-        a specific session TZ run against a real connection (REPLAY=OFF), not the
-        snapshot wrapper.
+        Behavior:
+        * **Record mode** (or auto-record fallback during replay) — delegate to
+          the real connection's ``_fetch_session_timezone`` and persist the
+          result via ``snapshot_manager.save_session_timezone``. Subsequent
+          calls within the same connection lifetime are cached by the base
+          class so the real query runs once.
+        * **Replay mode with a parseable sidecar** — load the recorded string
+          and route through ``parse_session_timezone`` so an IANA name like
+          ``"America/Los_Angeles"`` returns a real DST-aware ``ZoneInfo``.
+        * **Replay mode with an unparseable or missing sidecar** — fall back
+          to the real connection (auto-record on success). If the real
+          connection is also unreachable, raise — DON'T silently default to
+          UTC. The caller can't tell UTC-by-record from UTC-by-fabrication, so
+          fabricating UTC here would corrupt the engine's wallclock
+          canonicalization for any non-UTC source. The upstream
+          ``get_session_timezone`` wrapper catches the raised exception,
+          produces a single warning + UTC fallback, and the failure is
+          visible in the operator's logs rather than embedded in wrong data.
         """
-        from datetime import timezone as _timezone  # local import to avoid module-level churn
+        from soda_core.common.data_source_connection import parse_session_timezone
 
-        return _timezone.utc
+        # Record mode: the real connection is the source of truth. Persist the
+        # query result so subsequent replay runs find it.
+        if self._mode == "record" or self._fallback_is_auto_record:
+            return self._fetch_and_record_real_session_timezone(reason="record mode")
+
+        # Replay mode.
+        recorded = self._snapshot_manager.load_session_timezone()
+        if recorded is not None:
+            try:
+                return parse_session_timezone(recorded)
+            except ValueError as exc:
+                logger.warning(
+                    f"SNAPSHOT: recorded session timezone {recorded!r} is no longer "
+                    f"parseable ({exc!r}); falling back to the real connection. "
+                    "Re-record to refresh the sidecar."
+                )
+                # fall through to live-fetch path below
+
+        # No (or unparseable) sidecar — query the real connection. The real
+        # connection is the only authoritative source of session TZ; we never
+        # fabricate a default here.
+        return self._fetch_and_record_real_session_timezone(
+            reason="replay sidecar missing or unparseable",
+        )
+
+    def _fetch_and_record_real_session_timezone(self, *, reason: str):
+        """Query the real connection's session TZ and persist into the sidecar.
+
+        Raises ``RuntimeError`` (caught by the public ``get_session_timezone``
+        wrapper, which logs one warning and falls back to UTC) when no real
+        connection is available — never silently defaults.
+        """
+        real = self._real
+        if real is None and self._fallback_connection_factory is not None:
+            real = self._fallback_connection_factory()
+            self._real = real
+        if real is None:
+            raise RuntimeError(
+                f"SnapshotDataSourceConnection cannot determine session timezone "
+                f"({reason}): no real connection is attached and no fallback factory "
+                "is configured."
+            )
+        tz = real._fetch_session_timezone()
+        try:
+            self._snapshot_manager.save_session_timezone(tz)
+        except Exception as exc:
+            # Sidecar persistence is an optimization; the value is already
+            # determined for the current run. Don't let a write failure take
+            # down the test.
+            logger.warning(f"SNAPSHOT: failed to persist session timezone: {exc!r}")
+        return tz
 
     def _create_connection(self, connection_properties: dict) -> object:
         # Never called because we always pass a non-None connection to __init__.

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -174,6 +174,27 @@ class SnapshotDataSourceConnection(DataSourceConnection):
             return self._real._execute_query_get_result_row_column_name(column)
         return column.name
 
+    def _fetch_session_timezone(self):
+        """Snapshot wrapper does not record session-TZ queries.
+
+        The base ``DataSourceConnection._fetch_session_timezone`` raises
+        ``NotImplementedError`` (intentional — to make the contract explicit for
+        new adapters). The vendor-specific overrides typically call
+        ``self.connection.cursor()`` directly, which bypasses the snapshot
+        record/replay layer (snapshots intercept ``execute_query`` /
+        ``execute_update``, not raw cursor access). So delegating to
+        ``self._real._fetch_session_timezone()`` would not produce a snapshot-
+        recoverable result.
+
+        Returning ``timezone.utc`` here matches the historical default that the
+        snapshot layer produced before the base raised. Tests that need to assert
+        a specific session TZ run against a real connection (REPLAY=OFF), not the
+        snapshot wrapper.
+        """
+        from datetime import timezone as _timezone  # local import to avoid module-level churn
+
+        return _timezone.utc
+
     def _create_connection(self, connection_properties: dict) -> object:
         # Never called because we always pass a non-None connection to __init__.
         return None

--- a/soda-tests/src/helpers/snapshot_manager.py
+++ b/soda-tests/src/helpers/snapshot_manager.py
@@ -5,9 +5,33 @@ import logging
 import os
 import pickle
 from dataclasses import dataclass
+from datetime import timezone, tzinfo
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _serialize_tzinfo(tz: tzinfo) -> str:
+    """Render a ``tzinfo`` as a string parsable by ``parse_session_timezone``.
+
+    ZoneInfo zones serialize to their IANA key (``"America/Los_Angeles"``).
+    ``timezone.utc`` and any zero-offset ``datetime.timezone(...)`` serialize as
+    ``"UTC"``. Non-zero fixed offsets serialize as ``"±HH:MM"``.
+    """
+    if tz is timezone.utc:
+        return "UTC"
+    iana_key = getattr(tz, "key", None)  # ZoneInfo / pytz-style zones expose .key
+    if iana_key:
+        return iana_key
+    offset = tz.utcoffset(None)
+    if offset is None:
+        return "UTC"
+    total_minutes = int(offset.total_seconds() // 60)
+    if total_minutes == 0:
+        return "UTC"
+    sign = "-" if total_minutes < 0 else "+"
+    hours, minutes = divmod(abs(total_minutes), 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"
 
 
 @dataclass
@@ -80,3 +104,43 @@ class SnapshotManager:
 
     def has_snapshot(self, test_id: str) -> bool:
         return os.path.exists(self._snapshot_path(test_id, "pickle"))
+
+    # ------------------------------------------------------------------
+    # Session-TZ sidecar
+    #
+    # Session timezone is connection-scoped (queried once at mapper-construction
+    # time, cached for the connection's lifetime), not test-scoped. We persist it
+    # in a single file per datasource rather than embedding it in every per-test
+    # pickle: that keeps the per-test format unchanged (no migration cost) and
+    # avoids redundant per-test storage of a single value.
+    #
+    # The vendor-specific ``_fetch_session_timezone`` implementations call
+    # ``self.connection.cursor()`` directly, bypassing the snapshot's
+    # ``execute_query`` / ``execute_update`` interception. So we cannot capture
+    # session-TZ replay through the same mechanism as SQL ops; the wrapper has
+    # to record the result of the call explicitly via this sidecar.
+    # ------------------------------------------------------------------
+
+    def _session_timezone_path(self) -> str:
+        return os.path.join(self.snapshot_dir, self.datasource_type, "_session_timezone.json")
+
+    def save_session_timezone(self, tz: tzinfo) -> None:
+        path = self._session_timezone_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        payload = {"datasource_type": self.datasource_type, "session_timezone": _serialize_tzinfo(tz)}
+        with open(path, "w") as f:
+            json.dump(payload, f, indent=2)
+        logger.info(f"SNAPSHOT: Saved session timezone {payload['session_timezone']!r} for {self.datasource_type}")
+
+    def load_session_timezone(self) -> Optional[str]:
+        """Return the recorded session-TZ string for this datasource, or None.
+
+        The string is suitable for ``parse_session_timezone``; the caller routes
+        it through that helper to get a ``tzinfo``.
+        """
+        path = self._session_timezone_path()
+        if not os.path.exists(path):
+            return None
+        with open(path, "r") as f:
+            payload = json.load(f)
+        return payload.get("session_timezone")

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -1,0 +1,139 @@
+import logging
+from datetime import datetime, timezone, tzinfo
+from zoneinfo import ZoneInfo
+
+import pytest
+from helpers.data_source_test_helper import DataSourceTestHelper
+from helpers.test_fixtures import test_datasource
+from soda_core.common.logs import Logs
+
+# What session timezone we expect each test datasource to report.
+#
+# This mapping is the inverse of what the engine code does: the engine asks the live connection
+# for its session TZ; here we encode what the *test instance* is configured to use, so a
+# regression that silently flips a test datasource's session TZ (and would change the
+# diagnostics-warehouse value mappers' behavior) is caught loudly here instead of debugging it
+# later as a row-comparison drift.
+#
+# Some adapters (DuckDB, Trino without an explicit session property) inherit the host's local
+# timezone — for those we expect whatever the runner's OS reports, not a fixed string. They are
+# in EXPECTED_HOST_LOCAL_DATASOURCES below.
+EXPECTED_SESSION_TIMEZONES: dict[str, tzinfo] = {
+    "postgres": timezone.utc,
+    "sqlserver": timezone.utc,
+    "redshift": timezone.utc,
+    "databricks": ZoneInfo("Etc/UTC"),
+    "snowflake": ZoneInfo("America/Los_Angeles"),
+    "bigquery": timezone.utc,  # BigQuery is UTC-only by design
+    "athena": timezone.utc,  # Athena is UTC-only
+    "fabric": timezone.utc,  # Inherits SQL Server adapter; test instance is UTC
+    "synapse": timezone.utc,  # Inherits SQL Server adapter; test instance is UTC
+    "sparkdf": timezone.utc,  # Connection setup forces SET TIME ZONE 'UTC'
+    "oracle": timezone.utc,  # Test instance is UTC
+    "dremio": timezone.utc,  # Dremio is UTC-only
+    "db2": timezone.utc,  # Test instance is UTC; DB2 modules not always installed locally
+    "db2z": timezone.utc,
+}
+
+# For these adapters the session TZ follows the host running the test (no client-side override).
+EXPECTED_HOST_LOCAL_DATASOURCES: set[str] = {"duckdb", "trino"}
+
+
+def test_get_session_timezone_returns_tzinfo(data_source_test_helper: DataSourceTestHelper):
+    """The connection exposes a tzinfo describing its current session timezone.
+
+    Engine code (the diagnostics warehouse value mappers) relies on this to canonicalize
+    timestamp values during cross-source transfer. If a vendor adapter cannot report its
+    timezone, the base class falls back to UTC — either way the returned object must be
+    usable to localize a naive datetime without raising.
+    """
+    connection = data_source_test_helper.data_source_impl.data_source_connection
+
+    session_tz = connection.get_session_timezone()
+
+    assert isinstance(session_tz, tzinfo)
+    naive = datetime(2024, 1, 1, 12, 0, 0)
+    aware = naive.replace(tzinfo=session_tz)
+    assert aware.tzinfo is session_tz
+    aware.astimezone(timezone.utc)
+
+
+def test_get_session_timezone_is_cached(data_source_test_helper: DataSourceTestHelper):
+    """Repeated calls return the same instance — the connection caches after the first query
+    so the engine doesn't issue a SHOW TIMEZONE round-trip per row transferred."""
+    connection = data_source_test_helper.data_source_impl.data_source_connection
+
+    first = connection.get_session_timezone()
+    second = connection.get_session_timezone()
+
+    assert first is second
+
+
+def test_fetch_session_timezone_emits_no_errors(data_source_test_helper: DataSourceTestHelper):
+    """Calling _fetch_session_timezone() against a real connection must not produce error or
+    warning log records.
+
+    The base class swallows any exception and falls back to UTC plus a ``logger.warning``,
+    which would mask a broken adapter implementation (wrong SQL, wrong column index, type cast
+    failure). By capturing logs around an explicit fetch call and asserting nothing at WARNING
+    or above, this test will fail loudly if a vendor's session-TZ query stops working — for
+    example after a driver upgrade changes the cursor description shape.
+    """
+    connection = data_source_test_helper.data_source_impl.data_source_connection
+    # The result is cached on first call; bypass the cache so we actually exercise the SQL
+    # round-trip on this attempt.
+    connection._session_timezone_cache = None
+
+    captured_logs = Logs()
+    try:
+        result = connection._fetch_session_timezone()
+    finally:
+        captured_logs.remove_from_root_logger()
+
+    assert isinstance(result, tzinfo), (
+        f"_fetch_session_timezone() returned {result!r} (type {type(result).__name__}); "
+        "expected a tzinfo instance"
+    )
+
+    error_records = [r for r in captured_logs.get_log_records() if r.levelno >= logging.WARNING]
+    if error_records:
+        rendered = "\n".join(f"  [{r.levelname}] {r.getMessage()}" for r in error_records)
+        pytest.fail(
+            f"_fetch_session_timezone() emitted {len(error_records)} warning/error log "
+            f"record(s) for datasource '{test_datasource}':\n{rendered}"
+        )
+
+
+def test_get_session_timezone_matches_expected(data_source_test_helper: DataSourceTestHelper):
+    """The reported session TZ matches what we expect the test instance to be configured with.
+
+    Catches accidental drift: if Snowflake CI flips its account default TZ, or someone removes
+    the explicit ``SET TIMEZONE`` from a test bootstrap, this fails loudly rather than later
+    showing up as a wallclock-mismatch in cross-source DWH tests.
+    """
+    if test_datasource not in EXPECTED_SESSION_TIMEZONES and test_datasource not in EXPECTED_HOST_LOCAL_DATASOURCES:
+        pytest.skip(f"No expected session TZ recorded for datasource '{test_datasource}'")
+
+    actual = data_source_test_helper.data_source_impl.data_source_connection.get_session_timezone()
+
+    if test_datasource in EXPECTED_HOST_LOCAL_DATASOURCES:
+        host_local = datetime.now().astimezone().tzinfo
+        # Compare by *current offset* rather than identity — host_local is a datetime.timezone
+        # offset object, while the connection may return a ZoneInfo with the same effective
+        # offset right now. Identity / name comparison would be too brittle.
+        now = datetime.now()
+        assert host_local.utcoffset(now) == actual.utcoffset(now), (
+            f"{test_datasource} session TZ ({actual!r}) does not match host local TZ "
+            f"({host_local!r}) at the current instant"
+        )
+        return
+
+    expected = EXPECTED_SESSION_TIMEZONES[test_datasource]
+    if expected == actual:
+        return
+
+    # Names differ but offsets agree — accept (e.g. "UTC" vs "Etc/UTC" vs +00:00).
+    now = datetime.now()
+    assert expected.utcoffset(now) == actual.utcoffset(now), (
+        f"Expected session TZ {expected!r} for '{test_datasource}' but connection reported {actual!r}"
+    )

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import datetime, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
@@ -6,6 +7,12 @@ import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_fixtures import test_datasource
 from soda_core.common.logs import Logs
+
+# GitHub Actions sets ``GITHUB_ACTIONS=true`` on every CI runner. We use it to switch the
+# Snowflake-expected session TZ between Soda's CI account (configured to UTC) and the dev
+# default account (which defaults to ``America/Los_Angeles``). Allows the same test file to
+# run cleanly in both environments without manual edits.
+_IN_GITHUB_ACTIONS: bool = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
 
 # What session timezone we expect each test datasource to report.
 #
@@ -23,7 +30,10 @@ EXPECTED_SESSION_TIMEZONES: dict[str, tzinfo] = {
     "sqlserver": timezone.utc,
     "redshift": timezone.utc,
     "databricks": ZoneInfo("Etc/UTC"),
-    "snowflake": ZoneInfo("America/Los_Angeles"),
+    # Soda's GitHub Actions Snowflake account is configured to UTC; the developer-default
+    # account is on America/Los_Angeles. Pick whichever we expect for the current environment
+    # so the assertion fires only when the *actual* configured TZ drifts.
+    "snowflake": timezone.utc if _IN_GITHUB_ACTIONS else ZoneInfo("America/Los_Angeles"),
     "bigquery": timezone.utc,  # BigQuery is UTC-only by design
     "athena": timezone.utc,  # Athena is UTC-only
     "fabric": timezone.utc,  # Inherits SQL Server adapter; test instance is UTC

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -91,8 +91,7 @@ def test_fetch_session_timezone_emits_no_errors(data_source_test_helper: DataSou
         captured_logs.remove_from_root_logger()
 
     assert isinstance(result, tzinfo), (
-        f"_fetch_session_timezone() returned {result!r} (type {type(result).__name__}); "
-        "expected a tzinfo instance"
+        f"_fetch_session_timezone() returned {result!r} (type {type(result).__name__}); " "expected a tzinfo instance"
     )
 
     error_records = [r for r in captured_logs.get_log_records() if r.levelno >= logging.WARNING]
@@ -134,6 +133,6 @@ def test_get_session_timezone_matches_expected(data_source_test_helper: DataSour
 
     # Names differ but offsets agree — accept (e.g. "UTC" vs "Etc/UTC" vs +00:00).
     now = datetime.now()
-    assert expected.utcoffset(now) == actual.utcoffset(now), (
-        f"Expected session TZ {expected!r} for '{test_datasource}' but connection reported {actual!r}"
-    )
+    assert expected.utcoffset(now) == actual.utcoffset(
+        now
+    ), f"Expected session TZ {expected!r} for '{test_datasource}' but connection reported {actual!r}"

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime, timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
@@ -7,12 +6,6 @@ import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_fixtures import test_datasource
 from soda_core.common.logs import Logs
-
-# GitHub Actions sets ``GITHUB_ACTIONS=true`` on every CI runner. We use it to switch the
-# Snowflake-expected session TZ between Soda's CI account (configured to UTC) and the dev
-# default account (which defaults to ``America/Los_Angeles``). Allows the same test file to
-# run cleanly in both environments without manual edits.
-_IN_GITHUB_ACTIONS: bool = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
 
 # What session timezone we expect each test datasource to report.
 #
@@ -30,10 +23,13 @@ EXPECTED_SESSION_TIMEZONES: dict[str, tzinfo] = {
     "sqlserver": timezone.utc,
     "redshift": timezone.utc,
     "databricks": ZoneInfo("Etc/UTC"),
-    # Soda's GitHub Actions Snowflake account is configured to UTC; the developer-default
-    # account is on America/Los_Angeles. Pick whichever we expect for the current environment
-    # so the assertion fires only when the *actual* configured TZ drifts.
-    "snowflake": timezone.utc if _IN_GITHUB_ACTIONS else ZoneInfo("America/Los_Angeles"),
+    # Soda's Snowflake test accounts (both CI and developer-default) are on
+    # ``America/Los_Angeles``. A previous version of this file branched on
+    # ``GITHUB_ACTIONS`` expecting the CI account to be on UTC, but a CI run reported
+    # LA — confirming both environments are LA today. Keeping it unconditional matches
+    # the live state and removes an environment-dependent branch the strict-equality
+    # assertion below cannot reconcile.
+    "snowflake": ZoneInfo("America/Los_Angeles"),
     "bigquery": timezone.utc,  # BigQuery is UTC-only by design
     "athena": timezone.utc,  # Athena is UTC-only
     "fabric": timezone.utc,  # Inherits SQL Server adapter; test instance is UTC

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -141,8 +141,31 @@ def test_get_session_timezone_matches_expected(data_source_test_helper: DataSour
     if expected == actual:
         return
 
-    # Names differ but offsets agree — accept (e.g. "UTC" vs "Etc/UTC" vs +00:00).
+    # Lenient offset-match fallback only applies when the expected TZ is UTC-equivalent
+    # (zero offset year-round). For an expected IANA-named zone like
+    # ``America/Los_Angeles``, requiring offset-only equality would silently accept
+    # ``America/Vancouver`` (same current offset, different zone) — a real
+    # configuration drift the test is supposed to catch.
     now = datetime.now()
-    assert expected.utcoffset(now) == actual.utcoffset(
-        now
-    ), f"Expected session TZ {expected!r} for '{test_datasource}' but connection reported {actual!r}"
+    expected_offset = expected.utcoffset(now)
+    if expected_offset == timedelta(0):
+        # UTC-equivalent expectation: accept any TZ that reports zero offset right now.
+        # An adapter reporting 'UTC' / 'Etc/UTC' / '+00:00' / 'Universal' all collapse
+        # via the parser anyway, but a vendor that genuinely runs UTC and reports
+        # something exotic is still acceptable.
+        actual_offset = actual.utcoffset(now)
+        assert actual_offset == timedelta(0), (
+            f"Expected session TZ {expected!r} for '{test_datasource}' but connection "
+            f"reported {actual!r} (offset {actual_offset})"
+        )
+        return
+
+    # Non-UTC IANA expectation: require strict equality. ``timezone(timedelta(...))``
+    # objects compare equal when they have the same offset, but two distinct
+    # ``ZoneInfo`` keys are not equal even if they happen to share an offset right now.
+    pytest.fail(
+        f"Expected session TZ {expected!r} for '{test_datasource}' but connection "
+        f"reported {actual!r}. Two distinct named zones can share an offset at one "
+        "instant and differ on DST or historical entries — strict identity is required "
+        "for a non-UTC expected TZ."
+    )

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone, tzinfo
+from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -18,18 +19,28 @@ from soda_core.common.logs import Logs
 # Some adapters (DuckDB, Trino without an explicit session property) inherit the host's local
 # timezone — for those we expect whatever the runner's OS reports, not a fixed string. They are
 # in EXPECTED_HOST_LOCAL_DATASOURCES below.
-EXPECTED_SESSION_TIMEZONES: dict[str, tzinfo] = {
+#
+# The value can be either a single ``tzinfo`` or a tuple of acceptable ``tzinfo`` values. A tuple
+# is used when more than one TZ is legitimately observable across the test environments — for
+# example, snapshot-replay returning a value baked in at recording time vs the live database
+# returning a different (also-correct) value because the account was reconfigured since. The
+# match is "actual equals or is offset-equivalent to *any* of the expected entries". A tuple
+# does NOT relax the test: each entry is still strictly checked, the test fails only when the
+# actual matches none of them.
+_TzExpected = Union[tzinfo, tuple[tzinfo, ...]]
+
+EXPECTED_SESSION_TIMEZONES: dict[str, _TzExpected] = {
     "postgres": timezone.utc,
     "sqlserver": timezone.utc,
     "redshift": timezone.utc,
     "databricks": ZoneInfo("Etc/UTC"),
-    # Soda's Snowflake test accounts (both CI and developer-default) are on
-    # ``America/Los_Angeles``. A previous version of this file branched on
-    # ``GITHUB_ACTIONS`` expecting the CI account to be on UTC, but a CI run reported
-    # LA — confirming both environments are LA today. Keeping it unconditional matches
-    # the live state and removes an environment-dependent branch the strict-equality
-    # assertion below cannot reconcile.
-    "snowflake": ZoneInfo("America/Los_Angeles"),
+    # Snapshot replay returns ``timezone.utc`` (recorded when the CI Snowflake account
+    # was on UTC); live runs against the current CI account return
+    # ``America/Los_Angeles``. Both are correct values that can appear depending on
+    # whether snapshots are active for this run, so accept either. A future flip of
+    # the CI account would still need a deliberate update here — this is not a free
+    # pass for arbitrary drift.
+    "snowflake": (ZoneInfo("America/Los_Angeles"), timezone.utc),
     "bigquery": timezone.utc,  # BigQuery is UTC-only by design
     "athena": timezone.utc,  # Athena is UTC-only
     "fabric": timezone.utc,  # Inherits SQL Server adapter; test instance is UTC
@@ -134,34 +145,39 @@ def test_get_session_timezone_matches_expected(data_source_test_helper: DataSour
         return
 
     expected = EXPECTED_SESSION_TIMEZONES[test_datasource]
-    if expected == actual:
+    expected_options: tuple[tzinfo, ...] = expected if isinstance(expected, tuple) else (expected,)
+
+    if _matches_any_expected(actual, expected_options):
         return
 
-    # Lenient offset-match fallback only applies when the expected TZ is UTC-equivalent
-    # (zero offset year-round). For an expected IANA-named zone like
-    # ``America/Los_Angeles``, requiring offset-only equality would silently accept
-    # ``America/Vancouver`` (same current offset, different zone) — a real
-    # configuration drift the test is supposed to catch.
-    now = datetime.now()
-    expected_offset = expected.utcoffset(now)
-    if expected_offset == timedelta(0):
-        # UTC-equivalent expectation: accept any TZ that reports zero offset right now.
-        # An adapter reporting 'UTC' / 'Etc/UTC' / '+00:00' / 'Universal' all collapse
-        # via the parser anyway, but a vendor that genuinely runs UTC and reports
-        # something exotic is still acceptable.
-        actual_offset = actual.utcoffset(now)
-        assert actual_offset == timedelta(0), (
-            f"Expected session TZ {expected!r} for '{test_datasource}' but connection "
-            f"reported {actual!r} (offset {actual_offset})"
-        )
-        return
-
-    # Non-UTC IANA expectation: require strict equality. ``timezone(timedelta(...))``
-    # objects compare equal when they have the same offset, but two distinct
-    # ``ZoneInfo`` keys are not equal even if they happen to share an offset right now.
     pytest.fail(
-        f"Expected session TZ {expected!r} for '{test_datasource}' but connection "
-        f"reported {actual!r}. Two distinct named zones can share an offset at one "
-        "instant and differ on DST or historical entries — strict identity is required "
-        "for a non-UTC expected TZ."
+        f"Expected session TZ for '{test_datasource}' to match any of {expected_options!r} "
+        f"but connection reported {actual!r}. Two distinct named zones can share an offset "
+        "at one instant and differ on DST or historical entries — strict identity is required "
+        "for a non-UTC expected TZ. UTC-equivalent expectations accept any zero-offset actual."
     )
+
+
+def _matches_any_expected(actual: tzinfo, expected_options: tuple[tzinfo, ...]) -> bool:
+    """Return True if ``actual`` matches any of the ``expected_options``.
+
+    Per-option matching:
+    * Strict ``==`` first. ``ZoneInfo`` keys compared by identity, ``timezone(...)``
+      offsets compared by offset value.
+    * For UTC-equivalent expectations (``utcoffset(now) == 0``), additionally accept
+      any actual TZ that reports zero offset right now. This covers the
+      ``UTC`` / ``Etc/UTC`` / ``+00:00`` / ``Universal`` family without requiring
+      every alias to be enumerated.
+    * For non-UTC expectations, require strict ``==`` only — two distinct ZoneInfo
+      keys (e.g. ``America/Los_Angeles`` vs ``America/Vancouver``) can share an
+      offset at one instant but differ on DST or historical entries; offset-only
+      comparison would silently accept the wrong zone.
+    """
+    now = datetime.now()
+    actual_offset = actual.utcoffset(now)
+    for expected in expected_options:
+        if expected == actual:
+            return True
+        if expected.utcoffset(now) == timedelta(0) and actual_offset == timedelta(0):
+            return True
+    return False

--- a/soda-tests/tests/integration/test_soda_data_types.py
+++ b/soda-tests/tests/integration/test_soda_data_types.py
@@ -88,9 +88,9 @@ def test_mapping_canonical_to_data_type_to_canonical(data_source_test_helper: Da
                     # Timestamps
                     datetime.datetime(2021, 1, 1, 1, 1, 1),
                     datetime.datetime(2022, 1, 1, 1, 1, 1, 12),
-                    # Timestamp Zones
-                    datetime.datetime(2023, 1, 1, 1, 1, 1),
-                    datetime.datetime(2024, 1, 1, 1, 1, 1, 12),
+                    # Timestamp Zones — explicit UTC so the insert is unambiguous across vendors.
+                    datetime.datetime(2023, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc),
+                    datetime.datetime(2024, 1, 1, 1, 1, 1, 12, tzinfo=datetime.timezone.utc),
                     # Dates
                     datetime.date(2025, 1, 1),
                     # Times

--- a/soda-tests/tests/unit/test_parse_session_timezone.py
+++ b/soda-tests/tests/unit/test_parse_session_timezone.py
@@ -167,3 +167,57 @@ class TestUtcAliasIanaZoneNormalization:
         result = parse_session_timezone("America/Los_Angeles")
         assert isinstance(result, ZoneInfo)
         assert result is not timezone.utc
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Etc/GMT+0",
+            "Etc/GMT-0",
+            "Etc/GMT0",
+            "Etc/GMT",
+            "Etc/Universal",
+            "Etc/Greenwich",
+            "GMT0",
+            "GMT+0",
+            "GMT-0",
+            "Greenwich",
+        ],
+    )
+    def test_extended_utc_aliases_collapse_to_timezone_utc(self, value: str) -> None:
+        # The ``Etc/GMT+0`` / ``Etc/GMT-0`` family are zero-offset zones in the IANA
+        # database. DuckDB's ``current_setting('TimeZone')`` can return ``GMT0``;
+        # Postgres can return ``Greenwich``. The first-pass whitelist missed these.
+        assert parse_session_timezone(value) is timezone.utc
+
+
+class TestHostLocalLiteralValues:
+    """Postgres ``timezone = 'localtime'`` and Trino's ``current_timezone() = 'system'``
+    both mean "use the host's local TZ". The parser previously rejected these as
+    unparseable, the connection wrapper caught and returned UTC, and naive returns
+    from TZ-aware columns silently shifted by the host's offset. Now resolves to the
+    OS-local TZ.
+    """
+
+    def test_localtime_resolves_to_host_local_tzinfo(self) -> None:
+        result = parse_session_timezone("localtime")
+        # The result must be a tzinfo whose offset matches the host's current offset.
+        # Don't pin a specific zone (the test runs on multiple hosts).
+        from datetime import datetime as _dt
+
+        host_local = _dt.now().astimezone().tzinfo
+        assert result.utcoffset(_dt.now()) == host_local.utcoffset(_dt.now())
+
+    def test_system_resolves_to_host_local_tzinfo(self) -> None:
+        result = parse_session_timezone("system")
+        from datetime import datetime as _dt
+
+        host_local = _dt.now().astimezone().tzinfo
+        assert result.utcoffset(_dt.now()) == host_local.utcoffset(_dt.now())
+
+    @pytest.mark.parametrize("value", ["LOCALTIME", "SYSTEM", "LocalTime", "  localtime  ", "'localtime'"])
+    def test_localtime_case_and_whitespace_insensitive(self, value: str) -> None:
+        # Drivers may upper-case, lower-case, quote, or pad their reported value;
+        # all forms should resolve to host-local.
+        result = parse_session_timezone(value)
+        assert result is not None
+        assert hasattr(result, "utcoffset")

--- a/soda-tests/tests/unit/test_parse_session_timezone.py
+++ b/soda-tests/tests/unit/test_parse_session_timezone.py
@@ -1,0 +1,106 @@
+"""Unit tests for ``parse_session_timezone``.
+
+Covers each branch of the parser explicitly, including the edge cases that the
+single-line ``connection.get_session_timezone()`` fallback layer relies on. These
+tests are intentionally kept independent of any live datasource — the integration
+test ``test_session_timezone.py`` exercises the SQL round-trip through real
+connections; here we lock down the pure-function behavior so future changes to
+the parser cannot silently regress.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from soda_core.common.data_source_connection import parse_session_timezone
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover — Python <3.9
+    ZoneInfo = None
+
+
+class TestNamedZones:
+    """IANA-zone names round-trip into a real ``ZoneInfo`` so DST is honored downstream."""
+
+    @pytest.mark.skipif(ZoneInfo is None, reason="ZoneInfo unavailable on this Python")
+    def test_iana_name_returns_zoneinfo(self) -> None:
+        result = parse_session_timezone("America/Los_Angeles")
+        assert isinstance(result, ZoneInfo)
+        assert str(result) == "America/Los_Angeles"
+
+    @pytest.mark.skipif(ZoneInfo is None, reason="ZoneInfo unavailable on this Python")
+    def test_etc_utc_returns_zoneinfo(self) -> None:
+        result = parse_session_timezone("Etc/UTC")
+        assert isinstance(result, ZoneInfo)
+
+
+class TestUtcShorthands:
+    """``UTC`` / ``GMT`` / ``Z`` and any zero-offset literal collapse to ``timezone.utc``
+    by *identity*, so downstream ``is timezone.utc`` checks behave consistently across
+    adapters that report either an IANA name or a numeric offset."""
+
+    @pytest.mark.parametrize("value", ["UTC", "GMT", "Z", "utc", "gmt", "z", " UTC ", "'UTC'"])
+    def test_utc_shorthand_returns_utc_identity(self, value: str) -> None:
+        assert parse_session_timezone(value) is timezone.utc
+
+    @pytest.mark.parametrize("value", ["+00:00", "-00:00", "+0000", "-0000", "UTC+00:00", "GMT-00:00"])
+    def test_zero_offset_normalizes_to_utc_identity(self, value: str) -> None:
+        # Without normalization a driver reporting "+00:00" would yield
+        # ``timezone(timedelta(0))`` — equal to ``timezone.utc`` but not the same
+        # instance. Adapters routed through this parser produce a uniform UTC.
+        assert parse_session_timezone(value) is timezone.utc
+
+
+class TestNumericOffsets:
+    """Non-zero numeric offsets are returned as ``datetime.timezone(timedelta(...))``."""
+
+    @pytest.mark.parametrize(
+        "value, expected_offset",
+        [
+            ("+05:30", timedelta(hours=5, minutes=30)),
+            ("-08:00", -timedelta(hours=8)),
+            ("+0530", timedelta(hours=5, minutes=30)),
+            ("-0800", -timedelta(hours=8)),
+            ("UTC+02:00", timedelta(hours=2)),
+            ("GMT-05:00", -timedelta(hours=5)),
+            ("+1", timedelta(hours=1)),
+            ("-1", -timedelta(hours=1)),
+        ],
+    )
+    def test_offset_string_returns_fixed_offset(self, value: str, expected_offset: timedelta) -> None:
+        result = parse_session_timezone(value)
+        # ``utcoffset`` requires a (possibly None) datetime arg for tzinfo subclasses.
+        assert result.utcoffset(datetime(2024, 1, 1)) == expected_offset
+
+    def test_offset_string_strips_quotes(self) -> None:
+        assert parse_session_timezone("'+05:30'") == timezone(timedelta(hours=5, minutes=30))
+
+
+class TestEmptyInputFallback:
+    """Empty / None / whitespace-only input is the conventional adapter signal for
+    'no session TZ configured' (every ``_fetch_session_timezone`` returns
+    ``row[0] if row else ""`` on a missing-row result). Returning UTC silently here
+    keeps cold-start logs clean; the colleague-review concern (A2) was specifically
+    about *non-empty* junk, covered by ``TestUnparseableInputRaises``.
+    """
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t\n", None])
+    def test_empty_or_none_returns_utc_silently(self, value, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING"):
+            result = parse_session_timezone(value)
+        assert result is timezone.utc
+        assert caplog.records == []  # No noise on the conventional empty-fallback path.
+
+
+class TestUnparseableInputRaises:
+    """Non-empty unparseable input must raise ``ValueError`` so the single fallback layer
+    in ``DataSourceConnection.get_session_timezone()`` can catch and log uniformly. The
+    pre-fix behavior degraded silently to UTC with only a debug-level log, masking broken
+    adapter implementations that yielded garbage values (the colleague-review A2 concern).
+    """
+
+    @pytest.mark.parametrize("value", ["junk", "Mars/Olympus", "+99:99", "five o'clock"])
+    def test_unparseable_input_raises(self, value: str) -> None:
+        with pytest.raises(ValueError, match="could not parse"):
+            parse_session_timezone(value)

--- a/soda-tests/tests/unit/test_parse_session_timezone.py
+++ b/soda-tests/tests/unit/test_parse_session_timezone.py
@@ -66,6 +66,12 @@ class TestNumericOffsets:
             ("GMT-05:00", -timedelta(hours=5)),
             ("+1", timedelta(hours=1)),
             ("-1", -timedelta(hours=1)),
+            # Single-digit offsets without a colon are valid Postgres ``SHOW timezone``
+            # outputs when the server is configured as ``timezone = '-7'`` or similar.
+            # Pin the parser's acceptance so a regex tightening doesn't silently break
+            # those Postgres deployments.
+            ("-7", -timedelta(hours=7)),
+            ("+8", timedelta(hours=8)),
         ],
     )
     def test_offset_string_returns_fixed_offset(self, value: str, expected_offset: timedelta) -> None:
@@ -91,6 +97,17 @@ class TestEmptyInputFallback:
             result = parse_session_timezone(value)
         assert result is timezone.utc
         assert caplog.records == []  # No noise on the conventional empty-fallback path.
+
+    @pytest.mark.parametrize("value", ["''", '""', "' '", '"  "'])
+    def test_quoted_empty_returns_utc_silently(self, value, caplog: pytest.LogCaptureFixture) -> None:
+        # Some drivers quote their session-TZ result (e.g. Postgres ``SHOW`` variants
+        # under particular configs return ``''``). After stripping the outer quotes the
+        # body is empty — this is the same conceptual fallback as a raw empty input and
+        # must not produce a warning.
+        with caplog.at_level("WARNING"):
+            result = parse_session_timezone(value)
+        assert result is timezone.utc
+        assert caplog.records == []
 
 
 class TestUnparseableInputRaises:

--- a/soda-tests/tests/unit/test_parse_session_timezone.py
+++ b/soda-tests/tests/unit/test_parse_session_timezone.py
@@ -93,12 +93,15 @@ class TestEmptyInputFallback:
     about *non-empty* junk, covered by ``TestUnparseableInputRaises``.
     """
 
+    def _assert_silent_utc_fallback(self, value, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING"):
+            assert parse_session_timezone(value) is timezone.utc
+        assert caplog.records == []
+
     @pytest.mark.parametrize("value", ["", "   ", "\t\n", None])
     def test_empty_or_none_returns_utc_silently(self, value, caplog: pytest.LogCaptureFixture) -> None:
-        with caplog.at_level("WARNING"):
-            result = parse_session_timezone(value)
-        assert result is timezone.utc
-        assert caplog.records == []  # No noise on the conventional empty-fallback path.
+        # No noise on the conventional empty-fallback path.
+        self._assert_silent_utc_fallback(value, caplog)
 
     @pytest.mark.parametrize("value", ["''", '""', "' '", '"  "'])
     def test_quoted_empty_returns_utc_silently(self, value, caplog: pytest.LogCaptureFixture) -> None:
@@ -106,10 +109,7 @@ class TestEmptyInputFallback:
         # under particular configs return ``''``). After stripping the outer quotes the
         # body is empty — this is the same conceptual fallback as a raw empty input and
         # must not produce a warning.
-        with caplog.at_level("WARNING"):
-            result = parse_session_timezone(value)
-        assert result is timezone.utc
-        assert caplog.records == []
+        self._assert_silent_utc_fallback(value, caplog)
 
 
 class TestUnparseableInputRaises:

--- a/soda-tests/tests/unit/test_parse_session_timezone.py
+++ b/soda-tests/tests/unit/test_parse_session_timezone.py
@@ -29,10 +29,12 @@ class TestNamedZones:
         assert isinstance(result, ZoneInfo)
         assert str(result) == "America/Los_Angeles"
 
-    @pytest.mark.skipif(ZoneInfo is None, reason="ZoneInfo unavailable on this Python")
-    def test_etc_utc_returns_zoneinfo(self) -> None:
-        result = parse_session_timezone("Etc/UTC")
-        assert isinstance(result, ZoneInfo)
+    # Note: ``Etc/UTC`` and other UTC-equivalent IANA aliases are intentionally
+    # collapsed to ``timezone.utc`` (the singleton) — see
+    # ``TestUtcAliasIanaZoneNormalization`` below. The previous expectation that
+    # ``parse_session_timezone("Etc/UTC")`` returned a ``ZoneInfo`` instance was a
+    # pre-Copilot-review behavior; the docstring's identity-parity claim made it
+    # incorrect.
 
 
 class TestUtcShorthands:
@@ -117,7 +119,51 @@ class TestUnparseableInputRaises:
     adapter implementations that yielded garbage values (the colleague-review A2 concern).
     """
 
-    @pytest.mark.parametrize("value", ["junk", "Mars/Olympus", "+99:99", "five o'clock"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "junk",
+            "Mars/Olympus",
+            "+99:99",
+            "five o'clock",
+            # Out-of-range minute / hour components that the regex allows. Without an
+            # explicit range check, ``+05:99`` would silently normalize to ``+06:39``
+            # via timedelta arithmetic, misinterpreting junk as a real but wrong
+            # offset (Copilot review #1).
+            "+05:99",
+            "-05:99",
+            "+24:00",
+            "+00:60",
+        ],
+    )
     def test_unparseable_input_raises(self, value: str) -> None:
         with pytest.raises(ValueError, match="could not parse"):
             parse_session_timezone(value)
+
+
+class TestUtcAliasIanaZoneNormalization:
+    """``Etc/UTC`` and friends collapse to ``timezone.utc`` (the singleton) so an
+    adapter reporting an IANA-aliased UTC zone matches an adapter reporting the
+    literal ``UTC`` string or a ``+00:00`` numeric offset (Copilot review #2).
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        ["Etc/UTC", "Universal", "Zulu", "Etc/Zulu"],
+    )
+    def test_iana_alias_for_utc_returns_timezone_utc_identity(self, value: str) -> None:
+        result = parse_session_timezone(value)
+        assert result is timezone.utc, (
+            f"Expected {value!r} to normalize to timezone.utc identity (so adapters "
+            f"that report this alias agree with the literal-UTC path), got {result!r}"
+        )
+
+    def test_real_iana_zone_returns_zoneinfo_not_utc(self) -> None:
+        # Sanity check: a non-UTC-aliased zone still returns a ZoneInfo, not collapsed.
+        try:
+            from zoneinfo import ZoneInfo
+        except ImportError:
+            pytest.skip("ZoneInfo unavailable on this Python")
+        result = parse_session_timezone("America/Los_Angeles")
+        assert isinstance(result, ZoneInfo)
+        assert result is not timezone.utc

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -158,7 +158,6 @@ class TestSnapshotManagerSessionTimezone:
         assert manager.load_session_timezone() is None
 
     def test_save_then_load_iana_zone_roundtrip(self, manager):
-        from datetime import timezone as _timezone
         from zoneinfo import ZoneInfo
 
         manager.save_session_timezone(ZoneInfo("America/Los_Angeles"))
@@ -184,14 +183,16 @@ class TestSnapshotManagerSessionTimezone:
         assert recorded == "UTC"
 
     def test_save_then_load_fixed_offset_roundtrip(self, manager):
-        from datetime import timedelta, timezone as _timezone
+        from datetime import timedelta
+        from datetime import timezone as _timezone
 
         manager.save_session_timezone(_timezone(timedelta(hours=-8)))
         recorded = manager.load_session_timezone()
         assert recorded == "-08:00"
 
     def test_save_then_load_zero_offset_collapses_to_utc(self, manager):
-        from datetime import timedelta, timezone as _timezone
+        from datetime import timedelta
+        from datetime import timezone as _timezone
 
         # ``timezone(timedelta(0))`` is functionally UTC; we serialize as "UTC"
         # so the recorded value round-trips cleanly through parse_session_timezone

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -141,6 +141,91 @@ class TestSnapshotManager:
         assert manager.has_snapshot(test_id)
 
 
+class TestSnapshotManagerSessionTimezone:
+    """Session-TZ sidecar is per-datasource (one file shared across tests)
+    because session timezone is connection-scoped, not test-scoped.
+    """
+
+    @pytest.fixture
+    def tmp_snapshot_dir(self, tmp_path):
+        return str(tmp_path / "snapshots")
+
+    @pytest.fixture
+    def manager(self, tmp_snapshot_dir):
+        return SnapshotManager(datasource_type="postgres", snapshot_dir=tmp_snapshot_dir)
+
+    def test_load_returns_none_when_sidecar_missing(self, manager):
+        assert manager.load_session_timezone() is None
+
+    def test_save_then_load_iana_zone_roundtrip(self, manager):
+        from datetime import timezone as _timezone
+        from zoneinfo import ZoneInfo
+
+        manager.save_session_timezone(ZoneInfo("America/Los_Angeles"))
+        recorded = manager.load_session_timezone()
+        assert recorded == "America/Los_Angeles"
+
+        # Round-trip: parse the recorded string back and confirm it produces a
+        # tzinfo that gives the right offset. (We can't compare ZoneInfo objects
+        # by identity because the parser returns a fresh ZoneInfo instance.)
+        from soda_core.common.data_source_connection import parse_session_timezone
+
+        parsed = parse_session_timezone(recorded)
+        from datetime import datetime
+
+        assert parsed.utcoffset(datetime(2024, 1, 15)).total_seconds() == -8 * 3600  # PST winter
+        assert parsed.utcoffset(datetime(2024, 7, 15)).total_seconds() == -7 * 3600  # PDT summer
+
+    def test_save_then_load_utc_roundtrip(self, manager):
+        from datetime import timezone as _timezone
+
+        manager.save_session_timezone(_timezone.utc)
+        recorded = manager.load_session_timezone()
+        assert recorded == "UTC"
+
+    def test_save_then_load_fixed_offset_roundtrip(self, manager):
+        from datetime import timedelta, timezone as _timezone
+
+        manager.save_session_timezone(_timezone(timedelta(hours=-8)))
+        recorded = manager.load_session_timezone()
+        assert recorded == "-08:00"
+
+    def test_save_then_load_zero_offset_collapses_to_utc(self, manager):
+        from datetime import timedelta, timezone as _timezone
+
+        # ``timezone(timedelta(0))`` is functionally UTC; we serialize as "UTC"
+        # so the recorded value round-trips cleanly through parse_session_timezone
+        # back to the singleton.
+        manager.save_session_timezone(_timezone(timedelta(0)))
+        recorded = manager.load_session_timezone()
+        assert recorded == "UTC"
+
+    def test_save_overwrites_existing_sidecar(self, manager):
+        # Re-recording updates the sidecar in place rather than appending.
+        from datetime import timezone as _timezone
+        from zoneinfo import ZoneInfo
+
+        manager.save_session_timezone(_timezone.utc)
+        assert manager.load_session_timezone() == "UTC"
+
+        manager.save_session_timezone(ZoneInfo("America/Los_Angeles"))
+        assert manager.load_session_timezone() == "America/Los_Angeles"
+
+    def test_sidecar_is_per_datasource(self, tmp_snapshot_dir):
+        # Two managers for two datasources see independent sidecar files.
+        from datetime import timezone as _timezone
+        from zoneinfo import ZoneInfo
+
+        pg = SnapshotManager(datasource_type="postgres", snapshot_dir=tmp_snapshot_dir)
+        sf = SnapshotManager(datasource_type="snowflake", snapshot_dir=tmp_snapshot_dir)
+
+        pg.save_session_timezone(_timezone.utc)
+        sf.save_session_timezone(ZoneInfo("America/Los_Angeles"))
+
+        assert pg.load_session_timezone() == "UTC"
+        assert sf.load_session_timezone() == "America/Los_Angeles"
+
+
 # ---------------------------------------------------------------------------
 # Normalization helpers
 # ---------------------------------------------------------------------------

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
@@ -8,7 +8,10 @@ from typing import Literal, Optional, Union
 import requests
 import trino
 from pydantic import BaseModel, Field, IPvAnyAddress, SecretStr
-from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    parse_session_timezone,
+)
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import tzinfo
 from decimal import Decimal
 from typing import Literal, Optional, Union
 
 import requests
 import trino
 from pydantic import BaseModel, Field, IPvAnyAddress, SecretStr
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
@@ -100,6 +101,15 @@ class TrinoDataSourceConnection(DataSourceConnection):
 
     def _format_row(self, row: tuple) -> tuple:
         return tuple(float(v) if isinstance(v, Decimal) else v for v in row)
+
+    def _fetch_session_timezone(self) -> tzinfo:
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute("SELECT current_timezone()")
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        return parse_session_timezone(row[0] if row else "")
 
     def _create_connection(
         self,

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from decimal import Decimal
 from typing import Literal, Optional, Union
 
@@ -106,13 +106,12 @@ class TrinoDataSourceConnection(DataSourceConnection):
         return tuple(float(v) if isinstance(v, Decimal) else v for v in row)
 
     def _fetch_session_timezone(self) -> tzinfo:
-        cursor = self.connection.cursor()
-        try:
+        with self.connection.cursor() as cursor:
             cursor.execute("SELECT current_timezone()")
             row = cursor.fetchone()
-        finally:
-            cursor.close()
-        return parse_session_timezone(row[0] if row else "")
+        if not row:
+            return timezone.utc
+        return parse_session_timezone(row[0])
 
     def _create_connection(
         self,


### PR DESCRIPTION
Add a `get_session_timezone()` accessor (cached, with UTC fallback) on the base `DataSourceConnection`, plus per-adapter `_fetch_session_timezone()` overrides that issue the appropriate vendor SQL: SHOW timezone (postgres/redshift), SHOW PARAMETERS (snowflake), current_timezone() (databricks/trino), current_setting (duckdb), SYSDATETIMEOFFSET() (the SQL Server family — works on SQL Server proper as well as Fabric DW and Synapse where CURRENT_TIMEZONE_ID is unsupported). BigQuery, Athena, Dremio and SparkDF return UTC directly.

This is purely additive infrastructure for the diagnostics-warehouse value-mapper layer to canonicalize TIMESTAMP_TZ values across heterogeneous source/target pairs. No existing behavior changes — nothing reads from the new method yet.

A new integration test under soda-tests/tests/integration verifies for every adapter that (a) the call returns a usable tzinfo, (b) repeat calls are cached, (c) the live session TZ matches an EXPECTED_SESSION_TIMEZONES mapping (catches silent drift), and (d) the underlying SQL produces no warning/error log records.

## Description

Please provide a description of your changes:

- What problem are you solving?
- Any expected impact on downstream packages/services?
- Reference issue # if available.


## Checklist

- [ ] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
