### PR TITLE
fix(DTL-1776): isolate rows_tested_query metric from contract row_count

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -104,8 +104,17 @@ class FailedRowsCheckImpl(CheckImpl):
                 self.queries.append(failed_rows_count_query)
 
             if self.failed_rows_check_yaml.rows_tested_query and contract_impl.data_source_impl:
+                # DTL-1776: must NOT share identity with the contract-wide row_count
+                # metric. A plain RowCountMetricImpl with no filter hashes identical
+                # to ContractImpl.row_count_metric_impl, so RowsTestedQuery's
+                # measurement would overwrite dataset_rows_tested and leak this
+                # check's custom count into every other check's diagnostics.
                 self.check_rows_tested_metric_impl = self._resolve_metric(
-                    RowCountMetricImpl(contract_impl=contract_impl, check_impl=self)
+                    RowsTestedQueryMetricImpl(
+                        contract_impl=contract_impl,
+                        check_impl=self,
+                        rows_tested_query=self.failed_rows_check_yaml.rows_tested_query,
+                    )
                 )
                 rows_tested_sql = self.failed_rows_check_yaml.rows_tested_query
                 if contract_impl.should_apply_sampling:
@@ -229,6 +238,42 @@ class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
 
     def convert_db_value(self, value) -> any:
         return int(value) if value is not None else 0
+
+
+class RowsTestedQueryMetricImpl(MetricImpl):
+    """Holds the row count returned by a user-provided rows_tested_query.
+
+    Why: a plain `RowCountMetricImpl` would collide on identity with the
+    contract's dataset-wide row_count metric (same type, dataset, no filter),
+    causing the RowsTestedQuery's measurement to overwrite
+    `dataset_rows_tested` and leak into every other check's diagnostics
+    (DTL-1776). This subclass keeps the SQL in its identity hash so two
+    failed_rows checks with the same rows_tested_query may still share a
+    metric, while different queries — and the contract row_count metric — get
+    distinct ids. It is intentionally NOT an AggregationMetricImpl: the value
+    comes from the user's query, not the dataset COUNT(*) aggregation.
+    """
+
+    def __init__(
+        self,
+        contract_impl: ContractImpl,
+        check_impl: FailedRowsCheckImpl,
+        rows_tested_query: str,
+    ):
+        self.rows_tested_query: str = rows_tested_query
+        super().__init__(
+            contract_impl=contract_impl,
+            metric_type="rows_tested_query",
+            check_filter=check_impl.check_yaml.filter,
+        )
+
+    def _get_id_properties(self) -> dict[str, any]:
+        id_properties: dict[str, any] = super()._get_id_properties()
+        id_properties["rows_tested_query"] = self.rows_tested_query
+        return id_properties
+
+    def sql_condition_expression(self) -> Optional[SqlExpression]:
+        return None
 
 
 class FailedRowsQueryMetricImpl(MetricImpl):

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -104,17 +104,11 @@ class FailedRowsCheckImpl(CheckImpl):
                 self.queries.append(failed_rows_count_query)
 
             if self.failed_rows_check_yaml.rows_tested_query and contract_impl.data_source_impl:
-                # DTL-1776: must NOT share identity with the contract-wide row_count
-                # metric. A plain RowCountMetricImpl with no filter hashes identical
-                # to ContractImpl.row_count_metric_impl, so RowsTestedQuery's
-                # measurement would overwrite dataset_rows_tested and leak this
-                # check's custom count into every other check's diagnostics.
+                # Must NOT use RowCountMetricImpl here — its identity hash
+                # would match the contract-wide row_count metric and the
+                # custom-query measurement would clobber dataset_rows_tested.
                 self.check_rows_tested_metric_impl = self._resolve_metric(
-                    RowsTestedQueryMetricImpl(
-                        contract_impl=contract_impl,
-                        check_impl=self,
-                        rows_tested_query=self.failed_rows_check_yaml.rows_tested_query,
-                    )
+                    RowsTestedQueryMetricImpl(contract_impl=contract_impl, check_impl=self)
                 )
                 rows_tested_sql = self.failed_rows_check_yaml.rows_tested_query
                 if contract_impl.should_apply_sampling:
@@ -241,26 +235,14 @@ class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
 
 
 class RowsTestedQueryMetricImpl(MetricImpl):
