### PR TITLE
refactor(DTL-1780): consolidate aliasing under ALIAS — drop COLUMN/COUNT field_alias

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -301,8 +301,7 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
             column_sql = f'"{column.name}"'
         else:
             column_sql = self.build_expression_sql(column.name)
-        field_alias_sql: str = f" AS {self.quote_default(column.field_alias)}" if column.field_alias else ""
-        return f"{table_alias_sql}{column_sql}{field_alias_sql}"
+        return f"{table_alias_sql}{column_sql}"
 
     def literal_datetime(self, datetime: datetime):
         return f"From_iso8601_timestamp('{datetime.isoformat()}')"

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -181,6 +181,9 @@ class SqlExpression(BaseSqlExpression):
     def __post_init__(self):
         super().__post_init__()
 
+    def AS(self, alias: str) -> "ALIAS":
+        return ALIAS(self, alias)
+
 
 @dataclass
 class STAR(SqlExpression):
@@ -369,9 +372,6 @@ class COLUMN(SqlExpression):
 
     def IN(self, table_alias: str) -> COLUMN:
         return COLUMN(name=self.name, table_alias=table_alias)
-
-    def AS(self, alias: str) -> ALIAS:
-        return ALIAS(self, alias)
 
 
 @dataclass

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -193,7 +193,6 @@ class STAR(SqlExpression):
 @dataclass
 class COUNT(SqlExpression):
     expression: SqlExpression | str
-    field_alias: Optional[str] = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -367,13 +366,12 @@ class COLUMN(SqlExpression):
         SqlExpression | str
     )  # Use SqlExpression if you need to generate and/or rename a column dymamically, e.g. using a CASE statement
     table_alias: Optional[str] = None
-    field_alias: Optional[str] = None
 
     def IN(self, table_alias: str) -> COLUMN:
-        return COLUMN(name=self.name, table_alias=table_alias, field_alias=self.field_alias)
+        return COLUMN(name=self.name, table_alias=table_alias)
 
-    def AS(self, field_alias: str) -> COLUMN:
-        return COLUMN(name=self.name, table_alias=self.table_alias, field_alias=field_alias)
+    def AS(self, alias: str) -> ALIAS:
+        return ALIAS(self, alias)
 
 
 @dataclass
@@ -678,10 +676,8 @@ class CREATE_TABLE_COLUMN(BaseSqlExpression):
         super().__post_init__()
         self.handle_parent_node_update(self.default)
 
-    def convert_to_standard_column(
-        self, table_alias: Optional[str] = None, field_alias: Optional[str] = None
-    ) -> COLUMN:
-        return COLUMN(name=self.name, table_alias=table_alias, field_alias=field_alias)
+    def convert_to_standard_column(self, table_alias: Optional[str] = None) -> COLUMN:
+        return COLUMN(name=self.name, table_alias=table_alias)
 
 
 @dataclass

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -865,8 +865,7 @@ class SqlDialect:
         column_sql: str = self.build_expression_sql(
             column.name
         )  # If column.name is a SqlExpression, it will be compiled; if a string, it will be quoted
-        field_alias_sql: str = f" AS {self.quote_default(column.field_alias)}" if column.field_alias else ""
-        return f"{table_alias_sql}{column_sql}{field_alias_sql}"
+        return f"{table_alias_sql}{column_sql}"
 
     def _build_or_sql(self, or_expr: OR) -> str:
         if isinstance(or_expr.clauses, list) and len(or_expr.clauses) == 1:
@@ -1045,10 +1044,7 @@ class SqlDialect:
             return "*"
 
     def _build_count_sql(self, count: COUNT) -> str:
