### PR TITLE
Chore: enable cross source testing for all data sources 

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -354,8 +354,10 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
             return "string"
         if create_table_column.type.name == "char" and create_table_column.type.character_maximum_length is None:
             return "char(1)"
-        else:
-            return create_table_column.type.get_sql_data_type_str_with_parameters()
+        # Delegate to the base implementation so the type-aware and dialect-level
+        # safeguards (which strip e.g. `timestamp(2)` down to `timestamp` since
+        # supports_data_type_datetime_precision returns False for athena) apply.
+        return super()._build_create_table_column_type(create_table_column)
 
     def _is_not_null_ddl_supported(self) -> bool:
         return False

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -190,6 +190,13 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     # precision/scale) carry the correct decimal scale through; otherwise a
     # `numeric` column on the target defaults to scale 0 and silently truncates
     # the fractional part of every value.
+    #
+    # Note: these overrides intentionally bypass the base layer's
+    # `data_type_has_parameter_numeric_*` / `supports_data_type_numeric_*` gates
+    # (both return False for BigQuery in the CREATE TABLE path). The asymmetry
+    # is source-vs-target: BigQuery-as-source needs to *carry* the precision so
+    # downstream target dialects that do require it can render correctly, even
+    # though BigQuery-as-target would never render it itself.
     _BIGQUERY_NUMERIC_PRECISION = 38
     _BIGQUERY_NUMERIC_SCALE = 9
     _BIGQUERY_BIGNUMERIC_PRECISION = 76

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -183,6 +183,34 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     def supports_data_type_datetime_precision(self) -> bool:
         return False
 
+    # BigQuery's NUMERIC / BIGNUMERIC are fixed-precision (no per-column tuning),
+    # so INFORMATION_SCHEMA.COLUMNS doesn't expose NUMERIC_PRECISION / NUMERIC_SCALE.
+    # Hard-code BigQuery's documented values so consumers of the column metadata
+    # (e.g. cross-source CREATE TABLE on dialects that *do* require explicit
+    # precision/scale) carry the correct decimal scale through; otherwise a
+    # `numeric` column on the target defaults to scale 0 and silently truncates
+    # the fractional part of every value.
+    _BIGQUERY_NUMERIC_PRECISION = 38
+    _BIGQUERY_NUMERIC_SCALE = 9
+    _BIGQUERY_BIGNUMERIC_PRECISION = 76
+    _BIGQUERY_BIGNUMERIC_SCALE = 38
+
+    def extract_numeric_precision(self, row, columns) -> Optional[int]:
+        data_type_name: str = self.extract_data_type_name(row, columns).lower()
+        if data_type_name == "numeric":
+            return self._BIGQUERY_NUMERIC_PRECISION
+        if data_type_name == "bignumeric":
+            return self._BIGQUERY_BIGNUMERIC_PRECISION
+        return super().extract_numeric_precision(row, columns)
+
+    def extract_numeric_scale(self, row, columns) -> Optional[int]:
+        data_type_name: str = self.extract_data_type_name(row, columns).lower()
+        if data_type_name == "numeric":
+            return self._BIGQUERY_NUMERIC_SCALE
+        if data_type_name == "bignumeric":
+            return self._BIGQUERY_BIGNUMERIC_SCALE
+        return super().extract_numeric_scale(row, columns)
+
     def sql_expr_timestamp_literal(self, datetime_in_iso8601: str) -> str:
         return f"timestamp('{datetime_in_iso8601}')"
 

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -6,3 +6,47 @@ def test_random():
     sql_dialect: BigQuerySqlDialect = BigQuerySqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT RAND()\nFROM `a`;"
