### PR TITLE
fix: alias aggregation query columns and guard derived metrics

### DIFF
--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -224,6 +224,18 @@ class RANDOM(SqlExpression):
 
 
 @dataclass
+class ALIAS(SqlExpression):
+    """Wraps any expression so it is emitted with `<expr> AS <alias>`."""
+
+    expression: SqlExpression | str
+    alias: str
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.handle_parent_node_update(self.expression)
+
+
+@dataclass
 class SqlExpressionStr(SqlExpression):
     expression_str: str
 

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -22,6 +22,7 @@ from soda_core.common.metadata_types import (
     SqlDataType,
 )
 from soda_core.common.sql_ast import (
+    ALIAS,
     ALTER_TABLE,
     ALTER_TABLE_ADD_COLUMN,
     ALTER_TABLE_DROP_COLUMN,
@@ -820,6 +821,8 @@ class SqlDialect:
             return self._build_function_sql(expression)
         elif isinstance(expression, DISTINCT):
             return self._build_distinct_sql(expression)
+        elif isinstance(expression, ALIAS):
+            return f"{self.build_expression_sql(expression.expression)} AS {self.quote_default(expression.alias)}"
         elif isinstance(expression, SqlExpressionStr):
             return f"({expression.expression_str})"
         elif isinstance(expression, ORDINAL_POSITION):

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -219,13 +219,10 @@ class DuplicateCountMetricImpl(DerivedMetricImpl):
         return [self.distinct_count_metric_impl, self.valid_count_metric_impl]
 
     def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
-        distinct_count = measurement_values.get_value(self.distinct_count_metric_impl)
-        valid_count = measurement_values.get_value(self.valid_count_metric_impl)
-        # If either dependency is missing (e.g. the aggregation query failed upstream),
-        # propagate None so the check evaluates to NOT_EVALUATED rather than crashing
-        # the whole scan with `TypeError: unsupported operand type(s) for -`.
-        if distinct_count is None or valid_count is None:
+        values = self.gather_dependency_values(measurement_values)
+        if values is None:
             return None
+        distinct_count, valid_count = values
         return valid_count - distinct_count
 
 
@@ -377,8 +374,8 @@ class MultiColumnDuplicateCountMetricImpl(DerivedMetricImpl):
         return [self.multi_column_distinct_count_metric_impl, self.row_count_metric_impl]
 
     def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
-        distinct_count = measurement_values.get_value(self.multi_column_distinct_count_metric_impl)
-        row_count = measurement_values.get_value(self.row_count_metric_impl)
-        if distinct_count is None or row_count is None:
+        values = self.gather_dependency_values(measurement_values)
+        if values is None:
             return None
+        distinct_count, row_count = values
         return row_count - distinct_count

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -129,24 +129,22 @@ class ColumnDuplicateCheckImpl(MissingAndValidityCheckImpl):
 
         duplicate_count: int = 0
         duplicate_percent: float = 0
-        if (
-            isinstance(check_rows_tested_count, Number)
-            and isinstance(missing_count, Number)
-            and isinstance(distinct_count, Number)
+        threshold_value: Optional[Number] = None
+        if measurement_values.all_measured(
+            self.check_rows_tested_metric_impl,
+            self.missing_count_metric_impl,
+            self.distinct_count_metric_impl,
         ):
-            duplicate_count: int = check_rows_tested_count - missing_count - distinct_count
+            duplicate_count = check_rows_tested_count - missing_count - distinct_count
             diagnostic_metric_values["duplicate_count"] = duplicate_count
 
             non_missing_total: int = check_rows_tested_count - missing_count
             if non_missing_total > 0:
-                duplicate_percent: float = duplicate_count * 100 / non_missing_total
+                duplicate_percent = duplicate_count * 100 / non_missing_total
             diagnostic_metric_values["duplicate_percent"] = duplicate_percent
 
-        threshold_value: Optional[Number] = (
-            duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
-        )
-
-        outcome = self.evaluate_threshold(threshold_value)
+            threshold_value = duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
+            outcome = self.evaluate_threshold(threshold_value)
 
         return CheckResult(
             check=self._build_check_info(),
@@ -220,9 +218,14 @@ class DuplicateCountMetricImpl(DerivedMetricImpl):
     def get_metric_dependencies(self) -> list[MetricImpl]:
         return [self.distinct_count_metric_impl, self.valid_count_metric_impl]
 
-    def compute_derived_value(self, measurement_values: MeasurementValues) -> Number:
-        distinct_count: int = measurement_values.get_value(self.distinct_count_metric_impl)
-        valid_count: int = measurement_values.get_value(self.valid_count_metric_impl)
+    def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
+        distinct_count = measurement_values.get_value(self.distinct_count_metric_impl)
+        valid_count = measurement_values.get_value(self.valid_count_metric_impl)
+        # If either dependency is missing (e.g. the aggregation query failed upstream),
+        # propagate None so the check evaluates to NOT_EVALUATED rather than crashing
+        # the whole scan with `TypeError: unsupported operand type(s) for -`.
+        if distinct_count is None or valid_count is None:
+            return None
         return valid_count - distinct_count
 
 
@@ -289,11 +292,15 @@ class MultiColumnDuplicateCheckImpl(CheckImpl):
         distinct_count: int = measurement_values.get_value(self.multi_column_distinct_count_metric_impl)
         duplicate_count: int = 0
         duplicate_percent: float = 0
+        threshold_value: Optional[Number] = None
 
-        if isinstance(row_count, Number) and isinstance(distinct_count, Number):
+        if measurement_values.all_measured(self.row_count_metric_impl, self.multi_column_distinct_count_metric_impl):
             duplicate_count = row_count - distinct_count
             if row_count > 0:
                 duplicate_percent = duplicate_count * 100 / row_count
+
+            threshold_value = duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
+            outcome = self.evaluate_threshold(threshold_value)
 
         diagnostic_metric_values: dict[str, float] = {
             "duplicate_count": duplicate_count,
@@ -301,12 +308,6 @@ class MultiColumnDuplicateCheckImpl(CheckImpl):
             "check_rows_tested": row_count,
             "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
         }
-
-        threshold_value: Optional[Number] = (
-            duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
-        )
-
-        outcome = self.evaluate_threshold(threshold_value)
 
         return CheckResult(
             check=self._build_check_info(),
@@ -375,7 +376,9 @@ class MultiColumnDuplicateCountMetricImpl(DerivedMetricImpl):
     def get_metric_dependencies(self) -> list[MetricImpl]:
         return [self.multi_column_distinct_count_metric_impl, self.row_count_metric_impl]
 
-    def compute_derived_value(self, measurement_values: MeasurementValues) -> Number:
-        distinct_count: int = measurement_values.get_value(self.multi_column_distinct_count_metric_impl)
-        row_count: int = measurement_values.get_value(self.row_count_metric_impl)
+    def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
+        distinct_count = measurement_values.get_value(self.multi_column_distinct_count_metric_impl)
+        row_count = measurement_values.get_value(self.row_count_metric_impl)
+        if distinct_count is None or row_count is None:
+            return None
         return row_count - distinct_count

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -115,17 +115,9 @@ class ColumnDuplicateCheckImpl(MissingAndValidityCheckImpl):
     def evaluate(self, measurement_values: MeasurementValues) -> CheckResult:
         outcome: CheckOutcome = CheckOutcome.NOT_EVALUATED
 
-        diagnostic_metric_values: dict[str, float] = {"dataset_rows_tested": self.contract_impl.dataset_rows_tested}
-
-        distinct_count: int = measurement_values.get_value(self.distinct_count_metric_impl)
-
-        check_rows_tested_count: int = measurement_values.get_value(self.check_rows_tested_metric_impl)
-        if isinstance(check_rows_tested_count, Number):
-            diagnostic_metric_values["check_rows_tested"] = check_rows_tested_count
-
-        missing_count: int = measurement_values.get_value(self.missing_count_metric_impl)
-        if isinstance(missing_count, Number):
-            diagnostic_metric_values["missing_count"] = missing_count
+        distinct_count = measurement_values.get_value(self.distinct_count_metric_impl)
+        check_rows_tested_count = measurement_values.get_value(self.check_rows_tested_metric_impl)
+        missing_count = measurement_values.get_value(self.missing_count_metric_impl)
 
         duplicate_count: int = 0
         duplicate_percent: float = 0
@@ -144,11 +136,15 @@ class ColumnDuplicateCheckImpl(MissingAndValidityCheckImpl):
             threshold_value = duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
             outcome = self.evaluate_threshold(threshold_value)
 
-        # Always populate the duplicate diagnostics so consumers don't see nulls — they
-        # default to 0 if upstream measurements were unavailable. NOT_EVALUATED outcome
-        # already signals that the values aren't real measurements.
-        diagnostic_metric_values["duplicate_count"] = duplicate_count
-        diagnostic_metric_values["duplicate_percent"] = duplicate_percent
+        # Diagnostics must remain numeric for Soda Cloud DTO compliance — coalesce
+        # unmeasured fields to 0. NOT_EVALUATED outcome signals "not real".
+        diagnostic_metric_values: dict[str, float] = {
+            "duplicate_count": duplicate_count,
+            "duplicate_percent": duplicate_percent,
+            "check_rows_tested": check_rows_tested_count if check_rows_tested_count is not None else 0,
+            "missing_count": missing_count if missing_count is not None else 0,
+            "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
+        }
 
         return CheckResult(
             check=self._build_check_info(),
@@ -306,7 +302,7 @@ class MultiColumnDuplicateCheckImpl(CheckImpl):
         diagnostic_metric_values: dict[str, float] = {
             "duplicate_count": duplicate_count,
             "duplicate_percent": duplicate_percent,
-            "check_rows_tested": row_count,
+            "check_rows_tested": row_count if row_count is not None else 0,
             "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
         }
 

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -136,15 +136,19 @@ class ColumnDuplicateCheckImpl(MissingAndValidityCheckImpl):
             self.distinct_count_metric_impl,
         ):
             duplicate_count = check_rows_tested_count - missing_count - distinct_count
-            diagnostic_metric_values["duplicate_count"] = duplicate_count
 
             non_missing_total: int = check_rows_tested_count - missing_count
             if non_missing_total > 0:
                 duplicate_percent = duplicate_count * 100 / non_missing_total
-            diagnostic_metric_values["duplicate_percent"] = duplicate_percent
 
             threshold_value = duplicate_percent if self.metric_name == "duplicate_percent" else duplicate_count
             outcome = self.evaluate_threshold(threshold_value)
+
+        # Always populate the duplicate diagnostics so consumers don't see nulls — they
+        # default to 0 if upstream measurements were unavailable. NOT_EVALUATED outcome
+        # already signals that the values aren't real measurements.
+        diagnostic_metric_values["duplicate_count"] = duplicate_count
+        diagnostic_metric_values["duplicate_percent"] = duplicate_percent
 
         return CheckResult(
             check=self._build_check_info(),

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -161,9 +161,9 @@ class FailedRowsCheckImpl(CheckImpl):
         self, failed_rows_count: Optional[int], measurement_values: MeasurementValues
     ) -> tuple[Optional[float], dict[str, float]]:
         check_rows_tested: Optional[int] = measurement_values.get_value(self.check_rows_tested_metric_impl)
-        failed_rows_percent: Optional[float] = 0
-        if isinstance(check_rows_tested, Number) and isinstance(failed_rows_count, Number) and check_rows_tested > 0:
-            failed_rows_percent = failed_rows_count * 100 / check_rows_tested
+        failed_rows_percent: Optional[float] = None
+        if measurement_values.all_measured(self.failed_rows_count_metric_impl, self.check_rows_tested_metric_impl):
+            failed_rows_percent = failed_rows_count * 100 / check_rows_tested if check_rows_tested > 0 else 0
 
         if self.failed_rows_check_yaml.metric == "percent":
             threshold_value = failed_rows_percent

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -161,14 +161,18 @@ class FailedRowsCheckImpl(CheckImpl):
         self, failed_rows_count: Optional[int], measurement_values: MeasurementValues
     ) -> tuple[Optional[float], dict[str, float]]:
         check_rows_tested: Optional[int] = measurement_values.get_value(self.check_rows_tested_metric_impl)
-        failed_rows_percent: Optional[float] = None
+        # Default to 0 for diagnostics so consumers don't see null where they used to
+        # see 0. `threshold_value` carries the "is this real" signal: it stays None
+        # when dependencies are unmeasured, so evaluate_threshold → NOT_EVALUATED.
+        failed_rows_percent: float = 0
+        threshold_value: Optional[Number]
         if measurement_values.all_measured(self.failed_rows_count_metric_impl, self.check_rows_tested_metric_impl):
             failed_rows_percent = failed_rows_count * 100 / check_rows_tested if check_rows_tested > 0 else 0
-
-        if self.failed_rows_check_yaml.metric == "percent":
-            threshold_value = failed_rows_percent
+            threshold_value = (
+                failed_rows_percent if self.failed_rows_check_yaml.metric == "percent" else failed_rows_count
+            )
         else:
-            threshold_value = failed_rows_count
+            threshold_value = None if self.failed_rows_check_yaml.metric == "percent" else failed_rows_count
 
         diagnostic_metric_values = {
             "failed_rows_count": failed_rows_count,

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -126,8 +126,8 @@ class FailedRowsCheckImpl(CheckImpl):
 
         failed_rows_count: Optional[int] = measurement_values.get_value(self.failed_rows_count_metric_impl)
 
-        diagnostic_metric_values: dict[str, float] = {}
-        threshold_value: Optional[float] = None
+        diagnostic_metric_values: dict[str, Optional[Number]] = {}
+        threshold_value: Optional[Number] = None
 
         if self.failed_rows_check_yaml.expression:
             threshold_value, diagnostic_metric_values = self._evaluate_with_rows_tested(
@@ -143,7 +143,10 @@ class FailedRowsCheckImpl(CheckImpl):
                 threshold_value = failed_rows_count
 
                 diagnostic_metric_values = {
-                    "failed_rows_count": failed_rows_count,
+                    # `failedRowsCount` is @NotNull in the FailedRows DTO — coalesce to 0
+                    # in failure mode. `check_rows_tested` is nullable for this branch
+                    # (no rows_tested_query specified).
+                    "failed_rows_count": failed_rows_count if failed_rows_count is not None else 0,
                     "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
                     "check_rows_tested": None,
                 }
@@ -159,7 +162,7 @@ class FailedRowsCheckImpl(CheckImpl):
 
     def _evaluate_with_rows_tested(
         self, failed_rows_count: Optional[int], measurement_values: MeasurementValues
-    ) -> tuple[Optional[float], dict[str, float]]:
+    ) -> tuple[Optional[Number], dict[str, Optional[Number]]]:
         check_rows_tested: Optional[int] = measurement_values.get_value(self.check_rows_tested_metric_impl)
         # Default to 0 for diagnostics so consumers don't see null where they used to
         # see 0. `threshold_value` carries the "is this real" signal: it stays None
@@ -174,8 +177,10 @@ class FailedRowsCheckImpl(CheckImpl):
         else:
             threshold_value = None if self.failed_rows_check_yaml.metric == "percent" else failed_rows_count
 
-        diagnostic_metric_values = {
-            "failed_rows_count": failed_rows_count,
+        diagnostic_metric_values: dict[str, Optional[Number]] = {
+            # `failedRowsCount` is @NotNull in the FailedRows DTO — coalesce to 0
+            # in failure mode. `check_rows_tested` is nullable per DTO.
+            "failed_rows_count": failed_rows_count if failed_rows_count is not None else 0,
             "failed_rows_percent": failed_rows_percent,
             "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
             "check_rows_tested": check_rows_tested,

--- a/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
@@ -130,24 +130,23 @@ class InvalidCheckImpl(MissingAndValidityCheckImpl):
     def evaluate(self, measurement_values: MeasurementValues) -> CheckResult:
         outcome: CheckOutcome = CheckOutcome.NOT_EVALUATED
 
-        invalid_count: int = measurement_values.get_value(self.invalid_count_metric_impl)
-        row_count: int = measurement_values.get_value(self.row_count_metric)
-        invalid_percent: float = measurement_values.get_value(self.invalid_percent_metric)
-
-        diagnostic_metric_values: dict[str, float] = {
-            "invalid_count": invalid_count,
-            "invalid_percent": invalid_percent,
-            "check_rows_tested": row_count,
-            "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
-        }
-
-        missing_count: int = measurement_values.get_value(self.missing_count_metric_impl)
-        if isinstance(missing_count, Number):
-            diagnostic_metric_values["missing_count"] = missing_count
+        invalid_count = measurement_values.get_value(self.invalid_count_metric_impl)
+        row_count = measurement_values.get_value(self.row_count_metric)
+        invalid_percent = measurement_values.get_value(self.invalid_percent_metric)
+        missing_count = measurement_values.get_value(self.missing_count_metric_impl)
 
         threshold_value: Optional[Number] = invalid_percent if self.metric_name == "invalid_percent" else invalid_count
-
         outcome = self.evaluate_threshold(threshold_value)
+
+        # Diagnostics must remain numeric for Soda Cloud DTO compliance — coalesce
+        # unmeasured fields to 0. NOT_EVALUATED outcome signals "not real".
+        diagnostic_metric_values: dict[str, float] = {
+            "invalid_count": invalid_count if invalid_count is not None else 0,
+            "invalid_percent": invalid_percent if invalid_percent is not None else 0,
+            "check_rows_tested": row_count if row_count is not None else 0,
+            "missing_count": missing_count if missing_count is not None else 0,
+            "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
+        }
 
         return CheckResult(
             check=self._build_check_info(),

--- a/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/missing_check.py
@@ -79,20 +79,24 @@ class MissingCheckImpl(MissingAndValidityCheckImpl):
     def evaluate(self, measurement_values: MeasurementValues) -> CheckResult:
         outcome: CheckOutcome = CheckOutcome.NOT_EVALUATED
 
-        missing_count: int = measurement_values.get_value(self.missing_count_metric_impl)
-        row_count: int = measurement_values.get_value(self.row_count_metric_impl)
-        missing_percent: float = measurement_values.get_value(self.missing_percent_metric_impl)
+        missing_count = measurement_values.get_value(self.missing_count_metric_impl)
+        row_count = measurement_values.get_value(self.row_count_metric_impl)
+        missing_percent = measurement_values.get_value(self.missing_percent_metric_impl)
 
+        # `threshold_value` carries the "is this real" signal — stays None when an
+        # upstream metric is unmeasured so evaluate_threshold returns NOT_EVALUATED.
+        threshold_value: Optional[Number] = missing_percent if self.metric_name == "missing_percent" else missing_count
+        outcome = self.evaluate_threshold(threshold_value)
+
+        # Diagnostics must remain numeric for Soda Cloud DTO compliance (all four
+        # fields are @NotNull). Coalesce to 0 when upstream metrics are unmeasured —
+        # the NOT_EVALUATED outcome already signals these aren't real measurements.
         diagnostic_metric_values: dict[str, float] = {
-            "missing_count": missing_count,
-            "missing_percent": missing_percent,
-            "check_rows_tested": row_count,
+            "missing_count": missing_count if missing_count is not None else 0,
+            "missing_percent": missing_percent if missing_percent is not None else 0,
+            "check_rows_tested": row_count if row_count is not None else 0,
             "dataset_rows_tested": self.contract_impl.dataset_rows_tested,
         }
-
-        threshold_value: Optional[Number] = missing_percent if self.metric_name == "missing_percent" else missing_count
-
-        outcome = self.evaluate_threshold(threshold_value)
 
         return CheckResult(
             check=self._build_check_info(),

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1723,14 +1723,13 @@ class DerivedPercentageMetricImpl(DerivedMetricImpl):
         return [self.fraction_metric_impl, self.total_metric_impl]
 
     def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
+        # Propagate None when either dependency is unmeasured. Returning 0 here would
+        # falsely PASS percent checks with a `must_be: 0` threshold against a value
+        # we never actually measured (this powers missing_percent / invalid_percent /
+        # duplicate_percent).
         fraction = measurement_values.get_value(self.fraction_metric_impl)
-        if fraction is None:
-            return 0
         total = measurement_values.get_value(self.total_metric_impl)
-        if total is None:
-            # fraction came back but total did not (e.g. its aggregation query was in a
-            # different bundle that failed). Surface None so the check goes to
-            # NOT_EVALUATED rather than crashing on `fraction * 100 / None`.
+        if fraction is None or total is None:
             return None
         return (fraction * 100 / total) if total != 0 else 0
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1811,8 +1811,12 @@ class AggregationQuery(Query):
         self.logs: Logs = logs
 
     def can_accept(self, aggregation_metric_impl: AggregationMetricImpl) -> bool:
-        sql_expression: SqlExpression = aggregation_metric_impl.sql_expression()
-        sql_expression_str: str = self.data_source_impl.sql_dialect.build_expression_sql(sql_expression)
+        # Measure the SQL as it will actually be emitted, including the per-position
+        # ALIAS wrapper that build_field_expressions adds (`<expr> AS "m_<n>"`).
+        # Without this, the splitter under-estimates SQL length and large contracts
+        # can exceed get_max_sql_statement_length() at execute time.
+        aliased = ALIAS(aggregation_metric_impl.sql_expression(), f"m_{len(self.aggregation_metrics)}")
+        sql_expression_str: str = self.data_source_impl.sql_dialect.build_expression_sql(aliased)
         max_query_length: int = self.data_source_impl.sql_dialect.get_max_sql_statement_length()
         return self.query_size + len(sql_expression_str) < max_query_length
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1811,17 +1811,22 @@ class AggregationQuery(Query):
         self.logs: Logs = logs
 
     def can_accept(self, aggregation_metric_impl: AggregationMetricImpl) -> bool:
-        # Measure the SQL as it will actually be emitted, including the per-position
-        # ALIAS wrapper that build_field_expressions adds (`<expr> AS "m_<n>"`).
-        # Without this, the splitter under-estimates SQL length and large contracts
-        # can exceed get_max_sql_statement_length() at execute time.
-        aliased = ALIAS(aggregation_metric_impl.sql_expression(), f"m_{len(self.aggregation_metrics)}")
-        sql_expression_str: str = self.data_source_impl.sql_dialect.build_expression_sql(aliased)
         max_query_length: int = self.data_source_impl.sql_dialect.get_max_sql_statement_length()
-        return self.query_size + len(sql_expression_str) < max_query_length
+        return self.query_size + self._estimate_metric_sql_length(aggregation_metric_impl) < max_query_length
 
     def append_aggregation_metric(self, aggregation_metric_impl: AggregationMetricImpl) -> None:
+        # Track cumulative SQL size as metrics are added — `self.query_size` was
+        # otherwise frozen at the constructor's `COUNT(*)`-only estimate, so the
+        # splitter under-estimated for every metric past the first and could exceed
+        # get_max_sql_statement_length() at execute time on large contracts.
+        self.query_size += self._estimate_metric_sql_length(aggregation_metric_impl)
         self.aggregation_metrics.append(aggregation_metric_impl)
+
+    def _estimate_metric_sql_length(self, aggregation_metric_impl: AggregationMetricImpl) -> int:
+        # Measure the SQL as it will actually be emitted, including the per-position
+        # ALIAS wrapper that build_field_expressions adds (`<expr> AS "m_<n>"`).
+        aliased = ALIAS(aggregation_metric_impl.sql_expression(), f"m_{len(self.aggregation_metrics)}")
+        return len(self.data_source_impl.sql_dialect.build_expression_sql(aliased))
 
     def build_sql(self) -> str:
         field_expressions: list[SqlExpression] = self.build_field_expressions()

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -921,12 +921,15 @@ class MeasurementValues:
     def all_measured(self, *metric_impls: "MetricImpl") -> bool:
         """True iff every metric has a non-None measurement.
 
-        Use in check `evaluate()` to gate threshold-value construction: when any
-        dependency is unmeasured (because its aggregation query failed upstream),
-        return outcome NOT_EVALUATED instead of defaulting computed values to 0
-        and falsely PASSING against thresholds like `must_be: 0`. The CheckImpl
-        base also exposes `evaluate_threshold(None) -> NOT_EVALUATED`, but only
-        if `threshold_value` is None — checks must not default it to a Number.
+        Intent: gate threshold-value construction in `evaluate()`. If any dependency
+        is unmeasured (upstream aggregation query failed), callers must keep
+        `threshold_value=None` so `evaluate_threshold(None)` returns NOT_EVALUATED
+        — defaulting it to a Number (e.g. 0) would falsely PASS against thresholds
+        like `must_be: 0`.
+
+        Note: this is `is not None`, not `isinstance(Number)`. Diagnostic-dict
+        population in `evaluate()` already gates on `isinstance(Number)` for type
+        narrowing — that's a different concern and stays as-is.
         """
         return all(self.get_value(m) is not None for m in metric_impls)
 
@@ -1697,8 +1700,19 @@ class DerivedMetricImpl(MetricImpl, ABC):
         pass
 
     @abstractmethod
-    def compute_derived_value(self, measurement_values: MeasurementValues) -> Number:
+    def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
         pass
+
+    def gather_dependency_values(self, measurement_values: MeasurementValues) -> Optional[list]:
+        """Return the dependency values in declaration order, or None if any is unmeasured.
+
+        Use at the top of `compute_derived_value` to short-circuit when an upstream
+        aggregation query failed: returning None from the derived metric causes the
+        consuming check to evaluate to NOT_EVALUATED, not crash on None arithmetic
+        and not falsely PASS against a 0 default.
+        """
+        values = [measurement_values.get_value(d) for d in self.get_metric_dependencies()]
+        return None if any(v is None for v in values) else values
 
     def _get_id_properties(self) -> dict[str, any]:
         id_properties: dict[str, any] = super()._get_id_properties()
@@ -1723,14 +1737,10 @@ class DerivedPercentageMetricImpl(DerivedMetricImpl):
         return [self.fraction_metric_impl, self.total_metric_impl]
 
     def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
-        # Propagate None when either dependency is unmeasured. Returning 0 here would
-        # falsely PASS percent checks with a `must_be: 0` threshold against a value
-        # we never actually measured (this powers missing_percent / invalid_percent /
-        # duplicate_percent).
-        fraction = measurement_values.get_value(self.fraction_metric_impl)
-        total = measurement_values.get_value(self.total_metric_impl)
-        if fraction is None or total is None:
+        values = self.gather_dependency_values(measurement_values)
+        if values is None:
             return None
+        fraction, total = values
         return (fraction * 100 / total) if total != 0 else 0
 
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -918,6 +918,18 @@ class MeasurementValues:
     def get_value(self, metric_impl: MetricImpl) -> any:
         return self.metric_values_by_id.get(metric_impl.id)
 
+    def all_measured(self, *metric_impls: "MetricImpl") -> bool:
+        """True iff every metric has a non-None measurement.
+
+        Use in check `evaluate()` to gate threshold-value construction: when any
+        dependency is unmeasured (because its aggregation query failed upstream),
+        return outcome NOT_EVALUATED instead of defaulting computed values to 0
+        and falsely PASSING against thresholds like `must_be: 0`. The CheckImpl
+        base also exposes `evaluate_threshold(None) -> NOT_EVALUATED`, but only
+        if `threshold_value` is None — checks must not default it to a Number.
+        """
+        return all(self.get_value(m) is not None for m in metric_impls)
+
     def derive_value(self, derived_metric_impl: DerivedMetricImpl) -> None:
         if derived_metric_impl.id not in self.metric_values_by_id:
             if derived_metric_impl.id in self.metric_ids_being_derived:
@@ -1710,11 +1722,16 @@ class DerivedPercentageMetricImpl(DerivedMetricImpl):
     def get_metric_dependencies(self) -> list[MetricImpl]:
         return [self.fraction_metric_impl, self.total_metric_impl]
 
-    def compute_derived_value(self, measurement_values: MeasurementValues) -> Number:
-        fraction: int = measurement_values.get_value(self.fraction_metric_impl)
+    def compute_derived_value(self, measurement_values: MeasurementValues) -> Optional[Number]:
+        fraction = measurement_values.get_value(self.fraction_metric_impl)
         if fraction is None:
             return 0
-        total: int = measurement_values.get_value(self.total_metric_impl)
+        total = measurement_values.get_value(self.total_metric_impl)
+        if total is None:
+            # fraction came back but total did not (e.g. its aggregation query was in a
+            # different bundle that failed). Surface None so the check goes to
+            # NOT_EVALUATED rather than crashing on `fraction * 100 / None`.
+            return None
         return (fraction * 100 / total) if total != 0 else 0
 
 
@@ -1807,7 +1824,16 @@ class AggregationQuery(Query):
         if len(self.aggregation_metrics) == 0:
             # This is to get the initial query length in the constructor
             return [COUNT(STAR())]
-        return [aggregation_metric.sql_expression() for aggregation_metric in self.aggregation_metrics]
+        # Wrap each aggregation expression with a per-position alias so the result
+        # schema always has unique column names. Two metrics may render to byte-identical
+        # SQL (e.g. MissingCheckImpl and InvalidCheckImpl both resolve a MissingCount
+        # metric that produces the same SUM(CASE WHEN col IS NULL ...) expression);
+        # without aliases Spark 4.x rejects the query with "Can't unify schema with
+        # duplicate field names". Positional row access in execute() is unaffected.
+        return [
+            ALIAS(aggregation_metric.sql_expression(), f"m_{i}")
+            for i, aggregation_metric in enumerate(self.aggregation_metrics)
+        ]
 
     def execute(self) -> list[Measurement]:
         sql = self.build_sql()

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -169,6 +169,12 @@ def test_duplicate_check_survives_failed_aggregation_query(
         f"failed upstream; got {duplicate_result.outcome}"
     )
 
+    # NOT_EVALUATED must NOT propagate nulls into the diagnostics dict for fields that
+    # historically defaulted to 0 — consumers (Soda Cloud) depend on these being numeric.
+    diagnostics = duplicate_result.diagnostic_metric_values or {}
+    assert diagnostics.get("duplicate_count") == 0, f"duplicate_count must default to 0, got {diagnostics!r}"
+    assert diagnostics.get("duplicate_percent") == 0, f"duplicate_percent must default to 0, got {diagnostics!r}"
+
 
 def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
     data_source_test_helper: DataSourceTestHelper,
@@ -209,6 +215,14 @@ def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
         f"Expected NOT_EVALUATED when the failed_rows aggregation query failed; "
         f"got {failed_rows_result.outcome} (this is the falsely-PASSED regression)"
     )
+
+    # failed_rows_percent must remain a numeric default (0), not null — consumers
+    # depend on this. The threshold gating happens via threshold_value, not by
+    # nulling out the diagnostic.
+    diagnostics = failed_rows_result.diagnostic_metric_values or {}
+    assert (
+        diagnostics.get("failed_rows_percent") == 0
+    ), f"failed_rows_percent must default to 0, not None; got {diagnostics!r}"
 
 
 def test_missing_percent_does_not_falsely_pass_when_aggregation_fails(

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -13,6 +13,7 @@ Regression tests for two linked bugs surfaced on Databricks (DBR 18.2 / Spark 4.
    guard `valid_count - distinct_count` against None.
 """
 
+import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
 from soda_core.contracts.contract_verification import (
@@ -38,8 +39,13 @@ _test_table_specification = (
 )
 
 
-def _capture_executed_sql(data_source_test_helper: DataSourceTestHelper) -> list[str]:
-    """Monkeypatch the active data source connection to record every SQL it executes."""
+def _capture_executed_sql(data_source_test_helper: DataSourceTestHelper, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Patch the active data source connection to record every SQL it executes.
+
+    Uses pytest's `monkeypatch` so the wrap is auto-undone at test teardown — important
+    because the data source connection is session-scoped and the wrap would otherwise
+    leak into every subsequent test.
+    """
     captured: list[str] = []
     connection = data_source_test_helper.data_source_impl.data_source_connection
     original = connection.execute_query
@@ -48,7 +54,7 @@ def _capture_executed_sql(data_source_test_helper: DataSourceTestHelper) -> list
         captured.append(sql)
         return original(sql, log_query)
 
-    connection.execute_query = _wrapped  # type: ignore[assignment]
+    monkeypatch.setattr(connection, "execute_query", _wrapped)
     return captured
 
 
@@ -90,11 +96,12 @@ def _extract_select_field_lines(aggregation_sql: str) -> list[str]:
 
 def test_missing_and_invalid_on_same_column_produces_unique_aggregation_aliases(
     data_source_test_helper: DataSourceTestHelper,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #1: missing + invalid on the same column must not emit byte-identical
     aggregation expressions (which become duplicate output column names on Spark 4.x)."""
     test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
-    captured_sql = _capture_executed_sql(data_source_test_helper)
+    captured_sql = _capture_executed_sql(data_source_test_helper, monkeypatch)
 
     data_source_test_helper.assert_contract_fail(
         test_table=test_table,

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -202,3 +202,44 @@ def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
         f"Expected NOT_EVALUATED when the failed_rows aggregation query failed; "
         f"got {failed_rows_result.outcome} (this is the falsely-PASSED regression)"
     )
+
+
+def test_missing_percent_does_not_falsely_pass_when_aggregation_fails(
+    data_source_test_helper: DataSourceTestHelper,
+) -> None:
+    """Regression: a `missing:` check with `metric: percent` and `must_be: 0`
+    threshold must not falsely PASS when its underlying missing_count aggregation
+    query fails. The bug was in `DerivedPercentageMetricImpl.compute_derived_value`
+    defaulting to 0 when `fraction is None` — same shape as the failed_rows bug,
+    powering missing_percent / invalid_percent / duplicate_percent."""
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+
+    session_result = data_source_test_helper.verify_contract(
+        test_table=test_table,
+        contract_yaml_str="""
+            checks:
+              - failed_rows:
+                  name: poison the aggregation query
+                  expression: "definitely_not_a_column IS NULL"
+            columns:
+              - name: id
+                checks:
+                  - missing:
+                      name: id missing percent
+                      threshold:
+                        metric: percent
+                        must_be_less_than_or_equal: 0
+            """,
+    )
+
+    assert session_result is not None
+    assert session_result.contract_verification_results
+    result = session_result.contract_verification_results[0]
+    missing_results = [r for r in result.check_results if r.check.name == "id missing percent"]
+    assert missing_results, "Expected the missing check to produce a result"
+    missing_result: CheckResult = missing_results[0]
+
+    assert missing_result.outcome == CheckOutcome.NOT_EVALUATED, (
+        f"Expected NOT_EVALUATED when the missing_count aggregation query failed; "
+        f"got {missing_result.outcome} (this is the DerivedPercentageMetricImpl falsely-PASSED regression)"
+    )

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -172,8 +172,11 @@ def test_duplicate_check_survives_failed_aggregation_query(
     # NOT_EVALUATED must NOT propagate nulls into the diagnostics dict for fields that
     # historically defaulted to 0 — consumers (Soda Cloud) depend on these being numeric.
     diagnostics = duplicate_result.diagnostic_metric_values or {}
-    assert diagnostics.get("duplicate_count") == 0, f"duplicate_count must default to 0, got {diagnostics!r}"
-    assert diagnostics.get("duplicate_percent") == 0, f"duplicate_percent must default to 0, got {diagnostics!r}"
+    # All Duplicate DTO fields are @NotNull — assert none of them leak null in failure mode.
+    for field in ("duplicate_count", "duplicate_percent", "check_rows_tested", "missing_count"):
+        assert (
+            diagnostics.get(field) is not None
+        ), f"{field} must default to a numeric value (not null) under NOT_EVALUATED; got {diagnostics!r}"
 
 
 def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
@@ -220,9 +223,11 @@ def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
     # depend on this. The threshold gating happens via threshold_value, not by
     # nulling out the diagnostic.
     diagnostics = failed_rows_result.diagnostic_metric_values or {}
-    assert (
-        diagnostics.get("failed_rows_percent") == 0
-    ), f"failed_rows_percent must default to 0, not None; got {diagnostics!r}"
+    # `failed_rows_count` and `failed_rows_percent` are required by the FailedRows DTO.
+    for field in ("failed_rows_count", "failed_rows_percent"):
+        assert (
+            diagnostics.get(field) is not None
+        ), f"{field} must default to a numeric value (not null) under NOT_EVALUATED; got {diagnostics!r}"
 
 
 def test_missing_percent_does_not_falsely_pass_when_aggregation_fails(
@@ -264,3 +269,53 @@ def test_missing_percent_does_not_falsely_pass_when_aggregation_fails(
         f"Expected NOT_EVALUATED when the missing_count aggregation query failed; "
         f"got {missing_result.outcome} (this is the DerivedPercentageMetricImpl falsely-PASSED regression)"
     )
+
+    diagnostics = missing_result.diagnostic_metric_values or {}
+    # All Missing DTO fields are @NotNull — assert none of them leak null in failure mode.
+    for field in ("missing_count", "missing_percent", "check_rows_tested"):
+        assert (
+            diagnostics.get(field) is not None
+        ), f"{field} must default to a numeric value (not null) under NOT_EVALUATED; got {diagnostics!r}"
+
+
+def test_invalid_percent_does_not_leak_nulls_when_aggregation_fails(
+    data_source_test_helper: DataSourceTestHelper,
+) -> None:
+    """Mirror of missing-percent test for the invalid check, exercising
+    InvalidityCheckImpl.evaluate's diagnostic coalesce path."""
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+
+    session_result = data_source_test_helper.verify_contract(
+        test_table=test_table,
+        contract_yaml_str="""
+            checks:
+              - failed_rows:
+                  name: poison the aggregation query
+                  expression: "definitely_not_a_column IS NULL"
+            columns:
+              - name: id
+                checks:
+                  - invalid:
+                      name: id invalid percent
+                      valid_values: ['1', '2', '3']
+                      threshold:
+                        metric: percent
+                        must_be_less_than_or_equal: 0
+            """,
+    )
+
+    assert session_result is not None
+    assert session_result.contract_verification_results
+    result = session_result.contract_verification_results[0]
+    invalid_results = [r for r in result.check_results if r.check.name == "id invalid percent"]
+    assert invalid_results, "Expected the invalid check to produce a result"
+    invalid_result: CheckResult = invalid_results[0]
+
+    assert invalid_result.outcome == CheckOutcome.NOT_EVALUATED
+
+    diagnostics = invalid_result.diagnostic_metric_values or {}
+    # All Invalid DTO fields are @NotNull (including missing_count) — assert no nulls.
+    for field in ("invalid_count", "invalid_percent", "check_rows_tested", "missing_count"):
+        assert (
+            diagnostics.get(field) is not None
+        ), f"{field} must default to a numeric value (not null) under NOT_EVALUATED; got {diagnostics!r}"

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -1,0 +1,204 @@
+"""
+Regression tests for two linked bugs surfaced on Databricks (DBR 18.2 / Spark 4.1):
+
+1. The aggregation query emitted byte-identical SUM(CASE WHEN col IS NULL ...) expressions
+   whenever a column had both `missing:` and `invalid:` checks (because InvalidCheckImpl
+   started resolving its own MissingCountMetricImpl in PR #2588, and those instances do
+   not dedup against the missing check's MissingCountMetricImpl). Spark 4.x rejects result
+   schemas with duplicate auto-derived column names; older runtimes tolerated them.
+
+2. When the aggregation query fails for any reason, the duplicate check's
+   DuplicateCountMetricImpl.compute_derived_value crashes the whole scan with
+   `unsupported operand type(s) for -: 'NoneType' and 'NoneType'` because it does not
+   guard `valid_count - distinct_count` against None.
+"""
+
+from helpers.data_source_test_helper import DataSourceTestHelper
+from helpers.test_table import TestTableSpecification
+from soda_core.contracts.contract_verification import (
+    CheckOutcome,
+    CheckResult,
+    ContractVerificationResult,
+)
+
+_test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("aggregation_aliasing")
+    .column_varchar("id")
+    .column_integer("age")
+    .rows(
+        rows=[
+            ("1", 1),
+            ("2", 2),
+            ("3", None),
+            (None, 4),
+        ]
+    )
+    .build()
+)
+
+
+def _capture_executed_sql(data_source_test_helper: DataSourceTestHelper) -> list[str]:
+    """Monkeypatch the active data source connection to record every SQL it executes."""
+    captured: list[str] = []
+    connection = data_source_test_helper.data_source_impl.data_source_connection
+    original = connection.execute_query
+
+    def _wrapped(sql: str, log_query: bool = True):
+        captured.append(sql)
+        return original(sql, log_query)
+
+    connection.execute_query = _wrapped  # type: ignore[assignment]
+    return captured
+
+
+def _find_aggregation_sql(captured_sql: list[str]) -> str:
+    """Locate the aggregation query among captured SQL.
+
+    AggregationQuery is the only query that wraps the dataset in the
+    `_soda_filtered_dataset` CTE and then SELECTs aggregate expressions from it.
+    """
+    candidates = [sql for sql in captured_sql if "_soda_filtered_dataset" in sql and "SUM(" in sql.upper()]
+    assert candidates, f"Expected an aggregation query to have been executed. Captured:\n{captured_sql}"
+    # If there are multiple (large contracts may split), assert on the first one — it's
+    # enough that one carries the duplicated metrics for the regression to manifest.
+    return candidates[0]
+
+
+def _extract_select_field_lines(aggregation_sql: str) -> list[str]:
+    """Return the list of stripped SELECT field expressions for the OUTER SELECT.
+
+    The aggregation SQL has a CTE which itself contains a `SELECT *` — we want the
+    fields from the outer SELECT (the one whose FROM is `_soda_filtered_dataset`),
+    not the CTE's inner SELECT.
+    """
+    lines = aggregation_sql.splitlines()
+    # Locate the outer FROM line by looking for the dataset CTE alias.
+    outer_from_idx = next(
+        i for i, line in enumerate(lines) if line.lstrip().startswith("FROM ") and "_soda_filtered_dataset" in line
+    )
+    # The outer SELECT is the last `SELECT ` line before that FROM.
+    outer_select_idx = max(i for i, line in enumerate(lines[:outer_from_idx]) if line.lstrip().startswith("SELECT "))
+    fields: list[str] = []
+    for i in range(outer_select_idx, outer_from_idx):
+        line = lines[i]
+        if i == outer_select_idx:
+            line = line.lstrip()[len("SELECT ") :]
+        fields.append(line.strip().rstrip(","))
+    return fields
+
+
+def test_missing_and_invalid_on_same_column_produces_unique_aggregation_aliases(
+    data_source_test_helper: DataSourceTestHelper,
+) -> None:
+    """Issue #1: missing + invalid on the same column must not emit byte-identical
+    aggregation expressions (which become duplicate output column names on Spark 4.x)."""
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+    captured_sql = _capture_executed_sql(data_source_test_helper)
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str="""
+            columns:
+              - name: id
+                checks:
+                  - missing:
+                  - invalid:
+                      valid_values: ['1', '2', '3']
+            """,
+    )
+
+    aggregation_sql = _find_aggregation_sql(captured_sql)
+    fields = _extract_select_field_lines(aggregation_sql)
+
+    # The aggregation query must not contain two byte-identical field expressions —
+    # that is the shape that triggers "Can't unify schema with duplicate field names"
+    # on Databricks Spark 4.x.
+    duplicates = {f for f in fields if fields.count(f) > 1}
+    assert not duplicates, (
+        f"Aggregation query has duplicate field expressions {duplicates!r}. "
+        f"Full SELECT list:\n  " + "\n  ".join(fields) + f"\n\nFull SQL:\n{aggregation_sql}"
+    )
+
+
+def test_duplicate_check_survives_failed_aggregation_query(
+    data_source_test_helper: DataSourceTestHelper,
+) -> None:
+    """Issue #2: when the aggregation query fails (here: poisoned by a failed_rows
+    expression referencing a non-existent column), the duplicate check's derived
+    metric must not crash the scan with TypeError. It should produce NOT_EVALUATED."""
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+
+    # No assert_contract_* helper directly accepts "may raise or may return errors",
+    # so go through verify_contract and assert on the resulting outcome instead of
+    # letting an uncaught TypeError tear the test down.
+    session_result = data_source_test_helper.verify_contract(
+        test_table=test_table,
+        contract_yaml_str="""
+            checks:
+              - failed_rows:
+                  name: poison the aggregation query
+                  expression: "definitely_not_a_column IS NULL"
+            columns:
+              - name: id
+                checks:
+                  - duplicate:
+                      name: id should be unique
+            """,
+    )
+
+    assert session_result is not None, "verify_contract returned no session result — likely a TypeError"
+    assert session_result.contract_verification_results, "Expected at least one contract verification result"
+    result: ContractVerificationResult = session_result.contract_verification_results[0]
+
+    duplicate_results = [r for r in result.check_results if r.check.name == "id should be unique"]
+    assert (
+        duplicate_results
+    ), f"Expected the duplicate check to produce a result. Got: {[r.check.name for r in result.check_results]}"
+    duplicate_result: CheckResult = duplicate_results[0]
+
+    assert duplicate_result.outcome == CheckOutcome.NOT_EVALUATED, (
+        f"Expected duplicate check outcome NOT_EVALUATED when its aggregation query "
+        f"failed upstream; got {duplicate_result.outcome}"
+    )
+
+
+def test_failed_rows_percent_check_does_not_falsely_pass_when_aggregation_fails(
+    data_source_test_helper: DataSourceTestHelper,
+) -> None:
+    """Regression: `failed_rows: expression` with `metric: percent` and a threshold of
+    `must_be: 0` previously defaulted failed_rows_percent to 0 when its aggregation
+    query failed — producing a falsely PASSED outcome against the 0 threshold.
+
+    Use a syntactically valid expression that the aggregation rejects at execute
+    time. Most data sources will fail it (unresolved column). The check must be
+    NOT_EVALUATED, not PASSED.
+    """
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+
+    session_result = data_source_test_helper.verify_contract(
+        test_table=test_table,
+        contract_yaml_str="""
+            checks:
+              - failed_rows:
+                  name: failed_rows percent on poisoned expression
+                  expression: "definitely_not_a_column IS NULL"
+                  threshold:
+                    metric: percent
+                    must_be: 0
+            """,
+    )
+
+    assert session_result is not None
+    assert session_result.contract_verification_results
+    result = session_result.contract_verification_results[0]
+    failed_rows_results = [
+        r for r in result.check_results if r.check.name == "failed_rows percent on poisoned expression"
+    ]
+    assert failed_rows_results, "Expected the failed_rows check to produce a result"
+    failed_rows_result: CheckResult = failed_rows_results[0]
+
+    assert failed_rows_result.outcome == CheckOutcome.NOT_EVALUATED, (
+        f"Expected NOT_EVALUATED when the failed_rows aggregation query failed; "
+        f"got {failed_rows_result.outcome} (this is the falsely-PASSED regression)"
+    )

--- a/soda-tests/tests/unit/metrics/test_measurement_values.py
+++ b/soda-tests/tests/unit/metrics/test_measurement_values.py
@@ -196,3 +196,51 @@ def test_measurement_values_derive_with_empty_dependencies():
 
     # Should compute sum of empty list = 0
     assert mv.get_value(derived) == 0
+
+
+def test_all_measured_no_args_is_true():
+    """Vacuous truth: with no metrics to check, all_measured is True."""
+    mv = MeasurementValues([])
+    assert mv.all_measured() is True
+
+
+def test_all_measured_with_all_present():
+    """all_measured returns True when every metric has a measurement."""
+    m1, m2 = SimpleMockMetric("m1"), SimpleMockMetric("m2")
+    mv = MeasurementValues(
+        [
+            Measurement(metric_id="m1", value=42, metric_name="n"),
+            Measurement(metric_id="m2", value=1.0, metric_name="p"),
+        ]
+    )
+    assert mv.all_measured(m1, m2) is True
+
+
+def test_all_measured_with_one_missing():
+    """all_measured returns False if any metric has no measurement at all."""
+    m1, m2 = SimpleMockMetric("m1"), SimpleMockMetric("m2")
+    mv = MeasurementValues([Measurement(metric_id="m1", value=42, metric_name="n")])
+    assert mv.all_measured(m1, m2) is False
+
+
+def test_all_measured_with_explicit_none_value():
+    """A recorded measurement with value=None counts as unmeasured."""
+    m1 = SimpleMockMetric("m1")
+    mv = MeasurementValues([Measurement(metric_id="m1", value=None, metric_name="n")])
+    assert mv.all_measured(m1) is False
+
+
+def test_all_measured_with_zero_value_is_true():
+    """Boundary: 0 is a real measurement, not a stand-in for unmeasured. Must be True."""
+    m1, m2 = SimpleMockMetric("m1"), SimpleMockMetric("m2")
+    mv = MeasurementValues(
+        [Measurement(metric_id="m1", value=0, metric_name="n"), Measurement(metric_id="m2", value=0.0, metric_name="p")]
+    )
+    assert mv.all_measured(m1, m2) is True
+
+
+def test_all_measured_with_non_numeric_value_is_true():
+    """`all_measured` is `is not None`, not `isinstance(Number)`. A string measurement counts as measured."""
+    m1 = SimpleMockMetric("m1")
+    mv = MeasurementValues([Measurement(metric_id="m1", value="ok", metric_name="s")])
+    assert mv.all_measured(m1) is True


### PR DESCRIPTION
**Tracking ticket:** [SCS-1172](https://sodadata.atlassian.net/browse/SCS-1172). Related customer ticket: SCS-1164.

## Problem

Two linked customer-visible bugs surfaced on Databricks (Soda Demo) on 2026-05-06, after DBR 18.2 (Spark 4.1) went GA on 2026-05-04:

1. Contracts with both `missing:` and `invalid:` on the same column intermittently fail with:
   ```
   Query execution failed, continuing with remaining checks:
   Could not execute aggregation query: Can't unify schema with duplicate field names.
   ```
2. If a `duplicate:` check is also present, the failure escalates to a hard scan crash:
   ```
   An exception occurred: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
   ```

### Root causes

**Bug #1 — duplicate aggregation column aliases on Spark 4.x.** PR #2588 (Feb 24) added a `MissingCountMetricImpl` resolution inside `InvalidCheckImpl.setup_metrics`. The two `MissingCountMetricImpl` instances (one from each check) do not dedup in the metric resolver — their `missing_and_validity` objects differ (the invalid check carries `valid_values`) — yet both render to byte-identical SQL `SUM(CASE WHEN col IS NULL THEN 1 END)`. Spark 4.x rejects result schemas with duplicate auto-derived column names via `SchemaUtils.checkColumnNameDuplication`. Spark 3.x tolerated them; Snowflake auto-disambiguates.

**Bug #2 — None arithmetic + falsely-PASSED.** When any aggregation query fails, downstream metrics resolve to `None`. Two latent bugs:
- `DuplicateCountMetricImpl.compute_derived_value` did `valid_count - distinct_count` with no None guard → `TypeError`, crashing the whole scan.
- `ColumnDuplicateCheckImpl.evaluate` (and its multi-column twin, and `failed_rows: metric: percent`) defaulted computed values to `0` when dependencies were `None` → `evaluate_threshold(0)` against `must_be: 0` falsely PASSED checks we never actually measured.

## Changes

- **`ALIAS` AST node** emitting `<expr> AS "<alias>"`. `AggregationQuery.build_field_expressions` now wraps every metric in `ALIAS(..., f"m_{i}")` so output column names are always unique. Positional `row[i]` access in `execute()` is unaffected.
- **`MeasurementValues.all_measured(*metric_impls)`** — discoverable helper for `evaluate()` to gate threshold construction on dependency availability. Docstring distinguishes its `is not None` intent from `isinstance(Number)` diagnostic-dict gating.
- **`DerivedMetricImpl.gather_dependency_values()`** — lifts the None-guard idiom into the base class. Three derived metrics (`DuplicateCountMetricImpl`, `MultiColumnDuplicateCountMetricImpl`, `DerivedPercentageMetricImpl`) refactored to use it; abstract signature widened to `Optional[Number]`.
- **`ColumnDuplicateCheckImpl.evaluate`, `MultiColumnDuplicateCheckImpl.evaluate`, `FailedRowsCheckImpl._evaluate_with_rows_tested`** — hold outcome at NOT_EVALUATED when any dependency is missing, instead of calling `evaluate_threshold` against 0 defaults.

## Tests

Four new integration regression tests in `soda-tests/tests/integration/test_aggregation_query_aliasing.py`:
- duplicate aggregation expressions
- duplicate-check crash on upstream failure
- failed_rows percent falsely-PASSED on upstream failure
- missing_percent falsely-PASSED on upstream failure (via `DerivedPercentageMetricImpl`)

Six new unit tests in `soda-tests/tests/unit/metrics/test_measurement_values.py` covering `all_measured`: vacuous truth, all-present, one-missing, explicit `None` value, zero-value boundary, non-numeric value.

## Verification

- 910 tests pass on duckdb (no regressions in the existing suite).
- Both customer reproductions (Hazem's minimal `missing` + `invalid` repro and a poisoned-aggregation duplicate-check repro) run cleanly against `databricks_dev_m1n0`. Bug #1's contract returns correct check outcomes; bug #2's contract surfaces NOT_EVALUATED for both the failed `failed_rows` check and the dependent duplicate check, with the scan completing instead of crashing.
- All three Copilot review comments addressed (two already resolved in earlier commits; monkeypatch leak fixed in 351b6b24).

## CI

Commits are prefixed `[REPLAY=OFF]` because the new aggregation-query aliases (and the metric-output schema changes) invalidate cached SQL snapshots. The nightly snapshot recording job will refresh snapshots after merge.

## Out of scope (follow-ups)

- Generic SQL-level deduplication of byte-identical aggregation metrics. Aliasing solves the warehouse rejection, but Spark still computes the redundant SUM twice — proper dedup keyed on `(type(metric), rendered_sql_expression)` is the optimization fix. Tracked separately.
- Folding `COLUMN.field_alias` and `COUNT.field_alias` into `ALIAS` wrappers as a single canonical aliasing mechanism. Out of hotfix scope.

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions](https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml) — extensions code uses `AggregationQuery` and the changed types via import; no public API surface changed.


[SCS-1172]: https://sodadata.atlassian.net/browse/SCS-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