### PR TITLE
add --dry-run flag to contract verify command

### DIFF
--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -215,6 +215,14 @@ def _setup_contract_verify_command(contract_parsers) -> None:
         help="Specify the path to the diagnostics warehouse configuration file. ",
     )
 
+    verify_parser.add_argument(
+    "--dry-run",
+    const=True,
+    action="store_const",
+    default=False,
+    help="Print the SQL queries that would be executed without running them against the data source.",
+)
+
     def handle(args):
         contract_file_path = args.contract
         dataset_identifier = args.dataset
@@ -228,6 +236,7 @@ def _setup_contract_verify_command(contract_parsers) -> None:
         use_agent = args.use_agent
         blocking_timeout_in_minutes = args.blocking_timeout_in_minutes
         diagnostics_warehouse_file_path = args.diagnostics_warehouse
+        dry_run = args.dry_run
 
         # Parse --check-filter expressions
         try:
@@ -249,6 +258,7 @@ def _setup_contract_verify_command(contract_parsers) -> None:
             args.check_paths,
             check_selectors,
             diagnostics_warehouse_file_path,
+            dry_run=dry_run,
         )
 
         exit_with_code(exit_code)


### PR DESCRIPTION
Fixes #2473

## Problem
Users running expensive queries (e.g. BigQuery) have no way to preview 
the SQL that Soda would execute before incurring costs.

## Changes
- Added `--dry-run` flag to `soda contract verify` CLI command
- When active, builds all SQL queries and logs them with `[DRY RUN]` 
  prefix without executing them against the data source
- Wired through: cli.py → handlers/contract.py → verify_api.py → 
  contract_verification_impl.py via existing 
  `only_validate_without_execute` parameter

## Usage
```bash
soda contract verify -ds datasource.yml -c contract.yml --dry-run
```