### PR TITLE
return NOT_EVALUATED for percent checks

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -1741,8 +1741,9 @@ class DerivedPercentageMetricImpl(DerivedMetricImpl):
         if values is None:
             return None
         fraction, total = values
-        return (fraction * 100 / total) if total != 0 else 0
-
+        if total == 0:
+            return None  # No rows to evaluate; let evaluate_threshold return NOT_EVALUATED
+        return fraction * 100 / total
 
 class ValidCountMetric(AggregationMetricImpl):
     """TODO -- 3/10/2025: this metric is not used anywhere in the codebase, it's not clear if it's needed."""


### PR DESCRIPTION
fix: return NOT_EVALUATED for percent checks when row_count is zero

When a filter excludes all rows (row_count = 0), percent-based checks
(missing_percent, invalid_percent) previously computed 0.0 and evaluated
the threshold against it, causing unexpected FAILED results.

Return None from DerivedPercentageMetricImpl when total is 0 so that
evaluate_threshold correctly returns NOT_EVALUATED instead.

Fixes #2407