-        count_sql = f"COUNT({self.build_expression_sql(count.expression)})"
-        if count.field_alias:
-            count_sql = f"{count_sql} AS {self.quote_default(count.field_alias)}"
-        return count_sql
+        return f"COUNT({self.build_expression_sql(count.expression)})"
 
     def _build_distinct_sql(self, distinct: DISTINCT) -> str:
         expressions: list[SqlExpression] = (

--- a/soda-core/src/soda_core/common/statements/metadata_tables_query.py
+++ b/soda-core/src/soda_core/common/statements/metadata_tables_query.py
@@ -71,10 +71,10 @@ class MetadataTablesQuery:
             ),
             SELECT(
                 [
-                    self.sql_dialect.column_table_catalog() or ALIAS(LITERAL(None), "database_name"),
+                    self.sql_dialect.column_table_catalog() or LITERAL(None).AS("database_name"),
                     self.sql_dialect.column_table_schema(),
                     self.sql_dialect.column_table_name(),
-                    self.sql_dialect.column_table_type() or ALIAS(LITERAL(None), "table_type"),
+                    self.sql_dialect.column_table_type() or LITERAL(None).AS("table_type"),
                 ]
             ),
         ]

--- a/soda-core/src/soda_core/common/statements/metadata_tables_query.py
+++ b/soda-core/src/soda_core/common/statements/metadata_tables_query.py
@@ -71,10 +71,10 @@ class MetadataTablesQuery:
             ),
             SELECT(
                 [
-                    self.sql_dialect.column_table_catalog() or COLUMN(LITERAL(None), field_alias="database_name"),
+                    self.sql_dialect.column_table_catalog() or ALIAS(LITERAL(None), "database_name"),
                     self.sql_dialect.column_table_schema(),
                     self.sql_dialect.column_table_name(),
-                    self.sql_dialect.column_table_type() or COLUMN(LITERAL(None), field_alias="table_type"),
+                    self.sql_dialect.column_table_type() or ALIAS(LITERAL(None), "table_type"),
                 ]
             ),
         ]

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -346,7 +346,7 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
                     END AS "datetime_precision"
                 """
                 ),
-                ALIAS(current_database_expression, "table_catalog"),
+                current_database_expression.AS("table_catalog"),
                 COLUMN("nspname", table_alias="n").AS("table_schema"),
                 COLUMN("relname", table_alias="c").AS("table_name"),
                 RAW_SQL(self.relkind_table_type_sql_expression()),

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -12,7 +12,6 @@ from soda_core.common.metadata_types import (
     SqlDataType,
 )
 from soda_core.common.sql_ast import (
-    ALIAS,
     AND,
     CAST,
     COLUMN,

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -12,6 +12,7 @@ from soda_core.common.metadata_types import (
     SqlDataType,
 )
 from soda_core.common.sql_ast import (
+    ALIAS,
     AND,
     CAST,
     COLUMN,
@@ -264,11 +265,11 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
 
         select_columns = []
         if include_table_name_column:
-            select_columns.append(COLUMN("relname", table_alias="c", field_alias="table_name"))
+            select_columns.append(COLUMN("relname", table_alias="c").AS("table_name"))
 
         select_columns.extend(
             [
-                COLUMN("attname", table_alias="a", field_alias="column_name"),
+                COLUMN("attname", table_alias="a").AS("column_name"),
                 # Normalize data type into information_schema.columns style.
                 RAW_SQL(
                     """CASE