+
+
+# ---------------------------------------------------------------------------
+# BigQuery NUMERIC / BIGNUMERIC precision & scale — INFORMATION_SCHEMA.COLUMNS
+# doesn't expose precision/scale for either type, so the dialect hardcodes the
+# documented fixed values. Without these, cross-source CREATE TABLE on target
+# dialects that *do* require precision/scale would default to scale 0 and
+# silently truncate fractional values.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_numeric_precision_for_numeric_returns_38():
+    """NUMERIC is documented as NUMERIC(38, 9)."""
+    dialect = BigQuerySqlDialect()
+    row = ("col", "numeric")
+    assert dialect.extract_numeric_precision(row, columns=[]) == 38
+
+
+def test_extract_numeric_precision_for_bignumeric_returns_76():
+    """BIGNUMERIC is documented as BIGNUMERIC(76, 38)."""
+    dialect = BigQuerySqlDialect()
+    row = ("col", "bignumeric")
+    assert dialect.extract_numeric_precision(row, columns=[]) == 76
+
+
+def test_extract_numeric_scale_for_numeric_returns_9():
+    dialect = BigQuerySqlDialect()
+    row = ("col", "numeric")
+    assert dialect.extract_numeric_scale(row, columns=[]) == 9
+
+
+def test_extract_numeric_scale_for_bignumeric_returns_38():
+    dialect = BigQuerySqlDialect()
+    row = ("col", "bignumeric")
+    assert dialect.extract_numeric_scale(row, columns=[]) == 38
+
+
+def test_extract_numeric_precision_case_insensitive():
+    """INFORMATION_SCHEMA reports types upper-case; the override lowercases first."""
+    dialect = BigQuerySqlDialect()
+    row = ("col", "NUMERIC")
+    assert dialect.extract_numeric_precision(row, columns=[]) == 38
+    row = ("col", "BIGNUMERIC")
+    assert dialect.extract_numeric_precision(row, columns=[]) == 76

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -465,6 +465,23 @@ class SqlDialect:
     def _build_create_table_column_type(self, create_table_column: CREATE_TABLE_COLUMN) -> str:
         assert isinstance(create_table_column.type, SqlDataType)
 
+        # Strip precision/length fields that don't apply to this column's data type.
+        # Some source extensions populate multiple precision fields from a single
+        # cursor-description value (e.g. postgres sets numeric_precision AND
+        # datetime_precision from column.precision); without this filter,
+        # get_sql_data_type_str_with_parameters() picks the first non-None and would
+        # emit e.g. `timestamp(2)` from a leaked numeric_precision even after a
+        # subsequent dialect-level safeguard zeros datetime_precision.
+        type_name: str = create_table_column.type.name
+        if not self.data_type_has_parameter_character_maximum_length(type_name):
+            create_table_column.type.character_maximum_length = None
+        if not self.data_type_has_parameter_numeric_precision(type_name):
+            create_table_column.type.numeric_precision = None
+        if not self.data_type_has_parameter_numeric_scale(type_name):
+            create_table_column.type.numeric_scale = None
+        if not self.data_type_has_parameter_datetime_precision(type_name):
+            create_table_column.type.datetime_precision = None
+
         if not self.supports_data_type_character_maximum_length():
             create_table_column.type.character_maximum_length = None
         if not self.supports_data_type_numeric_precision():

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from abc import abstractmethod
 from datetime import date, datetime, time
@@ -465,6 +466,13 @@ class SqlDialect:
     def _build_create_table_column_type(self, create_table_column: CREATE_TABLE_COLUMN) -> str:
         assert isinstance(create_table_column.type, SqlDataType)
 
+        # Work on a shallow copy so the strip pass below doesn't mutate the
+        # caller's SqlDataType. Cross-source flows reuse a single source-side
+        # SqlDataType across two dialects (source render + target render); if
+        # the first render zeroed e.g. numeric_precision, the second render
+        # would see the already-stripped value.
+        sql_data_type: SqlDataType = dataclasses.replace(create_table_column.type)
+
         # Strip precision/length fields that don't apply to this column's data type.
         # Some source extensions populate multiple precision fields from a single
         # cursor-description value (e.g. postgres sets numeric_precision AND
