### PR TITLE
perf(DTL-1778): dedup byte-identical aggregation metrics

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -589,8 +589,12 @@ class ContractImpl:
         # convert their DB value differently (`int` vs `float` vs identity).
         canonical_metrics: list[AggregationMetricImpl] = []
         canonical_by_sql: dict[tuple[type, str], AggregationMetricImpl] = {}
-        # canonical_metric.id -> [aliased_metric.id, ...] for measurement emission.
-        metric_aliases: dict[str, list[str]] = {}
+        # canonical_metric.id -> [aliased_metric, ...]. We keep the full metric impls
+        # (not just ids) so AggregationQuery.execute can emit each Measurement under
+        # the aliased metric's own get_short_description() — two deduped metrics may
+        # belong to different check types (e.g. missing vs invalid) and have different
+        # metric_name semantics for downstream consumers.
+        metric_aliases: dict[str, list[AggregationMetricImpl]] = {}
         if self.data_source_impl is not None:
             sql_dialect = self.data_source_impl.sql_dialect
             for metric in aggregation_metrics:
@@ -600,7 +604,7 @@ class ContractImpl:
                     canonical_by_sql[key] = metric
                     canonical_metrics.append(metric)
                 else:
-                    metric_aliases.setdefault(canonical.id, []).append(metric.id)
+                    metric_aliases.setdefault(canonical.id, []).append(metric)
         else:
             canonical_metrics = aggregation_metrics
 
@@ -1824,7 +1828,7 @@ class AggregationQuery(Query):
         dataset_name: str,
         data_source_impl: Optional[DataSourceImpl],
         logs: Logs,
-        metric_aliases: Optional[dict[str, list[str]]] = None,
+        metric_aliases: Optional[dict[str, list["AggregationMetricImpl"]]] = None,
     ):
         super().__init__(data_source_impl=data_source_impl, metrics=[])
         self.cte: CTE = cte
@@ -1834,11 +1838,13 @@ class AggregationQuery(Query):
         self.data_source_impl: DataSourceImpl = data_source_impl
         self.query_size: int = len(self.build_sql())
         self.logs: Logs = logs
-        # canonical_metric.id -> [aliased_metric.id, ...]. After execute() computes
+        # canonical_metric.id -> [aliased_metric, ...]. After execute() computes
         # a Measurement for a canonical metric, it also emits Measurements with the
-        # same value for every aliased metric id (those metrics were deduped out
-        # of the SQL but still need values for downstream check evaluation).
-        self.metric_aliases: dict[str, list[str]] = metric_aliases or {}
+        # same value for every aliased metric (those metrics were deduped out of
+        # the SQL but still need values for downstream check evaluation). We keep
+        # the full metric impls so each Measurement uses the aliased metric's own
+        # get_short_description() — two deduped metrics may have different names.
+        self.metric_aliases: dict[str, list[AggregationMetricImpl]] = metric_aliases or {}
 
     def can_accept(self, aggregation_metric_impl: AggregationMetricImpl) -> bool:
         max_query_length: int = self.data_source_impl.sql_dialect.get_max_sql_statement_length()
@@ -1901,9 +1907,17 @@ class AggregationQuery(Query):
             measurements.append(
                 Measurement(metric_id=aggregation_metric_impl.id, value=measurement_value, metric_name=metric_name)
             )
-            # Mirror the value onto every aliased metric id that was deduped out
+            # Mirror the value onto every aliased metric that was deduped out
             # of this query. Each consumer (check.evaluate) looks up its metric by
-            # id; they all need to find a Measurement.
-            for aliased_id in self.metric_aliases.get(aggregation_metric_impl.id, ()):
-                measurements.append(Measurement(metric_id=aliased_id, value=measurement_value, metric_name=metric_name))
+            # id; they all need to find a Measurement. Use each aliased metric's own
+            # get_short_description() so metric_name reflects the consuming metric,
+            # not the canonical one we happened to keep in the SQL.
+            for aliased_metric in self.metric_aliases.get(aggregation_metric_impl.id, ()):
+                measurements.append(
+                    Measurement(
+                        metric_id=aliased_metric.id,
+                        value=measurement_value,
+                        metric_name=aliased_metric.get_short_description(),
+                    )
+                )
         return measurements

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -581,8 +581,31 @@ class ContractImpl:
             else:
                 other_queries.append(query)
 
