### PR TITLE
fix: normalize DB2 dashed-dotted TIMESTAMP literals in snapshot replay

### DIFF
--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -35,9 +35,11 @@ PicklableColumn = namedtuple(
 _SENTINEL = object()
 
 # Regex matching timestamps that appear as SQL string literals.
-# Matches ISO 8601 ('2026-03-16T18:24:35.151223', '2026-03-16T17:24:35+00:00')
-# and Oracle-style TIMESTAMP literals (TIMESTAMP '2026-03-18 14:09:40').
-_TIMESTAMP_RE = re.compile(r"(?:TIMESTAMP\s+)?'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.+\-]\S+)?'")
+# Matches ISO 8601 ('2026-03-16T18:24:35.151223', '2026-03-16T17:24:35+00:00'),
+# Oracle-style TIMESTAMP literals (TIMESTAMP '2026-03-18 14:09:40'), and the
+# DB2 dashed-dotted format (TIMESTAMP '2026-03-18-14.09.40.123456') where the
+# date-time separator is a dash and H/M/S are dot-separated.
+_TIMESTAMP_RE = re.compile(r"(?:TIMESTAMP\s+)?'\d{4}-\d{2}-\d{2}[T\- ]\d{2}[:.]\d{2}[:.]\d{2}(?:[.+\-]\S+)?'")
 _TIMESTAMP_PLACEHOLDER = "'__$$__SODA_TIMESTAMP__$$__'"
 
 # Regex matching __soda_temp_<uuid-hex> table names that use uuid4().hex.

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -907,6 +907,27 @@ class TestTimestampNormalization:
         assert "'__$$__SODA_TIMESTAMP__$$__'" in result
         assert "2026-03-18" not in result
 
+    def test_normalize_db2_dashed_dotted_timestamp_with_microseconds(self):
+        sql = "INSERT INTO t VALUES (TIMESTAMP '2026-05-15-21.09.16.123456')"
+        result = SnapshotDataSourceConnection._normalize_dynamic_values(sql)
+        assert "'__$$__SODA_TIMESTAMP__$$__'" in result
+        assert "2026-05-15" not in result
+
+    def test_normalize_db2_dashed_dotted_timestamp_without_microseconds(self):
+        sql = "INSERT INTO t VALUES (TIMESTAMP '2026-05-15-21.09.16')"
+        result = SnapshotDataSourceConnection._normalize_dynamic_values(sql)
+        assert "'__$$__SODA_TIMESTAMP__$$__'" in result
+        assert "2026-05-15" not in result
+
+    def test_sql_matches_db2_timestamps_with_different_values(self):
+        manager = SnapshotManager("db2", ".test_snapshots_temp")
+        conn = SnapshotDataSourceConnection(real_connection=None, snapshot_manager=manager, mode="replay")
+        conn.normalize_timestamps = True
+
+        stored = "INSERT INTO t VALUES (TIMESTAMP '2026-05-15-21.09.16.123456')"
+        incoming = "INSERT INTO t VALUES (TIMESTAMP '2026-06-01-08.30.45.000000')"
+        assert conn._sql_matches(stored, incoming)
+
     def test_normalize_timestamp_with_timezone(self):
         sql = "INSERT INTO t VALUES ('2026-03-16T17:24:35+00:00')"
         result = SnapshotDataSourceConnection._normalize_dynamic_values(sql)


### PR DESCRIPTION
The snapshot replay normalizer's timestamp regex only matched ISO and Oracle-style literals (colons in H:M:S, T/space between date and time). DB2's `literal_datetime` renders as `TIMESTAMP 'YYYY-MM-DD-HH.MM.SS.ffffff'`, so every `datetime.now()` inserted into the schema_versions table left a record-vs-replay mismatch on `*-db2` cross-source pairs.

## Description

Please provide a description of your changes:

- What problem are you solving?
- Any expected impact on downstream packages/services?
- Reference issue # if available.


## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
