### PR TITLE
fix(DTL-1799): isolate InvalidReferenceCountMetricImpl identity

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -104,8 +104,17 @@ class FailedRowsCheckImpl(CheckImpl):
                 self.queries.append(failed_rows_count_query)
 
             if self.failed_rows_check_yaml.rows_tested_query and contract_impl.data_source_impl:
+                # DTL-1776: must NOT share identity with the contract-wide row_count
+                # metric. A plain RowCountMetricImpl with no filter hashes identical
+                # to ContractImpl.row_count_metric_impl, so RowsTestedQuery's
+                # measurement would overwrite dataset_rows_tested and leak this
+                # check's custom count into every other check's diagnostics.
                 self.check_rows_tested_metric_impl = self._resolve_metric(
-                    RowCountMetricImpl(contract_impl=contract_impl, check_impl=self)
+                    RowsTestedQueryMetricImpl(
+                        contract_impl=contract_impl,
+                        check_impl=self,
+                        rows_tested_query=self.failed_rows_check_yaml.rows_tested_query,
+                    )
                 )
                 rows_tested_sql = self.failed_rows_check_yaml.rows_tested_query
                 if contract_impl.should_apply_sampling:
@@ -229,6 +238,42 @@ class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
 
     def convert_db_value(self, value) -> any:
         return int(value) if value is not None else 0
+
+
+class RowsTestedQueryMetricImpl(MetricImpl):
+    """Holds the row count returned by a user-provided rows_tested_query.
+
+    Why: a plain `RowCountMetricImpl` would collide on identity with the
+    contract's dataset-wide row_count metric (same type, dataset, no filter),
+    causing the RowsTestedQuery's measurement to overwrite
+    `dataset_rows_tested` and leak into every other check's diagnostics
+    (DTL-1776). This subclass keeps the SQL in its identity hash so two
+    failed_rows checks with the same rows_tested_query may still share a
+    metric, while different queries — and the contract row_count metric — get
+    distinct ids. It is intentionally NOT an AggregationMetricImpl: the value
+    comes from the user's query, not the dataset COUNT(*) aggregation.
+    """
+
+    def __init__(
+        self,
+        contract_impl: ContractImpl,
+        check_impl: FailedRowsCheckImpl,
+        rows_tested_query: str,
+    ):
+        self.rows_tested_query: str = rows_tested_query
+        super().__init__(
+            contract_impl=contract_impl,
+            metric_type="rows_tested_query",
+            check_filter=check_impl.check_yaml.filter,
+        )
+
+    def _get_id_properties(self) -> dict[str, any]:
+        id_properties: dict[str, any] = super()._get_id_properties()
+        id_properties["rows_tested_query"] = self.rows_tested_query
+        return id_properties
+
+    def sql_condition_expression(self) -> Optional[SqlExpression]:
+        return None
 
 
 class FailedRowsQueryMetricImpl(MetricImpl):

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -104,17 +104,11 @@ class FailedRowsCheckImpl(CheckImpl):
                 self.queries.append(failed_rows_count_query)
 
             if self.failed_rows_check_yaml.rows_tested_query and contract_impl.data_source_impl:
-                # DTL-1776: must NOT share identity with the contract-wide row_count
-                # metric. A plain RowCountMetricImpl with no filter hashes identical
-                # to ContractImpl.row_count_metric_impl, so RowsTestedQuery's
-                # measurement would overwrite dataset_rows_tested and leak this
-                # check's custom count into every other check's diagnostics.
+                # Must NOT use RowCountMetricImpl here — its identity hash
+                # would match the contract-wide row_count metric and the
+                # custom-query measurement would clobber dataset_rows_tested.
                 self.check_rows_tested_metric_impl = self._resolve_metric(
-                    RowsTestedQueryMetricImpl(
-                        contract_impl=contract_impl,
-                        check_impl=self,
-                        rows_tested_query=self.failed_rows_check_yaml.rows_tested_query,
-                    )
+                    RowsTestedQueryMetricImpl(contract_impl=contract_impl, check_impl=self)
                 )
                 rows_tested_sql = self.failed_rows_check_yaml.rows_tested_query
                 if contract_impl.should_apply_sampling:
@@ -241,26 +235,14 @@ class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
 
 
 class RowsTestedQueryMetricImpl(MetricImpl):