+        # Deduplicate byte-identical aggregation metrics before bundling them into
+        # queries. Two metrics that render to the same SQL (e.g. MissingCheckImpl
+        # and InvalidCheckImpl on the same column both resolving a MissingCount
+        # metric) compute the redundant aggregate twice on the warehouse otherwise.
+        # Key on (type, rendered_sql) so we never collapse metrics that would
+        # convert their DB value differently (`int` vs `float` vs identity).
+        canonical_metrics: list[AggregationMetricImpl] = []
+        canonical_by_sql: dict[tuple[type, str], AggregationMetricImpl] = {}
+        # canonical_metric.id -> [aliased_metric.id, ...] for measurement emission.
+        metric_aliases: dict[str, list[str]] = {}
+        if self.data_source_impl is not None:
+            sql_dialect = self.data_source_impl.sql_dialect
+            for metric in aggregation_metrics:
+                key = (type(metric), sql_dialect.build_expression_sql(metric.sql_expression()))
+                canonical = canonical_by_sql.get(key)
+                if canonical is None:
+                    canonical_by_sql[key] = metric
+                    canonical_metrics.append(metric)
+                else:
+                    metric_aliases.setdefault(canonical.id, []).append(metric.id)
+        else:
+            canonical_metrics = aggregation_metrics
+
         aggregation_queries: list[AggregationQuery] = []
-        for aggregation_metric in aggregation_metrics:
+        for aggregation_metric in canonical_metrics:
             if len(aggregation_queries) == 0 or not aggregation_queries[-1].can_accept(aggregation_metric):
                 aggregation_queries.append(
                     AggregationQuery(
@@ -591,6 +614,7 @@ class ContractImpl:
                         dataset_name=self.dataset_name,
                         data_source_impl=self.data_source_impl,
                         logs=self.logs,
+                        metric_aliases=metric_aliases,
                     )
                 )
             last_aggregation_query: AggregationQuery = aggregation_queries[-1]
@@ -1800,6 +1824,7 @@ class AggregationQuery(Query):
         dataset_name: str,
         data_source_impl: Optional[DataSourceImpl],
         logs: Logs,
+        metric_aliases: Optional[dict[str, list[str]]] = None,
     ):
         super().__init__(data_source_impl=data_source_impl, metrics=[])
         self.cte: CTE = cte
@@ -1809,6 +1834,11 @@ class AggregationQuery(Query):
         self.data_source_impl: DataSourceImpl = data_source_impl
         self.query_size: int = len(self.build_sql())
         self.logs: Logs = logs
+        # canonical_metric.id -> [aliased_metric.id, ...]. After execute() computes
+        # a Measurement for a canonical metric, it also emits Measurements with the
+        # same value for every aliased metric id (those metrics were deduped out
+        # of the SQL but still need values for downstream check evaluation).
+        self.metric_aliases: dict[str, list[str]] = metric_aliases or {}
 
     def can_accept(self, aggregation_metric_impl: AggregationMetricImpl) -> bool:
         max_query_length: int = self.data_source_impl.sql_dialect.get_max_sql_statement_length()
@@ -1867,11 +1897,13 @@ class AggregationQuery(Query):
         for i in range(0, len(self.aggregation_metrics)):
             aggregation_metric_impl: AggregationMetricImpl = self.aggregation_metrics[i]
             measurement_value = aggregation_metric_impl.convert_db_value(row[i])
+            metric_name = aggregation_metric_impl.get_short_description()
             measurements.append(
-                Measurement(
-                    metric_id=aggregation_metric_impl.id,
-                    value=measurement_value,
-                    metric_name=aggregation_metric_impl.get_short_description(),
-                )
+                Measurement(metric_id=aggregation_metric_impl.id, value=measurement_value, metric_name=metric_name)
             )