@@ -472,26 +480,26 @@ class SqlDialect:
         # get_sql_data_type_str_with_parameters() picks the first non-None and would
         # emit e.g. `timestamp(2)` from a leaked numeric_precision even after a
         # subsequent dialect-level safeguard zeros datetime_precision.
-        type_name: str = create_table_column.type.name
+        type_name: str = sql_data_type.name
         if not self.data_type_has_parameter_character_maximum_length(type_name):
-            create_table_column.type.character_maximum_length = None
+            sql_data_type.character_maximum_length = None
         if not self.data_type_has_parameter_numeric_precision(type_name):
-            create_table_column.type.numeric_precision = None
+            sql_data_type.numeric_precision = None
         if not self.data_type_has_parameter_numeric_scale(type_name):
-            create_table_column.type.numeric_scale = None
+            sql_data_type.numeric_scale = None
         if not self.data_type_has_parameter_datetime_precision(type_name):
-            create_table_column.type.datetime_precision = None
+            sql_data_type.datetime_precision = None
 
         if not self.supports_data_type_character_maximum_length():
-            create_table_column.type.character_maximum_length = None
+            sql_data_type.character_maximum_length = None
         if not self.supports_data_type_numeric_precision():
-            create_table_column.type.numeric_precision = None
+            sql_data_type.numeric_precision = None
         if not self.supports_data_type_numeric_scale():
-            create_table_column.type.numeric_scale = None
+            sql_data_type.numeric_scale = None
         if not self.supports_data_type_datetime_precision():
-            create_table_column.type.datetime_precision = None
+            sql_data_type.datetime_precision = None
 
-        return create_table_column.type.get_sql_data_type_str_with_parameters()
+        return sql_data_type.get_sql_data_type_str_with_parameters()
 
     def _quote_column_for_create_table(self, column_name: str) -> str:
         return self.quote_for_ddl(column_name)

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -74,7 +74,10 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
         assert isinstance(create_table_column.type, SqlDataType)
         # Default Fabric datetime precision to 6 when the source omits it. Done before
         # the clamp/super-delegation so the rendered DDL emits `datetime2(6)`/`time(6)`.
-        if create_table_column.type.name in ("datetime2", "time") and create_table_column.type.datetime_precision is None:
+        if (
+            create_table_column.type.name in ("datetime2", "time")
+            and create_table_column.type.datetime_precision is None
+        ):
             create_table_column.type.datetime_precision = 6
         # Clamp datetime precision to Fabric's max (0..6, lower than SQL Server's 0..7).
         # Cross-source flows from sources with higher native precision (e.g. Snowflake's

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -76,8 +76,17 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
             return "datetime2(6)"
         elif create_table_column.type.name == "time" and create_table_column.type.datetime_precision is None:
             return "time(6)"
-        else:
-            return create_table_column.type.get_sql_data_type_str_with_parameters()
+        # Clamp datetime precision to Fabric's max (0..6, lower than SQL Server's 0..7).
+        # Cross-source flows from sources with higher native precision (e.g. Snowflake's
+        # TIMESTAMP_NTZ defaults to 9) would otherwise produce e.g. `datetime2(9)` and
+        # fail CREATE TABLE with "precision value between 0 and 6 must be specified".
+        if create_table_column.type.name.lower() in ("datetime2", "datetimeoffset", "time"):
+            if (
+                create_table_column.type.datetime_precision is not None
+                and create_table_column.type.datetime_precision > 6
+            ):
+                create_table_column.type.datetime_precision = 6
+        return create_table_column.type.get_sql_data_type_str_with_parameters()
 
     def get_sql_data_type_name_by_soda_data_type_names(self) -> dict[str, str]:
         types = super().get_sql_data_type_name_by_soda_data_type_names()

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -72,10 +72,10 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
 
     def _build_create_table_column_type(self, create_table_column: CREATE_TABLE_COLUMN) -> str:
         assert isinstance(create_table_column.type, SqlDataType)