-    """Holds the row count returned by a user-provided rows_tested_query.
-
-    Why: a plain `RowCountMetricImpl` would collide on identity with the
-    contract's dataset-wide row_count metric (same type, dataset, no filter),
-    causing the RowsTestedQuery's measurement to overwrite
-    `dataset_rows_tested` and leak into every other check's diagnostics
-    (DTL-1776). This subclass keeps the SQL in its identity hash so two
-    failed_rows checks with the same rows_tested_query may still share a
-    metric, while different queries — and the contract row_count metric — get
-    distinct ids. It is intentionally NOT an AggregationMetricImpl: the value
-    comes from the user's query, not the dataset COUNT(*) aggregation.
+    """Row count from a user-provided rows_tested_query. SQL is part of the
+    identity so it can't collide with the contract row_count metric, and two
+    checks with the same SQL still share one measurement. Not an
+    AggregationMetricImpl: the value comes from the user's query, not COUNT(*).
     """
 
-    def __init__(
-        self,
-        contract_impl: ContractImpl,
-        check_impl: FailedRowsCheckImpl,
-        rows_tested_query: str,
-    ):
-        self.rows_tested_query: str = rows_tested_query
+    def __init__(self, contract_impl: ContractImpl, check_impl: FailedRowsCheckImpl):
+        self.rows_tested_query: str = check_impl.failed_rows_check_yaml.rows_tested_query
         super().__init__(
             contract_impl=contract_impl,
             metric_type="rows_tested_query",

--- a/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
@@ -92,6 +92,7 @@ class InvalidCheckImpl(MissingAndValidityCheckImpl):
                 InvalidReferenceCountMetricImpl(
                     contract_impl=contract_impl,
                     column_impl=column_impl,
+                    check_filter=self.check_yaml.filter,
                     missing_and_validity=self.missing_and_validity,
                     column_expression=self.column_expression,
                 )
@@ -196,17 +197,25 @@ class InvalidCountMetricImpl(AggregationMetricImpl):
 
 
 class InvalidReferenceCountMetricImpl(MetricImpl):
+    """Count of values invalid by reference-data lookup. Distinct metric_type
+    from the aggregation sibling InvalidCountMetricImpl so the two never share
+    an id even if other properties match. Value is supplied by
+    InvalidReferenceCountQuery, not the dataset aggregation query.
+    """
+
     def __init__(
         self,
         contract_impl: ContractImpl,
         column_impl: ColumnImpl,
+        check_filter: Optional[str],
         missing_and_validity: MissingAndValidity,
         column_expression: Optional[COLUMN | SqlExpressionStr] = None,
     ):
         super().__init__(
             contract_impl=contract_impl,
-            metric_type="invalid_count",
+            metric_type="invalid_reference_count",
             column_impl=column_impl,
+            check_filter=check_filter,
             missing_and_validity=missing_and_validity,
             column_expression=column_expression,
         )

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -278,6 +278,66 @@ def test_failed_rows_rows_tested_query_returns_null(data_source_test_helper: Dat
     assert "checkRowsTested" not in v4
 
 
+def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """DTL-1776: a failed_rows check's rows_tested_query must not overwrite the
+    contract-wide dataset_rows_tested.
+
+    Before the fix, the RowCountMetricImpl created to hold the rows_tested_query
+    result collided on identity hash with the contract's dataset row_count
+    metric. The RowsTestedQuery's measurement overwrote the aggregation query's
+    measurement, leaking the custom count into every check's datasetRowsTested
+    diagnostic (and also corrupting any row_count check threshold).
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    # Table has 3 rows. The rows_tested_query returns 999 — clearly different
+    # from the dataset's actual row count, so any leak is visible.
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - row_count:
+                  threshold:
+                    must_be: 3
+              - failed_rows:
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 999
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    row_count_check = next(c for c in checks if c["checkType"] == "row_count")
+    failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
+
+    # The row_count check must see the ACTUAL dataset row count (3), not the
+    # rows_tested_query's 999. checkRowsTested for row_count is the threshold
+    # value the check evaluates on — leakage here would also flip the outcome.
+    assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
+    assert row_count_check["outcome"] == "pass"
+
+    # The failed_rows check sees the dataset_rows_tested as the dataset's real
+    # count (3) and its own check_rows_tested as the custom query's result.
+    assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
+
+
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):
     """rows_tested_query with expression mode (no query) should emit a warning."""
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -325,6 +325,10 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
 
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
+    # 2 failing rows vs. default must_be=0 → fail. Pinned so a regression in
+    # threshold evaluation (the metric is the threshold value) shows up here
+    # rather than only via assert_contract_fail (any-check-fail wildcard).
+    assert failed_rows_check["outcome"] == "fail"
 
 
 def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