+            # Mirror the value onto every aliased metric id that was deduped out
+            # of this query. Each consumer (check.evaluate) looks up its metric by
+            # id; they all need to find a Measurement.
+            for aliased_id in self.metric_aliases.get(aggregation_metric_impl.id, ()):
+                measurements.append(Measurement(metric_id=aliased_id, value=measurement_value, metric_name=metric_name))
         return measurements

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -364,3 +364,30 @@ def test_byte_identical_aggregation_metrics_emitted_only_once(
     # Neither should be NOT_EVALUATED — both should have real numeric diagnostics.
     for r in missing_results + invalid_results:
         assert r.outcome != CheckOutcome.NOT_EVALUATED, f"{r.check.name} should have been evaluated; got {r.outcome}"
+
+    # The alias-id map is the load-bearing piece — without it, two Measurements
+    # would NOT be emitted under different metric ids and the invalid check would
+    # see missing_count as unmeasured. Assert the actual values flow through:
+    #   - test data is 4 rows, one with id=None → missing_count == 1
+    #   - missing check's missing_count diagnostic comes from its own MissingCountMetricImpl
+    #   - invalid check's missing_count diagnostic comes from the aliased one (same value)
+    # If alias emission were removed, the invalid check would coalesce missing_count
+    # to 0 via the framework default — so asserting on `missing_count == 1` here
+    # specifically covers the alias path.
+    invalid_diag = invalid_results[0].diagnostic_metric_values or {}
+    assert invalid_diag.get("missing_count") == 1, (
+        f"Invalid check's missing_count diagnostic must come from the aliased MissingCount "
+        f"measurement, not the 0 default. Got {invalid_diag!r}"
+    )
+    missing_diag = missing_results[0].diagnostic_metric_values or {}
+    assert missing_diag.get("missing_count") == 1, f"Missing check missing_count expected 1, got {missing_diag!r}"
+
+    # Each Measurement must use its own metric's name, not the canonical's.
+    # When MissingCount metrics from two check types dedup, get_short_description()
+    # returns the check type ("missing" vs "invalid"); both names must appear in
+    # the measurements collection.
+    measurement_names = {m.metric_name for m in contract_verification_result.measurements}
+    assert "missing" in measurement_names and "invalid" in measurement_names, (
+        f"Aliased Measurement must carry the aliased metric's get_short_description(), "
+        f"not the canonical's. Names present: {measurement_names}"
+    )

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -319,3 +319,48 @@ def test_invalid_percent_does_not_leak_nulls_when_aggregation_fails(
         assert (
             diagnostics.get(field) is not None
         ), f"{field} must default to a numeric value (not null) under NOT_EVALUATED; got {diagnostics!r}"
+
+
+def test_byte_identical_aggregation_metrics_emitted_only_once(
+    data_source_test_helper: DataSourceTestHelper,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DTL-1778: two metrics that render to identical SQL (MissingCount resolved
+    by both MissingCheckImpl and InvalidCheckImpl on the same column) must be
+    deduped so the warehouse computes the aggregate once. Each consuming check
+    still receives its measurement via the alias-id map."""
+    test_table = data_source_test_helper.ensure_test_table(_test_table_specification)
+    captured_sql = _capture_executed_sql(data_source_test_helper, monkeypatch)
+
+    contract_verification_result = data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str="""
+            columns:
+              - name: id
+                checks:
+                  - missing:
+                  - invalid:
+                      valid_values: ['1', '2', '3']
+            """,
+    )
+
+    aggregation_sql = _find_aggregation_sql(captured_sql)
+    fields = _extract_select_field_lines(aggregation_sql)
+
+    # Strip the per-position alias (`<expr> AS "m_<n>"`) to compare raw expressions.
+    # The dedup invariant: no two raw expressions are byte-identical.
+    raw_exprs = [field.rsplit(" AS ", 1)[0] for field in fields]
+    duplicates = {expr for expr in raw_exprs if raw_exprs.count(expr) > 1}
+    assert not duplicates, (
+        f"Aggregation query has duplicate raw expressions {duplicates!r}. "
+        f"Full SELECT list:\n  " + "\n  ".join(fields) + f"\n\nFull SQL:\n{aggregation_sql}"
+    )
+
+    # Both the missing and invalid checks must still produce real measurements;
+    # they share a measurement via the alias-id map.
+    missing_results = [r for r in contract_verification_result.check_results if r.check.type == "missing"]
+    invalid_results = [r for r in contract_verification_result.check_results if r.check.type == "invalid"]
+    assert missing_results and invalid_results
+    # Neither should be NOT_EVALUATED — both should have real numeric diagnostics.
+    for r in missing_results + invalid_results:
+        assert r.outcome != CheckOutcome.NOT_EVALUATED, f"{r.check.name} should have been evaluated; got {r.outcome}"


### PR DESCRIPTION
## Summary

Follow-up to PR #2695. That hotfix emitted per-position `AS m_<n>` aliases so Spark 4.x would accept aggregation queries containing byte-identical SQL expressions. The warehouse accepted the result but still computed the redundant aggregate twice.

This PR dedups byte-identical metrics in `ContractImpl._build_queries`, keyed on `(type(metric), rendered_sql_expression)`. First-seen metric becomes canonical and goes into the SQL; subsequent identical metrics are recorded in a `metric_aliases` map. `AggregationQuery.execute` emits one `Measurement` per canonical id plus one per aliased id, so every consuming check still finds its value.

Tracking: [DTL-1778](https://linear.app/sodadata/issue/DTL-1778). Customer context: [SCS-1172](https://sodadata.atlassian.net/browse/SCS-1172) / PR #2695.

## Why now

- Spark computes the same `SUM(CASE WHEN col IS NULL …)` twice for every column with `missing` + `invalid`. Costs scale with table size × redundancy factor.
- Reduces reliance on warehouse-side common-subexpression elimination.
- Restores the implicit invariant we lost in PR #2588: one metric → one Measurement.

## Test plan

- [x] New regression `test_byte_identical_aggregation_metrics_emitted_only_once` asserts the SQL has no duplicate raw expressions when `missing` + `invalid` are on the same column, and that both checks still produce real (non-NOT_EVALUATED) outcomes.
- [x] Full duckdb suite green (912 passed, +1 from the new test).
- [x] Existing aliasing regression test still passes (the alias names still differ even when there are fewer of them).
- [ ] Reviewer to verify against a real warehouse (databricks, snowflake) that EXPLAIN now shows one fewer aggregate compute.

## `[REPLAY=OFF]`

Cached snapshots from the nightly job are invalidated by the SQL shape change. Nightly snapshot recording will refresh after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCS-1172]: https://sodadata.atlassian.net/browse/SCS-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