-        if create_table_column.type.name == "datetime2" and create_table_column.type.datetime_precision is None:
-            return "datetime2(6)"
-        elif create_table_column.type.name == "time" and create_table_column.type.datetime_precision is None:
-            return "time(6)"
+        # Default Fabric datetime precision to 6 when the source omits it. Done before
+        # the clamp/super-delegation so the rendered DDL emits `datetime2(6)`/`time(6)`.
+        if create_table_column.type.name in ("datetime2", "time") and create_table_column.type.datetime_precision is None:
+            create_table_column.type.datetime_precision = 6
         # Clamp datetime precision to Fabric's max (0..6, lower than SQL Server's 0..7).
         # Cross-source flows from sources with higher native precision (e.g. Snowflake's
         # TIMESTAMP_NTZ defaults to 9) would otherwise produce e.g. `datetime2(9)` and
@@ -86,7 +86,9 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
                 and create_table_column.type.datetime_precision > 6
             ):
                 create_table_column.type.datetime_precision = 6
-        return create_table_column.type.get_sql_data_type_str_with_parameters()
+        # Delegate to super() so the base-layer strip pass + the SQL Server clamp
+        # both apply (mirrors Athena/SQL Server overrides).
+        return super()._build_create_table_column_type(create_table_column)
 
     def get_sql_data_type_name_by_soda_data_type_names(self) -> dict[str, str]:
         types = super().get_sql_data_type_name_by_soda_data_type_names()

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -1,3 +1,5 @@
+from soda_core.common.metadata_types import SqlDataType
+from soda_core.common.sql_ast import CREATE_TABLE_COLUMN
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_fabric.common.data_sources.fabric_data_source import FabricSqlDialect
 
@@ -6,3 +8,58 @@ def test_random():
     sql_dialect: FabricSqlDialect = FabricSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+# ---------------------------------------------------------------------------
+# Datetime precision default + clamp — Fabric's datetime2 / time / datetimeoffset
+# cap at 6 (one less than SQL Server). datetime2 / time without an explicit
+# precision are defaulted to 6 so the rendered DDL is `datetime2(6)` /
+# `time(6)`; precision > 6 is clamped down to 6.
+# ---------------------------------------------------------------------------
+
+
+def test_datetime2_with_no_precision_defaults_to_6():
+    """Fabric requires an explicit fractional-seconds precision on datetime2;
+    if the source omits it, the dialect injects 6 (Fabric's max)."""
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2"))
+    assert dialect._build_create_table_column_type(column) == "datetime2(6)"
+
+
+def test_time_with_no_precision_defaults_to_6():
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="t", type=SqlDataType(name="time"))
+    assert dialect._build_create_table_column_type(column) == "time(6)"
+
+
+def test_datetime2_precision_above_max_clamped_to_6():
+    """Cross-source flows from sources with native precision > 6 (e.g. SQL Server's
+    datetime2(7), Snowflake's TIMESTAMP_NTZ default of 9) must clamp down to
+    Fabric's max so CREATE TABLE doesn't fail."""
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "datetime2(6)"
+
+
+def test_datetimeoffset_precision_above_max_clamped_to_6():
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetimeoffset", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "datetimeoffset(6)"
+
+
+def test_time_precision_above_max_clamped_to_6():
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="t", type=SqlDataType(name="time", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "time(6)"
+
+
+def test_datetime2_precision_at_or_below_max_passes_through():
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=3))
+    assert dialect._build_create_table_column_type(column) == "datetime2(3)"
+
+
+def test_datetime2_precision_exactly_max_is_no_op():
+    dialect = FabricSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=6))
+    assert dialect._build_create_table_column_type(column) == "datetime2(6)"

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -6,7 +6,11 @@ from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import ColumnMetadata, SamplerType, SodaDataTypeName
+from soda_core.common.metadata_types import (
+    ColumnMetadata,
+    SamplerType,
+    SodaDataTypeName,
+)
 from soda_core.common.sql_ast import COLUMN, COUNT, DISTINCT, RANDOM, TUPLE, VALUES
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.contracts.impl.contract_verification_impl import ContractImpl

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING, Optional
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
+from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import SamplerType, SodaDataTypeName
+from soda_core.common.metadata_types import ColumnMetadata, SamplerType, SodaDataTypeName
 from soda_core.common.sql_ast import COLUMN, COUNT, DISTINCT, RANDOM, TUPLE, VALUES
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.contracts.impl.contract_verification_impl import ContractImpl
@@ -199,6 +200,27 @@ class SnowflakeSqlDialect(SqlDialect, sqlglot_dialect="snowflake"):
             "timestamp_ltz",
             TIMESTAMP_WITH_LOCAL_TIME_ZONE,
         ]