-    """Holds the row count returned by a user-provided rows_tested_query.
-
-    Why: a plain `RowCountMetricImpl` would collide on identity with the
-    contract's dataset-wide row_count metric (same type, dataset, no filter),
-    causing the RowsTestedQuery's measurement to overwrite
-    `dataset_rows_tested` and leak into every other check's diagnostics
-    (DTL-1776). This subclass keeps the SQL in its identity hash so two
-    failed_rows checks with the same rows_tested_query may still share a
-    metric, while different queries — and the contract row_count metric — get
-    distinct ids. It is intentionally NOT an AggregationMetricImpl: the value
-    comes from the user's query, not the dataset COUNT(*) aggregation.
+    """Row count from a user-provided rows_tested_query. SQL is part of the
+    identity so it can't collide with the contract row_count metric, and two
+    checks with the same SQL still share one measurement. Not an
+    AggregationMetricImpl: the value comes from the user's query, not COUNT(*).
     """
 
-    def __init__(
-        self,
-        contract_impl: ContractImpl,
-        check_impl: FailedRowsCheckImpl,
-        rows_tested_query: str,
-    ):
-        self.rows_tested_query: str = rows_tested_query
+    def __init__(self, contract_impl: ContractImpl, check_impl: FailedRowsCheckImpl):
+        self.rows_tested_query: str = check_impl.failed_rows_check_yaml.rows_tested_query
         super().__init__(
             contract_impl=contract_impl,
             metric_type="rows_tested_query",

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -278,6 +278,66 @@ def test_failed_rows_rows_tested_query_returns_null(data_source_test_helper: Dat
     assert "checkRowsTested" not in v4
 
 
+def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """DTL-1776: a failed_rows check's rows_tested_query must not overwrite the
+    contract-wide dataset_rows_tested.
+
+    Before the fix, the RowCountMetricImpl created to hold the rows_tested_query
+    result collided on identity hash with the contract's dataset row_count
+    metric. The RowsTestedQuery's measurement overwrote the aggregation query's
+    measurement, leaking the custom count into every check's datasetRowsTested
+    diagnostic (and also corrupting any row_count check threshold).
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    # Table has 3 rows. The rows_tested_query returns 999 — clearly different
+    # from the dataset's actual row count, so any leak is visible.
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - row_count:
+                  threshold:
+                    must_be: 3
+              - failed_rows:
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 999
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    row_count_check = next(c for c in checks if c["checkType"] == "row_count")
+    failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
+
+    # The row_count check must see the ACTUAL dataset row count (3), not the
+    # rows_tested_query's 999. checkRowsTested for row_count is the threshold
+    # value the check evaluates on — leakage here would also flip the outcome.
+    assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
+    assert row_count_check["outcome"] == "pass"
+
+    # The failed_rows check sees the dataset_rows_tested as the dataset's real
+    # count (3) and its own check_rows_tested as the custom query's result.
+    assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
+
+
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):
     """rows_tested_query with expression mode (no query) should emit a warning."""
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -325,6 +325,10 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
 
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
+    # 2 failing rows vs. default must_be=0 → fail. Pinned so a regression in
+    # threshold evaluation (the metric is the threshold value) shows up here
+    # rather than only via assert_contract_fail (any-check-fail wildcard).
+    assert failed_rows_check["outcome"] == "fail"
 
 
 def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
@@ -378,6 +382,7 @@ def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
     assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == pytest.approx(50.0)
