### PR TITLE
Fix: don't skip release-to-dev-pypi on [SKIP-TESTS] commits

### DIFF
--- a/.github/workflows/main.workflow.yaml
+++ b/.github/workflows/main.workflow.yaml
@@ -334,7 +334,14 @@ jobs:
         run: |
           echo modules=$(bash scripts/release_matrix.sh) >> "$GITHUB_OUTPUT"
   release-to-dev-pypi:
-    if: github.ref_name == 'main' # Pushes to "main" branch
+    # Mirror define-matrix's gating: without always() + an explicit
+    # needs.<job>.result check, GitHub Actions' default success() evaluates
+    # the *transitive* needs graph — so a [SKIP-TESTS] commit that skips
+    # `test` also skips this job, defeating the SKIP-TESTS contract
+    # (dev-pypi publish must still run on main).
+    if: |
+      always() && !cancelled() && github.ref_name == 'main'
+      && needs.define-matrix.result == 'success'
     runs-on: ubuntu-24.04
     needs: [define-matrix]
     strategy:


### PR DESCRIPTION
## Summary

The [SKIP-TESTS] gate added in #2710 was supposed to bypass the test matrix while still publishing dev artifacts on main. The dev-pypi publish regressed: `release-to-dev-pypi` is skipped when `[SKIP-TESTS]` causes the `test` job to skip — even though its direct dependency `define-matrix` succeeded.

**Cause:** GitHub Actions' default `success()` check on a job evaluates the *transitive* needs graph, so a skipped ancestor propagates as non-success. `define-matrix` already guards against this with `always() + needs.test.result == 'success' || == 'skipped'`. `release-to-dev-pypi` did not, so it was skipped on every bump-PR merge.

**Fix:** mirror the same pattern on `release-to-dev-pypi` — `always() && !cancelled() && github.ref_name == 'main' && needs.define-matrix.result == 'success'`.

## Observed in production

Run [26031647533](https://github.com/sodadata/soda-core/actions/runs/26031647533) (release_20260518_1 bump):

| job | conclusion | expected |
|---|---|---|
| pre-commit & lockfile | success | ✓ |
| detect [SKIP-TESTS] | success | ✓ |
| define-test-matrix | skipped | ✓ (SKIP-TESTS) |
| test | skipped | ✓ (SKIP-TESTS) |
| define-matrix | success | ✓ |
| **release-to-dev-pypi** | **skipped** | **should be success** |

## Test plan

- [ ] Merge an empty `[SKIP-TESTS]` commit to a branch off this PR (or rebump after merge) and confirm `release-to-dev-pypi` runs and publishes dev wheels.
- [ ] Confirm a normal (non-SKIP-TESTS) push to main still publishes dev wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)