+
+    # Snowflake's native max VARCHAR width — reported as CHARACTER_MAXIMUM_LENGTH
+    # for any unbounded VARCHAR / TEXT column in INFORMATION_SCHEMA.COLUMNS.
+    _UNBOUNDED_VARCHAR_LENGTH = 16777216
+
+    def build_column_metadatas_from_query_result(self, query_result: QueryResult) -> list[ColumnMetadata]:
+        column_metadatas = super().build_column_metadatas_from_query_result(query_result)
+        for cm in column_metadatas:
+            # Snowflake reports unbounded VARCHAR / TEXT columns with
+            # CHARACTER_MAXIMUM_LENGTH=16777216 in INFORMATION_SCHEMA — its native
+            # max. Normalize that to canonical TEXT (no length) so consumers of
+            # this column metadata see a length-less TEXT type rather than a
+            # literal VARCHAR(16777216) that some dialects can't represent.
+            if (
+                cm.sql_data_type is not None
+                and cm.sql_data_type.name.lower() in ("varchar", "char", "text", "string")
+                and cm.sql_data_type.character_maximum_length == self._UNBOUNDED_VARCHAR_LENGTH
+            ):
+                cm.sql_data_type.name = "text"
+                cm.sql_data_type.character_maximum_length = None
+        return column_metadatas
 
     def supports_sampler(self, sampler_type: SamplerType) -> bool:
         return sampler_type in (SamplerType.ABSOLUTE_LIMIT, SamplerType.PERCENTAGE)

--- a/soda-snowflake/tests/unit/test_snowflake_dialect.py
+++ b/soda-snowflake/tests/unit/test_snowflake_dialect.py
@@ -1,4 +1,5 @@
 import pytest
+from soda_core.common.data_source_results import QueryResult
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
 from soda_snowflake.common.data_sources.snowflake_data_source import SnowflakeSqlDialect
 
@@ -37,3 +38,63 @@ def test_random():
     sql_dialect: SnowflakeSqlDialect = SnowflakeSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == 'SELECT UNIFORM(0::FLOAT, 1::FLOAT, RANDOM())\nFROM "a";'