+    assert failed_rows_check["outcome"] == "fail"
 
 
 def test_two_failed_rows_checks_resolve_to_distinct_metrics(
@@ -439,6 +444,12 @@ def test_two_failed_rows_checks_resolve_to_distinct_metrics(
     # RowsTestedQueryMetricImpl ids collided.
     assert over_5["diagnostics"]["v4"]["checkRowsTested"] == 100
     assert over_8["diagnostics"]["v4"]["checkRowsTested"] == 200
+
+    # Both have > 0 failing rows vs default must_be=0 → both fail. Pinned per
+    # check so a wrong outcome on either side doesn't hide behind the other
+    # via assert_contract_fail (any-check-fail wildcard).
+    assert over_5["outcome"] == "fail"
+    assert over_8["outcome"] == "fail"
 
 
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -281,14 +281,9 @@ def test_failed_rows_rows_tested_query_returns_null(data_source_test_helper: Dat
 def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     data_source_test_helper: DataSourceTestHelper,
 ):
-    """DTL-1776: a failed_rows check's rows_tested_query must not overwrite the
-    contract-wide dataset_rows_tested.
-
-    Before the fix, the RowCountMetricImpl created to hold the rows_tested_query
-    result collided on identity hash with the contract's dataset row_count
-    metric. The RowsTestedQuery's measurement overwrote the aggregation query's
-    measurement, leaking the custom count into every check's datasetRowsTested
-    diagnostic (and also corrupting any row_count check threshold).
+    """A failed_rows rows_tested_query must not overwrite the contract's
+    dataset_rows_tested. Regression for an identity-hash collision between
+    the per-check rows-tested metric and the contract row_count metric.
     """
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
@@ -301,8 +296,7 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
         ]
     )
 
-    # Table has 3 rows. The rows_tested_query returns 999 — clearly different
-    # from the dataset's actual row count, so any leak is visible.
+    # rows_tested_query returns 999 vs. actual 3 — any leak is visible.
     data_source_test_helper.assert_contract_fail(
         test_table=test_table,
         contract_yaml_str=f"""
@@ -325,15 +319,10 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     row_count_check = next(c for c in checks if c["checkType"] == "row_count")
     failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
 
-    # The row_count check must see the ACTUAL dataset row count (3), not the
-    # rows_tested_query's 999. checkRowsTested for row_count is the threshold
-    # value the check evaluates on — leakage here would also flip the outcome.
     assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
     assert row_count_check["outcome"] == "pass"
 
-    # The failed_rows check sees the dataset_rows_tested as the dataset's real
-    # count (3) and its own check_rows_tested as the custom query's result.
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
 
@@ -341,10 +330,9 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
 def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     data_source_test_helper: DataSourceTestHelper,
 ):
-    """DTL-1776 — percent variant: the existing percent test uses
-    `SELECT COUNT(*)` returning 3, which coincidentally matches the dataset's
-    real row count and so hides any identity-collision regression on the
-    percent path. This test forces a divergent value to lock that down.
+    """Percent-path regression. The sibling percent test happens to use a
+    rows_tested_query that returns the real dataset count, which masks any
+    identity-collision regression. This forces a divergent value.
     """
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
@@ -382,17 +370,75 @@ def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     row_count_check = next(c for c in checks if c["checkType"] == "row_count")
     failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
 
-    # row_count must see the real dataset count, not the rows_tested_query's 4.
     assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
     assert row_count_check["outcome"] == "pass"
 
-    # failed_rows percent is 2/4 = 50% > 10% threshold → fails. The check's
-    # own check_rows_tested is the user's 4 (intentional), while the contract
-    # dataset_rows_tested stays at 3.
+    # 2 failing rows / 4 reported by rows_tested_query → 50% > 10% threshold.
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
-    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == 50.0
+    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == pytest.approx(50.0)
+
+
+def test_two_failed_rows_checks_resolve_to_distinct_metrics(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """Two failed_rows checks with different `query` (and different
+    `rows_tested_query`) must produce independent measurements — both the
+    failed_rows_count metric and the rows_tested_query metric must include
+    their SQL in the identity hash so they don't share an id.
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    # Rows are (0,4), (10,20), (10,17). end-start = 4, 10, 7.
+    #   > 5 selects 2 rows; > 8 selects 1 row. Distinct counts.
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  qualifier: gap_over_5
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 100
+              - failed_rows:
+                  qualifier: gap_over_8
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 8
+                  rows_tested_query: |
+                    SELECT 200
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    check_by_path = {c["checkPath"]: c for c in checks}
+    over_5 = next(c for path, c in check_by_path.items() if path.endswith("gap_over_5"))
+    over_8 = next(c for path, c in check_by_path.items() if path.endswith("gap_over_8"))
+
+    # Distinct failed_rows_count per check — would collapse to one value if
+    # FailedRowsQueryMetricImpl ids collided.
+    assert over_5["diagnostics"]["v4"]["failedRowsCount"] == 2
+    assert over_8["diagnostics"]["v4"]["failedRowsCount"] == 1
+
+    # Distinct check_rows_tested per check — would collapse if
+    # RowsTestedQueryMetricImpl ids collided.
+    assert over_5["diagnostics"]["v4"]["checkRowsTested"] == 100
+    assert over_8["diagnostics"]["v4"]["checkRowsTested"] == 200
 
 
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -338,6 +338,63 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
 
 
+def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """DTL-1776 — percent variant: the existing percent test uses
+    `SELECT COUNT(*)` returning 3, which coincidentally matches the dataset's
+    real row count and so hides any identity-collision regression on the
+    percent path. This test forces a divergent value to lock that down.
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - row_count:
+                  threshold:
+                    must_be: 3
+              - failed_rows:
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 4
+                  threshold:
+                    metric: percent
+                    must_be_less_than: 10
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    row_count_check = next(c for c in checks if c["checkType"] == "row_count")
+    failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
+
+    # row_count must see the real dataset count, not the rows_tested_query's 4.
+    assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
+    assert row_count_check["outcome"] == "pass"
+
+    # failed_rows percent is 2/4 = 50% > 10% threshold → fails. The check's
+    # own check_rows_tested is the user's 4 (intentional), while the contract
+    # dataset_rows_tested stays at 3.
+    assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
+    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == 50.0
+
+
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):
     """rows_tested_query with expression mode (no query) should emit a warning."""
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)


### PR DESCRIPTION
## Summary

- A `failed_rows` check with `rows_tested_query:` was leaking its custom count into `ContractImpl.dataset_rows_tested`, corrupting `datasetRowsTested` for every other check and the threshold value of any `row_count` check.
- Root cause: `RowCountMetricImpl` created for the rows-tested-query case hashed identically to the contract-wide row_count metric. `MetricsResolver` returned the same instance; `MeasurementValues` is a dict keyed by id, so the per-check `RowsTestedQuery` overwrote the dataset aggregation's `COUNT(*)`.
- Fix: dedicated non-aggregation `RowsTestedQueryMetricImpl` that includes the raw SQL in its identity hash.

## Why a new class instead of parametrizing `RowCountMetricImpl`?

`RowCountMetricImpl` is an `AggregationMetricImpl`. `_build_queries` picks aggregation metrics up by `isinstance` and folds them into the dataset's aggregation query as a `COUNT(*)` column. The `rows_tested_query` case needs the metric value to come from a *custom user SQL*, not from the aggregation. So even parametrizing the identity hash to make instances distinct would leave the value coming from the wrong place. Making the class conditionally non-aggregation via a flag couples two semantically different behaviors. The new class mirrors `FailedRowsQueryMetricImpl` (also a non-aggregation `MetricImpl` whose identity includes its SQL) — same pattern, ~15 lines.

## Test plan

- [x] `test_failed_rows_rows_tested_query_does_not_leak_to_other_checks` — count-metric path; asserts the `row_count` check sees the real dataset count
- [x] `test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks` — percent-metric path with a divergent `rows_tested_query` (sibling percent test uses a value that coincidentally matches and hides the bug)
- [x] `test_two_failed_rows_checks_resolve_to_distinct_metrics` — two failed_rows checks with distinct `query` and `rows_tested_query`; locks in both `FailedRowsQueryMetricImpl` and `RowsTestedQueryMetricImpl` identity-distinctness invariants. Fails on `origin/main` at `checkRowsTested` collapse (last-write-wins).
- [x] All three tests fail on pre-fix code, pass on this branch
- [x] Full `soda-tests/tests/integration` suite: 159 passed, 7 unrelated skips
- [x] Full `soda-tests/tests/unit` suite: 734 passed, 1 unrelated skip
- [x] CI green across postgres, snowflake, bigquery, databricks, duckdb, sqlserver, synapse, redshift, fabric, sparkdf, trino
- [x] Pre-commit clean (black, isort, autoflake)
- [x] Independent reviewer pass — no must-fix findings
- [x] Copilot review — no comments
- [x] SonarCloud float-equality warning addressed (`pytest.approx`)

## Follow-up

Reviewer flagged an analogous latent pattern in `InvalidReferenceCountMetricImpl` (`soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py:198`) — separate ticket filed.