### PR TITLE
Chore: add [SKIP-TESTS] commit message matcher

### DIFF
--- a/.github/workflows/main.workflow.yaml
+++ b/.github/workflows/main.workflow.yaml
@@ -53,9 +53,32 @@ jobs:
         run: uv lock --check
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
-  define-test-matrix:
+  detect-skip-tests:
+    name: detect [SKIP-TESTS]
     runs-on: ubuntu-24.04
-    needs: [check]
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check commit message for [SKIP-TESTS] prefix
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.event.pull_request.head.sha }}" --depth=1
+            COMMIT_MSG=$(git log -1 --pretty=%s FETCH_HEAD)
+          else
+            COMMIT_MSG=$(git log -1 --pretty=%s)
+          fi
+          if [[ "$COMMIT_MSG" == "[SKIP-TESTS]"* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Commit message starts with [SKIP-TESTS] — tests will be skipped"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+  define-test-matrix:
+    if: needs.detect-skip-tests.outputs.skip != 'true'
+    runs-on: ubuntu-24.04
+    needs: [check, detect-skip-tests]
     outputs:
       modules: ${{ steps.modules.outputs.modules }}
     steps:
@@ -297,7 +320,9 @@ jobs:
         run: docker rm -f trino-ci 2>/dev/null || true
 
   define-matrix:
-    if: github.ref_name == 'main'
+    if: |
+      always() && !cancelled() && github.ref_name == 'main'
+      && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-24.04
     needs: [test]
     outputs:


### PR DESCRIPTION
## Summary
- Add a `detect-skip-tests` job that inspects the head commit's subject line.
- When the subject starts with `[SKIP-TESTS]`, gate `define-test-matrix` (and therefore the `test` matrix) off; pre-commit, lockfile check, and `release-to-dev-pypi` continue to run.
- Relax `define-matrix`'s gate so it tolerates a `skipped` test result alongside the existing `success` path (real test failures still block the release pipeline).

Mirrors the existing `[REPLAY=OFF]` commit-message convention.

## Test plan
- [ ] Push a commit prefixed with `[SKIP-TESTS]` on a throwaway branch and confirm: `check` runs, `detect-skip-tests` reports `skip=true`, `define-test-matrix` + `test` are skipped, `define-matrix` + `release-to-dev-pypi` proceed.
- [ ] Push a commit without the prefix and confirm the test matrix runs as before.
- [ ] Force a test failure on a non-skip commit and confirm `define-matrix` does NOT run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)