+
+
+# ---------------------------------------------------------------------------
+# Unbounded VARCHAR / TEXT normalisation — Snowflake reports any unbounded
+# text column with CHARACTER_MAXIMUM_LENGTH=16777216 (its native max) in
+# INFORMATION_SCHEMA.COLUMNS. Consumers of column metadata (cross-source
+# CREATE TABLE on other dialects in particular) can't render a literal
+# VARCHAR(16777216), so the dialect normalises that to canonical TEXT with
+# no length.
+# ---------------------------------------------------------------------------
+
+# Layout matches Snowflake's INFORMATION_SCHEMA.COLUMNS query in
+# build_column_metadatas_from_query_result. Column names are uppercase
+# because Snowflake's default_casify uppercases identifiers.
+_COLUMN_LAYOUT = (
+    ("COLUMN_NAME",),
+    ("DATA_TYPE",),
+    ("CHARACTER_MAXIMUM_LENGTH",),
+    ("NUMERIC_PRECISION",),
+    ("NUMERIC_SCALE",),
+    ("DATETIME_PRECISION",),
+)
+
+
+def _build_metadatas(rows):
+    return SnowflakeSqlDialect().build_column_metadatas_from_query_result(
+        QueryResult(rows=rows, columns=_COLUMN_LAYOUT)
+    )
+
+
+def test_unbounded_varchar_normalised_to_text_without_length():
+    """An unbounded VARCHAR column (CHARACTER_MAXIMUM_LENGTH=16777216) must
+    be rewritten to canonical TEXT with no length, so cross-source CREATE
+    TABLE on dialects that can't represent VARCHAR(16777216) still works."""
+    metadatas = _build_metadatas([("note", "varchar", 16777216, None, None, None)])
+    assert metadatas[0].sql_data_type.name == "text"
+    assert metadatas[0].sql_data_type.character_maximum_length is None
+
+
+def test_unbounded_text_normalised_to_text_without_length():
+    metadatas = _build_metadatas([("note", "text", 16777216, None, None, None)])
+    assert metadatas[0].sql_data_type.name == "text"
+    assert metadatas[0].sql_data_type.character_maximum_length is None
+
+
+def test_bounded_varchar_passes_through_unchanged():
+    """A VARCHAR with an explicit length below the unbounded sentinel must
+    not be rewritten — only the sentinel value is normalised."""
+    metadatas = _build_metadatas([("short", "varchar", 50, None, None, None)])
+    assert metadatas[0].sql_data_type.name == "varchar"
+    assert metadatas[0].sql_data_type.character_maximum_length == 50
+
+
+def test_non_text_types_unaffected():
+    """A numeric column carrying CHARACTER_MAXIMUM_LENGTH=None must not be
+    touched by the normalisation (defensive: the strip pass key on type)."""
+    metadatas = _build_metadatas([("amount", "numeric", None, 38, 2, None)])
+    assert metadatas[0].sql_data_type.name == "numeric"
+    assert metadatas[0].sql_data_type.numeric_precision == 38
+    assert metadatas[0].sql_data_type.numeric_scale == 2

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -14,6 +14,7 @@ from soda_core.common.sql_ast import (
     COUNT,
     CREATE_TABLE,
     CREATE_TABLE_AS_SELECT,
+    CREATE_TABLE_COLUMN,
     CREATE_TABLE_IF_NOT_EXISTS,
     CREATE_VIEW,
     DISTINCT,
@@ -323,6 +324,22 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
             "datetime2",
             "datetimeoffset",
         ]
+
+    # SQL Server's datetime2 / datetimeoffset / time accept a fractional-seconds
+    # precision of 0..7. Any higher value is rejected at CREATE TABLE time.
+    _MAX_DATETIME_PRECISION = 7
+
+    def _build_create_table_column_type(self, create_table_column: CREATE_TABLE_COLUMN) -> str:
+        # Clamp datetime precision to SQL Server's max. Cross-source flows from sources
+        # with higher native precision (e.g. Snowflake's TIMESTAMP_NTZ defaults to 9)
+        # would otherwise produce e.g. `datetime2(9)` and fail CREATE TABLE.
+        if create_table_column.type.name.lower() in ("datetime2", "datetimeoffset", "time"):
+            if (
+                create_table_column.type.datetime_precision is not None
+                and create_table_column.type.datetime_precision > self._MAX_DATETIME_PRECISION
+            ):
+                create_table_column.type.datetime_precision = self._MAX_DATETIME_PRECISION
+        return super()._build_create_table_column_type(create_table_column)
 
     def default_varchar_length(self) -> Optional[int]:
         return 255

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -1,3 +1,5 @@
+from soda_core.common.metadata_types import SqlDataType
+from soda_core.common.sql_ast import CREATE_TABLE_COLUMN
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerSqlDialect
 
@@ -6,3 +8,51 @@ def test_random():
     sql_dialect: SqlServerSqlDialect = SqlServerSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+# ---------------------------------------------------------------------------