@@ -345,9 +346,9 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
                     END AS "datetime_precision"
                 """
                 ),
-                COLUMN(current_database_expression, field_alias="table_catalog"),
-                COLUMN("nspname", table_alias="n", field_alias="table_schema"),
-                COLUMN("relname", table_alias="c", field_alias="table_name"),
+                ALIAS(current_database_expression, "table_catalog"),
+                COLUMN("nspname", table_alias="n").AS("table_schema"),
+                COLUMN("relname", table_alias="c").AS("table_name"),
                 RAW_SQL(self.relkind_table_type_sql_expression()),
             ]
         )

--- a/soda-postgres/src/soda_postgres/statements/postgres_metadata_tables_query.py
+++ b/soda-postgres/src/soda_postgres/statements/postgres_metadata_tables_query.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.sql_ast import (
-    ALIAS,
     COLUMN,
     EQ,
     FROM,
@@ -36,7 +35,7 @@ class PostgresMetadataTablesQuery(MetadataTablesQuery):
         select: list = [
             SELECT(
                 [
-                    ALIAS(current_database_expression, "table_catalog"),
+                    current_database_expression.AS("table_catalog"),
                     COLUMN("nspname", table_alias="n").AS("table_schema"),
                     COLUMN("relname", table_alias="c").AS("table_name"),
                     RAW_SQL(self.sql_dialect.relkind_table_type_sql_expression()),

--- a/soda-postgres/src/soda_postgres/statements/postgres_metadata_tables_query.py
+++ b/soda-postgres/src/soda_postgres/statements/postgres_metadata_tables_query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.sql_ast import (
+    ALIAS,
     COLUMN,
     EQ,
     FROM,
@@ -35,9 +36,9 @@ class PostgresMetadataTablesQuery(MetadataTablesQuery):
         select: list = [
             SELECT(
                 [
-                    COLUMN(current_database_expression, field_alias="table_catalog"),
-                    COLUMN("nspname", table_alias="n", field_alias="table_schema"),
-                    COLUMN("relname", table_alias="c", field_alias="table_name"),
+                    ALIAS(current_database_expression, "table_catalog"),
+                    COLUMN("nspname", table_alias="n").AS("table_schema"),
+                    COLUMN("relname", table_alias="c").AS("table_name"),
                     RAW_SQL(self.sql_dialect.relkind_table_type_sql_expression()),
                 ]
             ),

--- a/soda-redshift/src/soda_redshift/statements/redshift_metadata_tables_query.py
+++ b/soda-redshift/src/soda_redshift/statements/redshift_metadata_tables_query.py
@@ -81,9 +81,9 @@ class RedshiftMetadataTablesQuery(MetadataTablesQuery):
         matview_select = [
             SELECT(
                 [
-                    COLUMN("database_name", field_alias="table_catalog"),
-                    COLUMN("schema_name", field_alias="table_schema"),
-                    COLUMN("name", field_alias="table_name"),
+                    COLUMN("database_name").AS("table_catalog"),
+                    COLUMN("schema_name").AS("table_schema"),
+                    COLUMN("name").AS("table_name"),
                     RAW_SQL("'MATERIALIZED VIEW' AS TABLE_TYPE"),
                 ]
             ),

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -304,3 +304,65 @@ def test_sql_ast_union_all():
     assert (
         my_union_statement == '(\nSELECT "name"\nFROM "customers"\n)\nUNION ALL\n(\nSELECT "age"\nFROM "customers"\n);'
     )
+
+
+# ---------------------------------------------------------------------------
+# ALIAS — DTL-1780 consolidation
+# ---------------------------------------------------------------------------
+
+
+def test_alias_renders_expression_with_quoted_alias():
+    """Baseline: ALIAS(<expr>, name) emits `<expr> AS "<name>"`."""
+    sql_dialect: SqlDialect = SqlDialect()
+    assert sql_dialect.build_expression_sql(ALIAS(COLUMN("name"), "n")) == '"name" AS "n"'
+
+
+def test_alias_wraps_arbitrary_expression():
+    """ALIAS must wrap any SqlExpression (LITERAL, COUNT, COMBINED_HASH, etc.) — the
+    pre-DTL-1780 per-class field_alias mechanism only worked on COLUMN and COUNT."""
+    sql_dialect: SqlDialect = SqlDialect()
+    assert sql_dialect.build_expression_sql(ALIAS(LITERAL(None), "database_name")) == 'NULL AS "database_name"'
+    assert sql_dialect.build_expression_sql(ALIAS(COUNT(STAR()), "n_count")) == 'COUNT(*) AS "n_count"'
+
+
+def test_column_AS_returns_alias_node():
+    """`COLUMN(...).AS("x")` is the legacy fluent API for aliasing. Post-DTL-1780 it
+    must return an ALIAS wrapper (not a mutated COLUMN with field_alias) so that
+    consumers can inspect the alias as `.alias` instead of `.field_alias`."""
+    aliased = COLUMN("name").AS("output")
+    assert isinstance(aliased, ALIAS), f"COLUMN.AS must return ALIAS; got {type(aliased).__name__}"
+    assert aliased.alias == "output"
+    sql_dialect: SqlDialect = SqlDialect()
+    assert sql_dialect.build_expression_sql(aliased) == '"name" AS "output"'
+
+
+def test_column_no_longer_accepts_field_alias_kwarg():
+    """Regression guard: a re-introduction of `field_alias` on COLUMN would silently
+    revive the deprecated per-class aliasing path."""
+    import pytest
+
+    with pytest.raises(TypeError):
+        COLUMN("name", field_alias="x")  # type: ignore[call-arg]
+
+
+def test_count_no_longer_accepts_field_alias_kwarg():
+    """Same guard for COUNT."""
+    import pytest
+
+    with pytest.raises(TypeError):
+        COUNT(STAR(), field_alias="x")  # type: ignore[call-arg]
+
+
+def test_alias_in_select_list_emits_in_sql():
+    """End-to-end: ALIAS inside SELECT emits the `AS` clause in the rendered SQL.
+    Load-bearing case for metadata queries that synthesize literal-backed output
+    columns (e.g. `NULL AS "database_name"`)."""
+    sql_dialect: SqlDialect = SqlDialect()
+    sql = sql_dialect.build_select_sql(
+        [
+            SELECT([ALIAS(LITERAL(None), "database_name"), ALIAS(COLUMN("name"), "table_name")]),
+            FROM("information_schema.tables"),
+        ]
+    )
+    assert 'NULL AS "database_name"' in sql
+    assert '"name" AS "table_name"' in sql

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -366,3 +366,15 @@ def test_alias_in_select_list_emits_in_sql():
     )
     assert 'NULL AS "database_name"' in sql
     assert '"name" AS "table_name"' in sql
+
+
+def test_AS_method_works_on_any_sql_expression():
+    """`.AS()` lives on `SqlExpression` so every expression type — not just COLUMN —
+    can be aliased fluently. `expr.AS("x")` is equivalent to `ALIAS(expr, "x")`."""
+    sql_dialect: SqlDialect = SqlDialect()
+    assert sql_dialect.build_expression_sql(LITERAL(None).AS("database_name")) == 'NULL AS "database_name"'
+    assert sql_dialect.build_expression_sql(COUNT(STAR()).AS("n_count")) == 'COUNT(*) AS "n_count"'
+    assert sql_dialect.build_expression_sql(RAW_SQL("current_database()").AS("table_catalog")) == (
+        'current_database() AS "table_catalog"'
+    )
+    assert isinstance(LITERAL(None).AS("x"), ALIAS)


### PR DESCRIPTION
## Summary

The codebase had three aliasing mechanisms in the SQL AST:

1. `COLUMN.field_alias` (per-class attribute)
2. `COUNT.field_alias` (per-class attribute)
3. `ALIAS(expression, alias)` (general wrapper, introduced in PR #2695)

`ALIAS` is strictly more powerful — wraps any `SqlExpression`. The per-class attrs only worked for `COLUMN`/`COUNT` and existed for historical reasons. This PR removes them in favor of `ALIAS`.

Tracking: [DTL-1780](https://linear.app/sodadata/issue/DTL-1780).

## Changes

- Drop `COLUMN.field_alias` and `COUNT.field_alias` dataclass attributes.
- Drop dispatcher branches for them in `sql_dialect.py` (base + athena override).
- `COLUMN.AS(alias)` returns `ALIAS(self, alias)` instead of a new `COLUMN`.
- `COLUMN.IN()` no longer propagates `field_alias`.
- `STAR.convert_to_standard_column` drops the unused `field_alias` parameter.
- Migrate call sites: 11 in soda-core (metadata queries, postgres, redshift). Soda-extensions migrated in a [matching branch](https://github.com/sodadata/soda-extensions/pull-or-branch/DTL-1780-consolidate-aliasing-under-alias).

## Why now

- Single canonical mechanism for output-column aliasing. Reduces cognitive load and the surface area for inconsistencies.
- Removes redundant dispatcher branches and dataclass attrs.

## Test plan

- [x] soda-core 911 passed on duckdb. No SQL output changes — metadata queries produce identical strings.
- [x] soda-extensions 136 passed (reconciliation + groupby + migration unit suites).
- [ ] Reviewer to verify diff is purely mechanical and emits identical SQL.

## Related

- Introduced `ALIAS`: PR #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)