@@ -378,6 +382,7 @@ def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
     assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == pytest.approx(50.0)
+    assert failed_rows_check["outcome"] == "fail"
 
 
 def test_two_failed_rows_checks_resolve_to_distinct_metrics(
@@ -439,6 +444,12 @@ def test_two_failed_rows_checks_resolve_to_distinct_metrics(
     # RowsTestedQueryMetricImpl ids collided.
     assert over_5["diagnostics"]["v4"]["checkRowsTested"] == 100
     assert over_8["diagnostics"]["v4"]["checkRowsTested"] == 200
+
+    # Both have > 0 failing rows vs default must_be=0 → both fail. Pinned per
+    # check so a wrong outcome on either side doesn't hide behind the other
+    # via assert_contract_fail (any-check-fail wildcard).
+    assert over_5["outcome"] == "fail"
+    assert over_8["outcome"] == "fail"
 
 
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -281,14 +281,9 @@ def test_failed_rows_rows_tested_query_returns_null(data_source_test_helper: Dat
 def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     data_source_test_helper: DataSourceTestHelper,
 ):
-    """DTL-1776: a failed_rows check's rows_tested_query must not overwrite the
-    contract-wide dataset_rows_tested.
-
-    Before the fix, the RowCountMetricImpl created to hold the rows_tested_query
-    result collided on identity hash with the contract's dataset row_count
-    metric. The RowsTestedQuery's measurement overwrote the aggregation query's
-    measurement, leaking the custom count into every check's datasetRowsTested
-    diagnostic (and also corrupting any row_count check threshold).
+    """A failed_rows rows_tested_query must not overwrite the contract's
+    dataset_rows_tested. Regression for an identity-hash collision between
+    the per-check rows-tested metric and the contract row_count metric.
     """
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
@@ -301,8 +296,7 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
         ]
     )
 
-    # Table has 3 rows. The rows_tested_query returns 999 — clearly different
-    # from the dataset's actual row count, so any leak is visible.
+    # rows_tested_query returns 999 vs. actual 3 — any leak is visible.
     data_source_test_helper.assert_contract_fail(
         test_table=test_table,
         contract_yaml_str=f"""
@@ -325,15 +319,10 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     row_count_check = next(c for c in checks if c["checkType"] == "row_count")
     failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
 
-    # The row_count check must see the ACTUAL dataset row count (3), not the
-    # rows_tested_query's 999. checkRowsTested for row_count is the threshold
-    # value the check evaluates on — leakage here would also flip the outcome.
     assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
     assert row_count_check["outcome"] == "pass"
 
-    # The failed_rows check sees the dataset_rows_tested as the dataset's real
-    # count (3) and its own check_rows_tested as the custom query's result.
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
 
@@ -341,10 +330,9 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
 def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     data_source_test_helper: DataSourceTestHelper,
 ):
-    """DTL-1776 — percent variant: the existing percent test uses
-    `SELECT COUNT(*)` returning 3, which coincidentally matches the dataset's
-    real row count and so hides any identity-collision regression on the
-    percent path. This test forces a divergent value to lock that down.
+    """Percent-path regression. The sibling percent test happens to use a
+    rows_tested_query that returns the real dataset count, which masks any
+    identity-collision regression. This forces a divergent value.
     """
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
@@ -382,17 +370,75 @@ def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
     row_count_check = next(c for c in checks if c["checkType"] == "row_count")
     failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
 
-    # row_count must see the real dataset count, not the rows_tested_query's 4.
     assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
     assert row_count_check["outcome"] == "pass"
 
-    # failed_rows percent is 2/4 = 50% > 10% threshold → fails. The check's
-    # own check_rows_tested is the user's 4 (intentional), while the contract
-    # dataset_rows_tested stays at 3.
+    # 2 failing rows / 4 reported by rows_tested_query → 50% > 10% threshold.
     assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
-    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == 50.0
+    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == pytest.approx(50.0)
+
+
+def test_two_failed_rows_checks_resolve_to_distinct_metrics(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """Two failed_rows checks with different `query` (and different
+    `rows_tested_query`) must produce independent measurements — both the
+    failed_rows_count metric and the rows_tested_query metric must include
+    their SQL in the identity hash so they don't share an id.
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    # Rows are (0,4), (10,20), (10,17). end-start = 4, 10, 7.
+    #   > 5 selects 2 rows; > 8 selects 1 row. Distinct counts.
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  qualifier: gap_over_5
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 100
+              - failed_rows:
+                  qualifier: gap_over_8
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 8
+                  rows_tested_query: |
+                    SELECT 200
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    check_by_path = {c["checkPath"]: c for c in checks}
+    over_5 = next(c for path, c in check_by_path.items() if path.endswith("gap_over_5"))
+    over_8 = next(c for path, c in check_by_path.items() if path.endswith("gap_over_8"))
+
+    # Distinct failed_rows_count per check — would collapse to one value if
+    # FailedRowsQueryMetricImpl ids collided.
+    assert over_5["diagnostics"]["v4"]["failedRowsCount"] == 2
+    assert over_8["diagnostics"]["v4"]["failedRowsCount"] == 1
+
+    # Distinct check_rows_tested per check — would collapse if
+    # RowsTestedQueryMetricImpl ids collided.
+    assert over_5["diagnostics"]["v4"]["checkRowsTested"] == 100
+    assert over_8["diagnostics"]["v4"]["checkRowsTested"] == 200
 
 
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -338,6 +338,63 @@ def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 999
 
 
+def test_failed_rows_rows_tested_query_percent_does_not_leak_to_other_checks(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """DTL-1776 — percent variant: the existing percent test uses
+    `SELECT COUNT(*)` returning 3, which coincidentally matches the dataset's
+    real row count and so hides any identity-collision regression on the
+    percent path. This test forces a divergent value to lock that down.
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - row_count:
+                  threshold:
+                    must_be: 3
+              - failed_rows:
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT 4
+                  threshold:
+                    metric: percent
+                    must_be_less_than: 10
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    checks = soda_core_insert_scan_results_command["checks"]
+    row_count_check = next(c for c in checks if c["checkType"] == "row_count")
+    failed_rows_check = next(c for c in checks if c["checkType"] == "failed_rows")
+
+    # row_count must see the real dataset count, not the rows_tested_query's 4.
+    assert row_count_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert row_count_check["diagnostics"]["v4"]["checkRowsTested"] == 3
+    assert row_count_check["outcome"] == "pass"
+
+    # failed_rows percent is 2/4 = 50% > 10% threshold → fails. The check's
+    # own check_rows_tested is the user's 4 (intentional), while the contract
+    # dataset_rows_tested stays at 3.
+    assert failed_rows_check["diagnostics"]["v4"]["datasetRowsTested"] == 3
+    assert failed_rows_check["diagnostics"]["v4"]["checkRowsTested"] == 4
+    assert failed_rows_check["diagnostics"]["v4"]["failedRowsPercent"] == 50.0
+
+
 def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source_test_helper: DataSourceTestHelper):
     """rows_tested_query with expression mode (no query) should emit a warning."""
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)

--- a/soda-tests/tests/integration/test_invalid_reference_check.py
+++ b/soda-tests/tests/integration/test_invalid_reference_check.py
@@ -142,6 +142,50 @@ def test_invalid_count_with_check_and_dataset_filter(data_source_test_helper: Da
     assert get_diagnostic_value(check_result, "check_rows_tested") == 2
 
 
+def test_two_invalid_reference_checks_with_different_filters_resolve_to_distinct_metrics(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """Two reference-invalidity checks on the same column with the same
+    valid_reference_data but different `filter:` must produce independent
+    measurements. Regression for InvalidReferenceCountMetricImpl omitting
+    check_filter from its identity hash — without that, both metrics share
+    an id and the last InvalidReferenceCountQuery write clobbers the first.
+    """
+    referencing_table = data_source_test_helper.ensure_test_table(referencing_table_specification)
+    referenced_table = data_source_test_helper.ensure_test_table(referenced_table_specification)
+
+    id_quoted: str = data_source_test_helper.quote_column("id")
+
+    # Test data has 8 rows; reference table contains valid country codes NL, BE.
+    #   id <= 4 → rows 1-4, of which only row 3 (XX) is invalid (not missing,
+    #             not in ref) → invalid_count = 1.
+    #   id  > 4 → rows 5-8, of which rows 5,6 (XX) are invalid; rows 7,8 have
+    #             None country (missing, excluded from invalid) → invalid_count = 2.
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_fail(
+        test_table=referencing_table,
+        contract_yaml_str=f"""
+            columns:
+              - name: country
+                valid_reference_data:
+                  dataset: {data_source_test_helper.build_dqn(referenced_table)}
+                  column: country_code
+                checks:
+                  - invalid:
+                      qualifier: low_ids
+                      filter: |
+                        {id_quoted} <= 4
+                  - invalid:
+                      qualifier: high_ids
+                      filter: |
+                        {id_quoted} > 4
+        """,
+    )
+
+    check_by_qualifier = {cr.check.qualifier: cr for cr in contract_verification_result.check_results}
+    assert get_diagnostic_value(check_by_qualifier["low_ids"], "invalid_count") == 1
+    assert get_diagnostic_value(check_by_qualifier["high_ids"], "invalid_count") == 2
+
+
 def test_invalid_count_excl_missing(data_source_test_helper: DataSourceTestHelper):
     referencing_table = data_source_test_helper.ensure_test_table(referencing_table_specification)
     referenced_table = data_source_test_helper.ensure_test_table(referenced_table_specification)

--- a/soda-tests/tests/integration/test_invalid_reference_check.py
+++ b/soda-tests/tests/integration/test_invalid_reference_check.py
@@ -2,6 +2,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
 from soda_core.contracts.contract_verification import (
+    CheckOutcome,
     CheckResult,
     ContractVerificationResult,
 )
@@ -182,8 +183,16 @@ def test_two_invalid_reference_checks_with_different_filters_resolve_to_distinct
     )
 
     check_by_qualifier = {cr.check.qualifier: cr for cr in contract_verification_result.check_results}
-    assert get_diagnostic_value(check_by_qualifier["low_ids"], "invalid_count") == 1
-    assert get_diagnostic_value(check_by_qualifier["high_ids"], "invalid_count") == 2
+    low_ids = check_by_qualifier["low_ids"]
+    high_ids = check_by_qualifier["high_ids"]
+
+    assert get_diagnostic_value(low_ids, "invalid_count") == 1
+    assert get_diagnostic_value(high_ids, "invalid_count") == 2
+
+    # Both have > 0 invalid vs default must_be=0 → both fail. Pinned so a
+    # wrong outcome doesn't hide behind assert_contract_fail (any-check-fail).
+    assert low_ids.outcome == CheckOutcome.FAILED
+    assert high_ids.outcome == CheckOutcome.FAILED
 
 
 def test_invalid_count_excl_missing(data_source_test_helper: DataSourceTestHelper):


### PR DESCRIPTION
Stacked on #2703 (DTL-1776). Merge that first.

## Summary

`InvalidReferenceCountMetricImpl` shared `metric_type=\"invalid_count\"` with the aggregation sibling `InvalidCountMetricImpl`, **and** did not include `check_filter` in its identity hash. Two reference-invalidity checks on the same column with the same `valid_reference_data` but different `filter:` clauses produced colliding metric ids; `MeasurementValues.metric_values_by_id` is a dict keyed by id, so the second `InvalidReferenceCountQuery` write clobbered the first and both checks reported the same count.

- Thread `check_filter` through `InvalidReferenceCountMetricImpl.__init__` to `super().__init__()` so it participates in the identity hash.
- Rename `metric_type` to `\"invalid_reference_count\"` so the two sibling classes can never collide on id even if all other base properties happen to match. The **public** diagnostic name `\"invalid_count\"` stays unchanged (it's the dict key in `evaluate()`; the rename only affects the internal `Measurement.metric_name`).

## Why not a shared base class with `RowsTestedQueryMetricImpl`?

Considered and rejected. The discriminators are fundamentally different:
- `RowsTestedQueryMetricImpl` needs the user-supplied raw SQL string in its identity — it overrides `_get_id_properties` to add it.
- `InvalidReferenceCountMetricImpl` only needs `check_filter` + `missing_and_validity` (including `ref_*` fields) — all already in `MetricImpl._get_id_properties`. No override needed.

A shared base would be a marker class with no shared behavior. Skipping.

## Test plan

- [x] New `test_two_invalid_reference_checks_with_different_filters_resolve_to_distinct_metrics` — two reference-invalid checks on `country` with `filter: id <= 4` and `filter: id > 4`; expected counts 1 and 2.
- [x] Test fails on pre-fix code (`assert 2 == 1` — both checks read the last-write-wins value), passes on this branch.
- [x] Full `soda-tests/tests/integration` suite green.
- [x] Full `soda-tests/tests/unit` suite green.
- [x] Pre-commit clean.
- [x] Independent reviewer pass — no findings.

## Linear

[DTL-1799](https://linear.app/sodadata/issue/DTL-1799/invalidreferencecountmetricimpl-shares-the-invalid-count-metric-type)