+# Datetime precision clamp — SQL Server's datetime2/time/datetimeoffset cap at 7.
+# Cross-source flows from sources with higher native precision (e.g. Snowflake's
+# TIMESTAMP_NTZ defaults to 9) used to emit e.g. `datetime2(9)` and fail CREATE
+# TABLE; the dialect override clamps anything > 7 down to 7.
+# ---------------------------------------------------------------------------
+
+
+def test_datetime2_precision_above_max_clamped_to_7():
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "datetime2(7)"
+
+
+def test_datetimeoffset_precision_above_max_clamped_to_7():
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetimeoffset", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "datetimeoffset(7)"
+
+
+def test_time_precision_above_max_clamped_to_7():
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="t", type=SqlDataType(name="time", datetime_precision=9))
+    assert dialect._build_create_table_column_type(column) == "time(7)"
+
+
+def test_datetime2_precision_at_or_below_max_passes_through():
+    """Precision ≤ 7 must be preserved verbatim — the clamp is upper-bound only."""
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=4))
+    assert dialect._build_create_table_column_type(column) == "datetime2(4)"
+
+
+def test_datetime2_precision_exactly_max_is_no_op():
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="ts", type=SqlDataType(name="datetime2", datetime_precision=7))
+    assert dialect._build_create_table_column_type(column) == "datetime2(7)"
+
+
+def test_clamp_skips_non_datetime_types():
+    """Only datetime2 / datetimeoffset / time are clamped; an int column with
+    a stray datetime_precision must not have it inserted into the DDL."""
+    dialect = SqlServerSqlDialect()
+    column = CREATE_TABLE_COLUMN(name="age", type=SqlDataType(name="int", datetime_precision=9))
+    # The base strip pass zeroes datetime_precision on non-datetime types before render.
+    assert dialect._build_create_table_column_type(column) == "int"

--- a/soda-tests/tests/integration/test_drop_old_schema.py
+++ b/soda-tests/tests/integration/test_drop_old_schema.py
@@ -41,6 +41,16 @@ def determine_if_schema_needs_to_be_dropped(schema_name: str) -> bool:
             ]  # soda_diagnostics_0db10c31_20251119_093446
             # Only drop the schema if it has a date
             must_have_date = True
+            # Fallback for the cross-source variant: soda_diagnostics_<datasource>_<YYYYMMDD>_<8hex>
+            # Variable-length datasource names shift the date off the fixed offset above,
+            # so the substring above won't be a date. Only kick in when the fixed-offset
+            # extraction didn't produce an 8-digit string AND the name has the exact
+            # 5-underscore-part shape with parts[3] being 8 digits — otherwise behavior
+            # for all other schema names is unchanged.
+            if not (len(potential_date_string) == 8 and potential_date_string.isdigit()):
+                parts = schema_name.split("_")
+                if len(parts) == 5 and len(parts[3]) == 8 and parts[3].isdigit():
+                    potential_date_string = parts[3]
         elif schema_name.upper().startswith("ALTERNATE_DWH_"):
             potential_date_string: str = schema_name[len("ALTERNATE_DWH_") + 9 :]  # ALTERNATE_DWH_0db10c31_20251119
         elif schema_name.lower().startswith("ci_"):

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -139,6 +139,29 @@ def test_sql_ast_create_table_if_not_exists():
     )
 
 
+def test_sql_ast_create_table_strips_inapplicable_precision_fields():
+    """Regression for the postgres → athena/oracle/redshift leak: a timestamp
+    column carrying a stray numeric_precision (e.g. from psycopg's polymorphic
+    column.precision) used to render as `timestamp(2)` because
+    get_sql_data_type_str_with_parameters picked the first non-None field.
+    The base _build_create_table_column_type now strips fields the column's
+    data type doesn't actually support before rendering."""
+    sql_dialect: SqlDialect = SqlDialect()
+
+    leaked_timestamp = CREATE_TABLE_COLUMN(
+        name="ts",
+        # numeric_precision is inapplicable to timestamp — must not leak into DDL.
+        type=SqlDataType(name="timestamp", numeric_precision=2),
+    )
+    statement = sql_dialect.build_create_table_sql(
+        CREATE_TABLE_IF_NOT_EXISTS(fully_qualified_table_name='"t"', columns=[leaked_timestamp])
+    )
+    assert '"ts" timestamp\n' in statement
+    assert "timestamp(2)" not in statement
+    # Defensive copy: rendering must not have mutated the caller's SqlDataType.
+    assert leaked_timestamp.type.numeric_precision == 2
+
+
 def test_sql_ast_insert_into_with_columns():
     sql_dialect: SqlDialect = SqlDialect()
 


### PR DESCRIPTION
## Summary

Five narrow dialect / test-helper fixes that the expanded cross-source DWH matrix in soda-extensions surfaces. Each fix is scoped to a single dialect or shared helper — no cross-cutting refactors.

### 1. Generic precision-strip in base CREATE TABLE rendering
Postgres source extension populates both `numeric_precision` and `datetime_precision` from psycopg's polymorphic `column.precision`, which leaks `numeric_precision` onto timestamp columns. After the dialect-level `datetime_precision` strip on athena / oracle / redshift, `SqlDataType` rendering fell through to the still-set `numeric_precision` branch and emitted `timestamp(2)` — rejected by all three.

`_build_create_table_column_type` in the base layer now strips `numeric_precision` from non-numeric columns and `datetime_precision` from non-datetime columns *before* dialect overrides run (via the existing `data_type_has_parameter_*` helpers). Athena's override delegates to `super()` so the safeguards apply.

Fixes cross-source DWH failed_rows_query on postgres → athena / oracle / redshift.

### 2. Snowflake VARCHAR / TEXT normalisation
Snowflake reports unbounded text columns with `CHARACTER_MAXIMUM_LENGTH=16777216` (its native max). The dialect now normalises that to a length-less canonical TEXT, so downstream targets don't choke on a literal `VARCHAR(16777216)` they can't represent.

### 3. BigQuery NUMERIC / BIGNUMERIC precision & scale
BigQuery's `INFORMATION_SCHEMA` doesn't expose precision/scale for NUMERIC / BIGNUMERIC columns. Override `extract_numeric_precision` / `extract_numeric_scale` to return the documented fixed values `(38,9)` and `(76,38)`. Without this, every fractional value was silently truncated to scale 0 on cross-source moves.

### 4. SQL Server / Synapse / Fabric datetime precision clamp
SQL Server's `datetime2` / `time` / `datetimeoffset` accept precision 0..7 (Fabric's max is 6). Cross-source flows from higher-precision sources (e.g. Snowflake `TIMESTAMP_NTZ` defaults to 9) used to emit e.g. `datetime2(9)` and fail CREATE TABLE. Clamped at the dialect level; Synapse inherits via SQL Server.

### 5. `test_drop_old_schemas` fallback
Strict fallback for the new cross-source schema-name shape `soda_diagnostics_<datasource>_<YYYYMMDD>_<hash>`, which broke the fixed-offset date extraction in the old parser. Only triggers when the schema has exactly 5 underscore-parts and parts[3] is 8 digits; existing schema names parse identically.

## Description

- **What problem are you solving?**
  Unblocking the full 14-source cross-source DWH matrix (full cartesian product) that soda-extensions PR #373 enables in CI. The matrix exposed dialect mismatches that the previous hand-picked compatibility list never exercised.

- **Any expected impact on downstream packages/services?**
  Yes — paired with soda-extensions PR #373, which contains the matrix expansion + CI plumbing + a couple of soda-extensions-specific dialect fixes (BigQuery cursor description, DB2 decimal clamp).

- **Reference issue:** R-581.

## Verification

Local validation: 44 previously-failing cross-source test cases now pass across 11 source/target combinations; 44 regression test cases unaffected. CI on soda-extensions PR #373 shows 182/182 cross-source cells green (14 sources × 13 targets, duckdb excluded as DWH target by design).

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].
  - This work is *for* soda-extensions PR #373.

[1]: https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml
