### PR TITLE
Rename Soda Agent to Soda Runner (backwards-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,18 +230,18 @@ Parameter | Required | Description
 `-p`,`--publish`| No | Publish results and contract to Soda Cloud. Requires "Manage contract" permission; [learn about permissions here](https://docs.soda.io/soda-v4/dataset-attributes-and-responsibilities).
 
 
-### Verify a contract remotely using Soda Agent
+### Verify a contract remotely using Soda Runner
 
-To verify contracts via Soda Cloud using the [Soda Agent](https://docs.soda.io/soda-v4/reference/soda-agent-basic-concepts),  configure a dataset and contract in Soda Cloud and configure an agent in your environment.  To obtain the Soda Cloud dataset identifier, for example `postgres_ds/db/schema/dataset`, open the contract in Soda Cloud, enable the `Toggle Code` control, and copy the identifier from the first line of the contract.  To launch contract verification:
+To verify contracts via Soda Cloud using the Soda Runner (formerly known as the Soda Agent), configure a dataset and contract in Soda Cloud and configure a runner in your environment.  To obtain the Soda Cloud dataset identifier, for example `postgres_ds/db/schema/dataset`, open the contract in Soda Cloud, enable the `Toggle Code` control, and copy the identifier from the first line of the contract.  To launch contract verification:
 
 ```
-soda contract verify -sc sc_config.yml -d postgres_ds/db/schema/dataset -a 
+soda contract verify -sc sc_config.yml -d postgres_ds/db/schema/dataset -r
 ```
 Parameter | Required | Description
 --- | --- | ---
-`-a`,`--use-agent`| Yes | Use Soda Agent for execution
-`-sc`,`--soda-cloud`| with `-a` | Path to a Soda Cloud YAML configuration file
-`-d`,`--dataset`| with `-a` | Soda Cloud dataset identifier
+`-r`,`--use-runner`| Yes | Use Soda Runner for execution. The legacy `-a`/`--use-agent` flag is still accepted as a deprecated alias.
+`-sc`,`--soda-cloud`| with `-r` | Path to a Soda Cloud YAML configuration file
+`-d`,`--dataset`| with `-r` | Soda Cloud dataset identifier
 `-p`,`--publish`| No | Publish results and contract to Soda Cloud. Requires "Manage contract" permission; [learn about permissions here](https://docs.soda.io/soda-v4/dataset-attributes-and-responsibilities).
 
 

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -471,12 +471,23 @@ class CheckCollectionImpl:
         self.dwh_data_source_file_path: Optional[str] = dwh_data_source_file_path
 
     @property
-    def is_test_verification_on_agent(self) -> bool:
-        """Whether this is a test scan running on the Soda Cloud agent.
+    def is_test_verification_on_runner(self) -> bool:
+        """Whether this is a test scan running on the Soda Cloud Runner (formerly Soda Agent).
 
         Default: False. Subclasses (``ContractImpl``) override.
         """
         return False
+
+    @property
+    def is_test_verification_on_agent(self) -> bool:
+        """Deprecated alias for :pyattr:`is_test_verification_on_runner`."""
+        from soda_core.common._deprecation import warn_deprecated
+
+        warn_deprecated(
+            f"{type(self).__name__}.is_test_verification_on_agent",
+            f"{type(self).__name__}.is_test_verification_on_runner",
+        )
+        return self.is_test_verification_on_runner
 
     @property
     def is_sampling_enabled(self) -> bool:
@@ -484,7 +495,7 @@ class CheckCollectionImpl:
 
     @property
     def should_apply_sampling(self) -> bool:
-        return self.is_test_verification_on_agent and self.is_sampling_enabled
+        return self.is_test_verification_on_runner and self.is_sampling_enabled
 
     def _dataset_checks_came_before_columns_in_yaml(self) -> Optional[bool]:
         keys: list[str] = self.yaml.yaml_object.keys()

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -629,7 +629,7 @@ class CheckCollectionImpl:
                 f"collection_id (used to prefix checkPath for backend routing)."
             )
 
-        if self.data_source_impl and self.soda_config.is_running_on_agent:
+        if self.data_source_impl and self.soda_config.is_running_on_runner:
             self.data_source_impl.switch_warehouse(self.compute_warehouse, contract_impl=self)
         data_source: Optional[DataSource] = None
         check_results: list[CheckResult] = []

--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import signal
 import sys
 import traceback
@@ -156,12 +157,22 @@ def _setup_contract_verify_command(contract_parsers) -> None:
         help="Set variable values to be used in the contract with format '--set <variable_name>=<variable_value>'.",
     )
     verify_parser.add_argument(
-        "-a",
-        "--use-agent",
+        "-r",
+        "--use-runner",
         const=True,
         action="store_const",
         default=False,
-        help="Executes contract verification on Soda Agent instead of locally in this library.",
+        help="Executes contract verification on the Soda Runner instead of locally in this library.",
+    )
+    # Deprecated alias kept for backwards compatibility (formerly Soda Agent).
+    verify_parser.add_argument(
+        "-a",
+        "--use-agent",
+        dest="use_agent_deprecated",
+        const=True,
+        action="store_const",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     verify_parser.add_argument(
         "-btm",
@@ -169,7 +180,7 @@ def _setup_contract_verify_command(contract_parsers) -> None:
         type=int,
         default=60,
         help="Max time in minutes that the CLI should wait for the contract "
-        "verification to complete on Soda Agent.  Default is 60 minutes.",
+        "verification to complete on the Soda Runner. Default is 60 minutes.",
     )
     verify_parser.add_argument(
         "-p",
@@ -225,7 +236,13 @@ def _setup_contract_verify_command(contract_parsers) -> None:
             exit_with_code(ExitCode.LOG_ERRORS)
         publish = args.publish
         verbose = args.verbose
-        use_agent = args.use_agent
+        use_runner = args.use_runner
+        if getattr(args, "use_agent_deprecated", False):
+            print(
+                "warning: -a/--use-agent is deprecated; use -r/--use-runner instead.",
+                file=sys.stderr,
+            )
+            use_runner = use_runner or args.use_agent_deprecated
         blocking_timeout_in_minutes = args.blocking_timeout_in_minutes
         diagnostics_warehouse_file_path = args.diagnostics_warehouse
 
@@ -244,7 +261,7 @@ def _setup_contract_verify_command(contract_parsers) -> None:
             variables,
             publish,
             verbose,
-            use_agent,
+            use_runner,
             blocking_timeout_in_minutes,
             args.check_paths,
             check_selectors,

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from soda_core.cli.exit_codes import ExitCode
+from soda_core.common._deprecation import deprecated_kwarg
 from soda_core.common.exceptions import (
     ContractParserException,
     InvalidArgumentException,
@@ -24,12 +25,21 @@ def handle_verify_contract(
     variables: Optional[Dict[str, str]],
     publish: bool,
     verbose: bool,
-    use_agent: bool,
-    blocking_timeout_in_minutes: int,
-    check_paths: Optional[list[str]],
-    check_selectors: list[CheckSelector],
-    diagnostics_warehouse_file_path: Optional[str],
+    use_runner: Optional[bool] = None,
+    blocking_timeout_in_minutes: int = 60,
+    check_paths: Optional[list[str]] = None,
+    check_selectors: Optional[list[CheckSelector]] = None,
+    diagnostics_warehouse_file_path: Optional[str] = None,
+    **kwargs,
 ) -> ExitCode:
+    if "use_agent" in kwargs:
+        use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
+    if kwargs:
+        raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+    if use_runner is None:
+        use_runner = False
+    if check_selectors is None:
+        check_selectors = []
     try:
         contract_verification_result = verify_contract(
             contract_file_path=contract_file_path,
@@ -40,7 +50,7 @@ def handle_verify_contract(
             variables=variables,
             publish=publish,
             verbose=verbose,
-            use_agent=use_agent,
+            use_runner=use_runner,
             blocking_timeout_in_minutes=blocking_timeout_in_minutes,
             check_paths=check_paths,
             check_selectors=check_selectors,

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -32,8 +32,7 @@ def handle_verify_contract(
     diagnostics_warehouse_file_path: Optional[str] = None,
     **kwargs,
 ) -> ExitCode:
-    if "use_agent" in kwargs:
-        use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
+    use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
     if kwargs:
         raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
     if use_runner is None:

--- a/soda-core/src/soda_core/common/_deprecation.py
+++ b/soda-core/src/soda_core/common/_deprecation.py
@@ -6,6 +6,11 @@ from typing import Any, Callable, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+# Sentinel used to distinguish "caller did not provide the new param" from "caller passed None/False/0".
+# Without this, callsites with a concrete default (e.g. `use_runner: bool = False`) would always
+# look "explicitly set" to deprecated_kwarg and trip the conflict check.
+_UNSET: Any = object()
+
 
 def warn_deprecated(old_name: str, new_name: str, stacklevel: int = 2) -> None:
     warnings.warn(
@@ -30,18 +35,22 @@ def deprecated_kwarg(
     kwargs: dict[str, Any],
     old_name: str,
     new_name: str,
-    current_new_value: Any = None,
-    sentinel: Any = None,
+    current_new_value: Any = _UNSET,
 ) -> Any:
     """Pop an old kwarg from kwargs, warn, and return the value to use for the new param.
 
-    Returns the new param's effective value. Raises TypeError if both old and new are passed with
-    conflicting values.
+    Use the ``Optional[T] = None`` + normalize-at-bottom pattern at the callsite so the new
+    param defaults to ``None`` when the caller didn't supply it. Both ``_UNSET`` and ``None``
+    are treated as "new param not supplied" by this helper; that means callsites can simply
+    forward the value of the new param without having to detect whether it was explicit.
+
+    Returns the effective value for the new param. Raises TypeError only when the caller
+    passed both the old and the new kwarg with conflicting non-None values.
     """
     if old_name not in kwargs:
         return current_new_value
     old_value = kwargs.pop(old_name)
     warn_deprecated(old_name, new_name, stacklevel=3)
-    if current_new_value not in (None, sentinel) and old_value != current_new_value:
-        raise TypeError(f"Cannot pass both {old_name} and {new_name} with conflicting values; use {new_name} only.")
-    return old_value
+    if current_new_value is _UNSET or current_new_value is None or current_new_value == old_value:
+        return old_value
+    raise TypeError(f"Cannot pass both {old_name} and {new_name} with conflicting values; use {new_name} only.")

--- a/soda-core/src/soda_core/common/_deprecation.py
+++ b/soda-core/src/soda_core/common/_deprecation.py
@@ -43,7 +43,5 @@ def deprecated_kwarg(
     old_value = kwargs.pop(old_name)
     warn_deprecated(old_name, new_name, stacklevel=3)
     if current_new_value not in (None, sentinel) and old_value != current_new_value:
-        raise TypeError(
-            f"Cannot pass both {old_name} and {new_name} with conflicting values; use {new_name} only."
-        )
+        raise TypeError(f"Cannot pass both {old_name} and {new_name} with conflicting values; use {new_name} only.")
     return old_value

--- a/soda-core/src/soda_core/common/_deprecation.py
+++ b/soda-core/src/soda_core/common/_deprecation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import Any, Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def warn_deprecated(old_name: str, new_name: str, stacklevel: int = 2) -> None:
+    warnings.warn(
+        f"{old_name} is deprecated and will be removed in a future release; use {new_name} instead.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
+
+
+def deprecated_alias(new_callable: Callable[..., Any], old_name: str, new_name: str) -> Callable[..., Any]:
+    @functools.wraps(new_callable)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        warn_deprecated(old_name, new_name, stacklevel=3)
+        return new_callable(*args, **kwargs)
+
+    wrapper.__name__ = old_name
+    wrapper.__qualname__ = old_name
+    return wrapper
+
+
+def deprecated_kwarg(
+    kwargs: dict[str, Any],
+    old_name: str,
+    new_name: str,
+    current_new_value: Any = None,
+    sentinel: Any = None,
+) -> Any:
+    """Pop an old kwarg from kwargs, warn, and return the value to use for the new param.
+
+    Returns the new param's effective value. Raises TypeError if both old and new are passed with
+    conflicting values.
+    """
+    if old_name not in kwargs:
+        return current_new_value
+    old_value = kwargs.pop(old_name)
+    warn_deprecated(old_name, new_name, stacklevel=3)
+    if current_new_value not in (None, sentinel) and old_value != current_new_value:
+        raise TypeError(
+            f"Cannot pass both {old_name} and {new_name} with conflicting values; use {new_name} only."
+        )
+    return old_value

--- a/soda-core/src/soda_core/common/env_config_helper.py
+++ b/soda-core/src/soda_core/common/env_config_helper.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from dotenv import load_dotenv
+from soda_core.common._deprecation import warn_deprecated
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.utils import strtobool
 
@@ -53,9 +54,16 @@ class EnvConfigHelper:
         return os.getenv("SODA_INSTRUCTION_ID")
 
     @property
-    def is_running_on_agent(self) -> bool:
-        # SODA_INSTRUCTION_ID is only set when running in Soda Agent
+    def is_running_on_runner(self) -> bool:
+        # SODA_INSTRUCTION_ID is only set when running in Soda Runner (formerly Soda Agent).
+        # The env var name itself remains SODA_INSTRUCTION_ID for backwards compatibility with
+        # existing Runner runtimes that set it.
         return self.soda_instruction_id is not None
+
+    @property
+    def is_running_on_agent(self) -> bool:
+        warn_deprecated("EnvConfigHelper.is_running_on_agent", "EnvConfigHelper.is_running_on_runner")
+        return self.is_running_on_runner
 
     @property
     def soda_scan_definition_type(self) -> str | None:

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -557,6 +557,16 @@ class SodaCloud:
 
     def verify_contract_on_agent(
         self,
+        *args,
+        **kwargs,
+    ) -> ContractVerificationResult:
+        from soda_core.common._deprecation import warn_deprecated
+
+        warn_deprecated("SodaCloud.verify_contract_on_agent", "SodaCloud.verify_contract_on_runner")
+        return self.verify_contract_on_runner(*args, **kwargs)
+
+    def verify_contract_on_runner(
+        self,
         contract_yaml: ContractYaml,
         variables: dict[str, str],
         blocking_timeout_in_minutes: int,

--- a/soda-core/src/soda_core/contracts/__init__.py
+++ b/soda-core/src/soda_core/contracts/__init__.py
@@ -4,16 +4,21 @@ from soda_core.contracts.api import (
     verify_contract,
     verify_contract_locally,
     verify_contract_on_agent,
+    verify_contract_on_runner,
     verify_contracts_locally,
     verify_contracts_on_agent,
+    verify_contracts_on_runner,
 )
 
 __all__ = [
     "test_contract",
     "verify_contract",
     "verify_contract_locally",
-    "verify_contract_on_agent",
+    "verify_contract_on_runner",
     "verify_contracts_locally",
+    "verify_contracts_on_runner",
+    # Deprecated aliases kept for backwards compatibility:
+    "verify_contract_on_agent",
     "verify_contracts_on_agent",
     "publish_contract",
 ]

--- a/soda-core/src/soda_core/contracts/api/__init__.py
+++ b/soda-core/src/soda_core/contracts/api/__init__.py
@@ -4,16 +4,21 @@ from soda_core.contracts.api.verify_api import (
     verify_contract,
     verify_contract_locally,
     verify_contract_on_agent,
+    verify_contract_on_runner,
     verify_contracts_locally,
     verify_contracts_on_agent,
+    verify_contracts_on_runner,
 )
 
 __all__ = [
     "test_contract",
     "verify_contract",
     "verify_contract_locally",
-    "verify_contract_on_agent",
+    "verify_contract_on_runner",
     "verify_contracts_locally",
+    "verify_contracts_on_runner",
+    # Deprecated aliases kept for backwards compatibility:
+    "verify_contract_on_agent",
     "verify_contracts_on_agent",
     "publish_contract",
 ]

--- a/soda-core/src/soda_core/contracts/api/test_api.py
+++ b/soda-core/src/soda_core/contracts/api/test_api.py
@@ -41,7 +41,7 @@ def test_contract(
         variables=variables,
         only_validate_without_execute=True,
         soda_cloud_publish_results=False,
-        soda_cloud_use_agent=False,
+        soda_cloud_use_runner=False,
         soda_cloud_verbose=verbose,
     )
 

--- a/soda-core/src/soda_core/contracts/api/verify_api.py
+++ b/soda-core/src/soda_core/contracts/api/verify_api.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Optional, Union
 
+from soda_core.common._deprecation import deprecated_kwarg, warn_deprecated
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import (
     InvalidArgumentException,
@@ -110,15 +111,15 @@ def verify_contract_locally(
         variables=variables,
         data_timestamp=data_timestamp,
         publish=publish,
-        use_agent=False,
+        use_runner=False,
         check_paths=check_paths,
         dwh_data_source_file_path=dwh_data_source_file_path,
         check_selectors=check_selectors,
     )
 
 
-@deprecated("Use verify_contract_on_agent instead")
-def verify_contracts_on_agent(
+@deprecated("Use verify_contract_on_runner instead")
+def verify_contracts_on_runner(
     soda_cloud_file_path: str,
     contract_file_paths: Optional[Union[str, list[str]]] = None,
     dataset_identifiers: Optional[list[str]] = None,
@@ -153,7 +154,7 @@ def verify_contracts_on_agent(
     contract_file_path = __attempt_pick_first_element(contract_file_paths)
     dataset_identifier = __attempt_pick_first_element(dataset_identifiers)
 
-    return verify_contract_on_agent(
+    return verify_contract_on_runner(
         soda_cloud_file_path=soda_cloud_file_path,
         contract_file_path=contract_file_path,
         dataset_identifier=dataset_identifier,
@@ -166,7 +167,13 @@ def verify_contracts_on_agent(
     )
 
 
-def verify_contract_on_agent(
+@deprecated("Use verify_contracts_on_runner instead")
+def verify_contracts_on_agent(*args, **kwargs) -> ContractVerificationSessionResult:
+    warn_deprecated("verify_contracts_on_agent", "verify_contracts_on_runner")
+    return verify_contracts_on_runner(*args, **kwargs)
+
+
+def verify_contract_on_runner(
     soda_cloud_file_path: str,
     contract_file_path: Optional[str] = None,
     dataset_identifier: Optional[str] = None,
@@ -178,7 +185,7 @@ def verify_contract_on_agent(
     blocking_timeout_in_minutes: int = 60,
 ) -> ContractVerificationSessionResult:
     """
-    Verifies the contract on an agent.
+    Verifies the contract on a Soda Runner (formerly Soda Agent).
     """
     return verify_contract(
         contract_file_path=contract_file_path,
@@ -189,9 +196,15 @@ def verify_contract_on_agent(
         variables=variables,
         publish=publish,
         verbose=verbose,
-        use_agent=True,
+        use_runner=True,
         blocking_timeout_in_minutes=blocking_timeout_in_minutes,
     )
+
+
+def verify_contract_on_agent(*args, **kwargs) -> ContractVerificationSessionResult:
+    """Deprecated alias for verify_contract_on_runner. Kept for backwards compatibility."""
+    warn_deprecated("verify_contract_on_agent", "verify_contract_on_runner")
+    return verify_contract_on_runner(*args, **kwargs)
 
 
 def verify_contract(
@@ -200,7 +213,7 @@ def verify_contract(
     data_source_file_path: Optional[str],
     soda_cloud_file_path: Optional[str],
     publish: bool,
-    use_agent: bool,
+    use_runner: Optional[bool] = None,
     variables: Optional[Dict[str, str]] = None,
     data_timestamp: Optional[str] = None,
     verbose: bool = False,
@@ -210,7 +223,14 @@ def verify_contract(
     check_paths: Optional[list[str]] = None,
     dwh_data_source_file_path: Optional[str] = None,
     check_selectors: Optional[list[CheckSelector]] = None,
+    **kwargs,
 ) -> ContractVerificationSessionResult:
+    if "use_agent" in kwargs:
+        use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
+    if kwargs:
+        raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+    if use_runner is None:
+        use_runner = False
     if not data_source_file_paths:
         data_source_file_paths = []
 
@@ -243,7 +263,7 @@ def verify_contract(
             data_source_file_paths,
             data_sources,
             publish,
-            use_agent,
+            use_runner,
             soda_cloud_client,
         )
 
@@ -258,7 +278,7 @@ def verify_contract(
             data_source_yaml_sources.extend(
                 _create_datasource_yamls(
                     data_source_file_paths,
-                    use_agent,
+                    use_runner,
                 )
             )
 
@@ -271,9 +291,9 @@ def verify_contract(
             data_timestamp=data_timestamp,
             only_validate_without_execute=False,
             soda_cloud_publish_results=publish,
-            soda_cloud_use_agent=use_agent,
+            soda_cloud_use_runner=use_runner,
             soda_cloud_verbose=verbose,
-            soda_cloud_use_agent_blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+            soda_cloud_use_runner_blocking_timeout_in_minutes=blocking_timeout_in_minutes,
             check_paths=check_paths,
             check_selectors=check_selectors,
             dwh_data_source_file_path=dwh_data_source_file_path,
@@ -297,7 +317,7 @@ def validate_verify_arguments(
     data_source_file_paths: Optional[list[str]],
     data_sources: Optional[list[DataSourceImpl]],
     publish: bool,
-    use_agent: bool,
+    use_runner: bool,
     soda_cloud_client: Optional[SodaCloud],
 ) -> None:
     if publish and not soda_cloud_client:
@@ -306,9 +326,9 @@ def validate_verify_arguments(
             "Please provide the '--soda-cloud' argument with a valid configuration file path."
         )
 
-    if use_agent and not soda_cloud_client:
+    if use_runner and not soda_cloud_client:
         raise InvalidArgumentException(
-            "A Soda Cloud configuration file is required to use the -a/--agent argument. "
+            "A Soda Cloud configuration file is required to use the -r/--runner argument. "
             "Please provide the '--soda-cloud' argument with a valid configuration file path."
         )
 
@@ -321,7 +341,7 @@ def validate_verify_arguments(
             "Please provide the '--soda-cloud' argument with a valid configuration file path."
         )
 
-    if not data_source_file_paths and not use_agent and not data_sources:
+    if not data_source_file_paths and not use_runner and not data_sources:
         raise InvalidArgumentException("At least one of -ds/--data-source or -d/--dataset value is required.")
 
 
@@ -370,7 +390,7 @@ def _create_contract_yamls(
 
 def _create_datasource_yamls(
     data_source_file_paths: Optional[list[str]],
-    use_agent: bool,
+    use_runner: bool,
 ) -> Optional[DataSourceYamlSource]:
     data_source_yamls: list[DataSourceYamlSource] = []
 
@@ -382,9 +402,9 @@ def _create_datasource_yamls(
     if data_source_yamls:
         return data_source_yamls
 
-    # By this point, we can only progress if we are using an agent.
-    # Then the agent will provide the data source config.
-    if use_agent:
+    # By this point, we can only progress if we are using a runner (formerly agent).
+    # Then the runner will provide the data source config.
+    if use_runner:
         return None
 
     raise InvalidDataSourceConfigurationException(

--- a/soda-core/src/soda_core/contracts/api/verify_api.py
+++ b/soda-core/src/soda_core/contracts/api/verify_api.py
@@ -167,10 +167,46 @@ def verify_contracts_on_runner(
     )
 
 
-@deprecated("Use verify_contracts_on_runner instead")
-def verify_contracts_on_agent(*args, **kwargs) -> ContractVerificationSessionResult:
-    warn_deprecated("verify_contracts_on_agent", "verify_contracts_on_runner")
-    return verify_contracts_on_runner(*args, **kwargs)
+@deprecated("Use verify_contract_on_runner instead")
+def verify_contracts_on_agent(
+    soda_cloud_file_path: str,
+    contract_file_paths: Optional[Union[str, list[str]]] = None,
+    dataset_identifiers: Optional[list[str]] = None,
+    data_source_file_path: Optional[str] = None,
+    data_source_file_paths: list[str] = [],
+    variables: Optional[Dict[str, str]] = None,
+    publish: bool = False,
+    verbose: bool = False,
+    blocking_timeout_in_minutes: int = 60,
+) -> ContractVerificationSessionResult:
+    # Don't route through ``verify_contracts_on_runner`` — that path is itself deprecated and
+    # would emit a second redundant warning. Apply the same first-element-pick that the plural
+    # variant did and delegate straight to the canonical singular function.
+    if not contract_file_paths and not dataset_identifiers:
+        raise InvalidArgumentException(__AT_LEAST_ONE_CONTRACT_OR_DATASET_REQUIRED)
+    if isinstance(contract_file_paths, str):
+        contract_file_paths = [contract_file_paths]
+    if contract_file_paths and len(contract_file_paths) > 1:
+        raise InvalidArgumentException("Only one contract is allowed at a time")
+    if dataset_identifiers and len(dataset_identifiers) > 1:
+        raise InvalidArgumentException("Only one dataset identifier is allowed at a time")
+    if contract_file_paths and dataset_identifiers:
+        logger.info(
+            "Both contract file paths and dataset identifiers are provided. Only evaluating the contract file paths."
+        )
+    contract_file_path = contract_file_paths[0] if contract_file_paths else None
+    dataset_identifier = dataset_identifiers[0] if dataset_identifiers else None
+    return verify_contract_on_runner(
+        soda_cloud_file_path=soda_cloud_file_path,
+        contract_file_path=contract_file_path,
+        dataset_identifier=dataset_identifier,
+        data_source_file_path=data_source_file_path,
+        data_source_file_paths=data_source_file_paths,
+        variables=variables,
+        publish=publish,
+        verbose=verbose,
+        blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+    )
 
 
 def verify_contract_on_runner(
@@ -225,8 +261,7 @@ def verify_contract(
     check_selectors: Optional[list[CheckSelector]] = None,
     **kwargs,
 ) -> ContractVerificationSessionResult:
-    if "use_agent" in kwargs:
-        use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
+    use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
     if kwargs:
         raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
     if use_runner is None:

--- a/soda-core/src/soda_core/contracts/contract_generator.py
+++ b/soda-core/src/soda_core/contracts/contract_generator.py
@@ -31,8 +31,10 @@ class IContractGenerator:
         output_file_path: Optional[str],
         verbose: bool,
         soda_cloud: Optional[SodaCloud],
-        use_agent: bool,
+        use_runner: bool = False,
         generate_checks: bool = True,
         include_type_parameters: bool = True,
+        **kwargs,
     ):
+        # Backwards-compat: accept legacy use_agent kwarg.
         raise NotImplementedError("No implementation for create_skeleton() yet. Please install an appropriate plugin.")

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -28,8 +28,8 @@ class ContractVerificationSession:
     @param data_source_yaml_sources: The data source YAML sources to use for the verification.
     @param soda_cloud_impl: The Soda Cloud implementation to use for the verification.
     @param soda_cloud_publish_results: If True, publish the results to Soda Cloud.
-    @param soda_cloud_use_agent: If True, use the Soda Cloud agent for the verification.
-    @param soda_cloud_verbose: If True, enable verbose logging for the Soda Cloud agent.
+    @param soda_cloud_use_runner: If True, use the Soda Cloud runner (formerly agent) for the verification.
+    @param soda_cloud_verbose: If True, enable verbose logging for the Soda Cloud runner.
     """
 
     @classmethod
@@ -43,17 +43,33 @@ class ContractVerificationSession:
         data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
         soda_cloud_impl: Optional["SodaCloud"] = None,
         soda_cloud_publish_results: bool = False,
-        soda_cloud_use_agent: bool = False,
+        soda_cloud_use_runner: bool = False,
         soda_cloud_verbose: bool = False,
-        soda_cloud_use_agent_blocking_timeout_in_minutes: int = 60,
+        soda_cloud_use_runner_blocking_timeout_in_minutes: int = 60,
         check_paths: Optional[list[str]] = None,
         dwh_data_source_file_path: Optional[str] = None,
         check_selectors: Optional[list["CheckSelector"]] = None,
+        **kwargs,
     ) -> ContractVerificationSessionResult:
+        from soda_core.common._deprecation import deprecated_kwarg
         from soda_core.contracts.impl.check_selector import CheckSelector
         from soda_core.contracts.impl.contract_verification_impl import (
             ContractVerificationSessionImpl,
         )
+
+        if "soda_cloud_use_agent" in kwargs:
+            soda_cloud_use_runner = deprecated_kwarg(
+                kwargs, "soda_cloud_use_agent", "soda_cloud_use_runner", soda_cloud_use_runner
+            )
+        if "soda_cloud_use_agent_blocking_timeout_in_minutes" in kwargs:
+            soda_cloud_use_runner_blocking_timeout_in_minutes = deprecated_kwarg(
+                kwargs,
+                "soda_cloud_use_agent_blocking_timeout_in_minutes",
+                "soda_cloud_use_runner_blocking_timeout_in_minutes",
+                soda_cloud_use_runner_blocking_timeout_in_minutes,
+            )
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
 
         # Merge check_paths into check_selectors for backward compatibility
         merged_selectors = list(check_selectors) if check_selectors else []
@@ -68,9 +84,9 @@ class ContractVerificationSession:
             data_source_yaml_sources=data_source_yaml_sources,
             soda_cloud_impl=soda_cloud_impl,
             soda_cloud_publish_results=soda_cloud_publish_results,
-            soda_cloud_use_agent=soda_cloud_use_agent,
+            soda_cloud_use_runner=soda_cloud_use_runner,
             soda_cloud_verbose=soda_cloud_verbose,
-            soda_cloud_use_agent_blocking_timeout_in_minutes=soda_cloud_use_agent_blocking_timeout_in_minutes,
+            soda_cloud_use_runner_blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
             check_selectors=merged_selectors,
             dwh_data_source_file_path=dwh_data_source_file_path,
         )

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -43,9 +43,9 @@ class ContractVerificationSession:
         data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
         soda_cloud_impl: Optional["SodaCloud"] = None,
         soda_cloud_publish_results: bool = False,
-        soda_cloud_use_runner: bool = False,
+        soda_cloud_use_runner: Optional[bool] = None,
         soda_cloud_verbose: bool = False,
-        soda_cloud_use_runner_blocking_timeout_in_minutes: int = 60,
+        soda_cloud_use_runner_blocking_timeout_in_minutes: Optional[int] = None,
         check_paths: Optional[list[str]] = None,
         dwh_data_source_file_path: Optional[str] = None,
         check_selectors: Optional[list["CheckSelector"]] = None,
@@ -57,19 +57,21 @@ class ContractVerificationSession:
             ContractVerificationSessionImpl,
         )
 
-        if "soda_cloud_use_agent" in kwargs:
-            soda_cloud_use_runner = deprecated_kwarg(
-                kwargs, "soda_cloud_use_agent", "soda_cloud_use_runner", soda_cloud_use_runner
-            )
-        if "soda_cloud_use_agent_blocking_timeout_in_minutes" in kwargs:
-            soda_cloud_use_runner_blocking_timeout_in_minutes = deprecated_kwarg(
-                kwargs,
-                "soda_cloud_use_agent_blocking_timeout_in_minutes",
-                "soda_cloud_use_runner_blocking_timeout_in_minutes",
-                soda_cloud_use_runner_blocking_timeout_in_minutes,
-            )
+        soda_cloud_use_runner = deprecated_kwarg(
+            kwargs, "soda_cloud_use_agent", "soda_cloud_use_runner", soda_cloud_use_runner
+        )
+        soda_cloud_use_runner_blocking_timeout_in_minutes = deprecated_kwarg(
+            kwargs,
+            "soda_cloud_use_agent_blocking_timeout_in_minutes",
+            "soda_cloud_use_runner_blocking_timeout_in_minutes",
+            soda_cloud_use_runner_blocking_timeout_in_minutes,
+        )
         if kwargs:
             raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+        if soda_cloud_use_runner is None:
+            soda_cloud_use_runner = False
+        if soda_cloud_use_runner_blocking_timeout_in_minutes is None:
+            soda_cloud_use_runner_blocking_timeout_in_minutes = 60
 
         # Merge check_paths into check_selectors for backward compatibility
         merged_selectors = list(check_selectors) if check_selectors else []

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -89,9 +89,9 @@ class ContractVerificationSessionImpl:
     @param data_source_yaml_sources: The data source YAML sources to use for the verification.
     @param soda_cloud_impl: The Soda Cloud implementation to use for the verification.
     @param soda_cloud_publish_results: If True, publish the results to Soda Cloud.
-    @param soda_cloud_use_agent: If True, use the Soda Cloud agent for the verification.
-    @param soda_cloud_verbose: If True, enable verbose logging for the Soda Cloud agent.
-    @param soda_cloud_use_agent_blocking_timeout_in_minutes: The timeout for the Soda Cloud agent.
+    @param soda_cloud_use_runner: If True, use the Soda Cloud Runner (formerly Soda Agent) for the verification.
+    @param soda_cloud_verbose: If True, enable verbose logging for the Soda Cloud Runner.
+    @param soda_cloud_use_runner_blocking_timeout_in_minutes: The timeout for the Soda Cloud Runner.
     @param dwh_data_source_file_path: The file path to the Diagnostics Warehouse data source.
     """
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -181,11 +181,11 @@ class ContractVerificationSessionImpl:
             check_selectors = []
 
         if soda_cloud_use_runner:
-            contract_verification_results: list[ContractVerificationResult] = cls._execute_on_agent(
+            contract_verification_results: list[ContractVerificationResult] = cls._execute_on_runner(
                 contract_yaml_sources=contract_yaml_sources,
                 variables=variables,
                 soda_cloud_impl=soda_cloud_impl,
-                soda_cloud_use_agent_blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
+                soda_cloud_use_runner_blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
                 soda_cloud_publish_results=soda_cloud_publish_results,
                 soda_cloud_verbose=soda_cloud_verbose,
             )
@@ -314,16 +314,16 @@ class ContractVerificationSessionImpl:
         return None
 
     @classmethod
-    def _execute_on_agent(
+    def _execute_on_runner(
         cls,
         contract_yaml_sources: list[ContractYamlSource],
         variables: dict[str, str],
         soda_cloud_impl: Optional[SodaCloud],
-        soda_cloud_use_agent_blocking_timeout_in_minutes: int,
+        soda_cloud_use_runner_blocking_timeout_in_minutes: int,
         soda_cloud_publish_results: bool,
         soda_cloud_verbose: bool,
     ) -> list[ContractVerificationResult]:
-        "Verifies Contracts on the Soda Cloud agent."
+        "Verifies Contracts on the Soda Cloud Runner (formerly agent)."
         contract_verification_results: list[ContractVerificationResult] = []
 
         for contract_yaml_source in contract_yaml_sources:
@@ -332,7 +332,7 @@ class ContractVerificationSessionImpl:
                     yaml_source=contract_yaml_source, provided_variable_values=variables
                 )
                 # Build a ContractImpl whose only job is to dispatch through
-                # ``verify_on_agent``. ``data_source_impl`` and
+                # ``verify_on_runner``. ``data_source_impl`` and
                 # ``soda_cloud_impl`` are left None on the impl, and
                 # ``only_validate_without_execute=True`` keeps the engine
                 # from connecting to a data source or executing queries.
@@ -343,7 +343,7 @@ class ContractVerificationSessionImpl:
                 # but any errors logged during the parse are popped from
                 # the impl's own ``Logs`` below and prepended onto the
                 # returned result — otherwise ``soda_cloud.verify_contract
-                # _on_agent``'s late-bound ``Logs()`` (which starts AFTER
+                # _on_runner``'s late-bound ``Logs()`` (which starts AFTER
                 # this construction) would silently drop them.
                 contract_impl: ContractImpl = ContractImpl(
                     yaml=contract_yaml,
@@ -352,10 +352,10 @@ class ContractVerificationSessionImpl:
                 init_log_records = contract_impl.logs.pop_log_records()
                 contract_impl.logs.remove_from_root_logger()
 
-                contract_verification_result: ContractVerificationResult = contract_impl.verify_on_agent(
+                contract_verification_result: ContractVerificationResult = contract_impl.verify_on_runner(
                     soda_cloud_impl=soda_cloud_impl,
                     variables=variables,
-                    blocking_timeout_in_minutes=soda_cloud_use_agent_blocking_timeout_in_minutes,
+                    blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
                     publish_results=soda_cloud_publish_results,
                     verbose=soda_cloud_verbose,
                 )
@@ -367,6 +367,27 @@ class ContractVerificationSessionImpl:
             except:
                 logger.error(msg=f"Could not verify contract {contract_yaml_source}", exc_info=True)
         return contract_verification_results
+
+    @classmethod
+    def _execute_on_agent(cls, *args, **kwargs) -> list[ContractVerificationResult]:
+        """Deprecated alias for :py:meth:`_execute_on_runner`."""
+        from soda_core.common._deprecation import warn_deprecated
+
+        warn_deprecated(
+            "ContractVerificationSessionImpl._execute_on_agent",
+            "ContractVerificationSessionImpl._execute_on_runner",
+        )
+        # Map the legacy timeout kwarg to the canonical one. We accept either name
+        # for backwards compatibility; the helper raises on conflicting values.
+        kwargs["soda_cloud_use_runner_blocking_timeout_in_minutes"] = deprecated_kwarg(
+            kwargs,
+            "soda_cloud_use_agent_blocking_timeout_in_minutes",
+            "soda_cloud_use_runner_blocking_timeout_in_minutes",
+            kwargs.get("soda_cloud_use_runner_blocking_timeout_in_minutes"),
+        )
+        if kwargs["soda_cloud_use_runner_blocking_timeout_in_minutes"] is None:
+            del kwargs["soda_cloud_use_runner_blocking_timeout_in_minutes"]
+        return cls._execute_on_runner(*args, **kwargs)
 
 
 class ContractImplExtension(Protocol):
@@ -489,15 +510,26 @@ class ContractImpl(CheckCollectionImpl):
         return data_source_impl
 
     @property
-    def is_test_verification_on_agent(self) -> bool:
+    def is_test_verification_on_runner(self) -> bool:
         """Contract-specific test-mode predicate.
 
-        True when running on the Soda Cloud agent in test-scan mode (as
-        determined by ``EnvConfigHelper`` env vars).
+        True when running on the Soda Cloud Runner (formerly agent) in test-scan mode
+        (as determined by ``EnvConfigHelper`` env vars).
         """
         return self.soda_config.is_running_on_runner and self.soda_config.is_contract_test_scan_definition_type
 
-    def verify_on_agent(
+    @property
+    def is_test_verification_on_agent(self) -> bool:
+        """Deprecated alias for :pyattr:`is_test_verification_on_runner`."""
+        from soda_core.common._deprecation import warn_deprecated
+
+        warn_deprecated(
+            "ContractImpl.is_test_verification_on_agent",
+            "ContractImpl.is_test_verification_on_runner",
+        )
+        return self.is_test_verification_on_runner
+
+    def verify_on_runner(
         self,
         soda_cloud_impl: SodaCloud,
         variables: dict,
@@ -512,6 +544,13 @@ class ContractImpl(CheckCollectionImpl):
             publish_results=publish_results,
             verbose=verbose,
         )
+
+    def verify_on_agent(self, *args, **kwargs) -> ContractVerificationResult:
+        """Deprecated alias for :py:meth:`verify_on_runner`."""
+        from soda_core.common._deprecation import warn_deprecated
+
+        warn_deprecated("ContractImpl.verify_on_agent", "ContractImpl.verify_on_runner")
+        return self.verify_on_runner(*args, **kwargs)
 
 
 def _get_contract_verification_status(has_errors: bool, check_results: list[CheckResult]) -> CheckCollectionStatus:

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -505,7 +505,7 @@ class ContractImpl(CheckCollectionImpl):
         publish_results: bool,
         verbose: bool,
     ) -> ContractVerificationResult:
-        return soda_cloud_impl.verify_contract_on_agent(
+        return soda_cloud_impl.verify_contract_on_runner(
             contract_yaml=self.yaml,
             variables=variables,
             blocking_timeout_in_minutes=blocking_timeout_in_minutes,

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from ruamel.yaml import YAML
 from soda_core.check_collections.base import CheckCollectionImpl
+from soda_core.common._deprecation import deprecated_kwarg
 from soda_core.common.consistent_hash_builder import ConsistentHashBuilder
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import InvalidRegexException, SodaCoreException
@@ -105,12 +106,32 @@ class ContractVerificationSessionImpl:
         data_source_yaml_sources: Optional[list[DataSourceYamlSource]] = None,
         soda_cloud_impl: Optional[SodaCloud] = None,
         soda_cloud_publish_results: bool = False,
-        soda_cloud_use_agent: bool = False,
+        soda_cloud_use_runner: Optional[bool] = None,
         soda_cloud_verbose: bool = False,
-        soda_cloud_use_agent_blocking_timeout_in_minutes: int = 60,
+        soda_cloud_use_runner_blocking_timeout_in_minutes: Optional[int] = None,
         check_selectors: Optional[list[CheckSelector]] = None,
         dwh_data_source_file_path: Optional[str] = None,
+        **kwargs,
     ):
+        # Backwards-compat: accept the legacy "agent" kwarg names. Optional[T] = None +
+        # normalize-at-bottom lets us forward the new param to deprecated_kwarg without
+        # tripping its conflict check when the caller only supplied the legacy name.
+        soda_cloud_use_runner = deprecated_kwarg(
+            kwargs, "soda_cloud_use_agent", "soda_cloud_use_runner", soda_cloud_use_runner
+        )
+        soda_cloud_use_runner_blocking_timeout_in_minutes = deprecated_kwarg(
+            kwargs,
+            "soda_cloud_use_agent_blocking_timeout_in_minutes",
+            "soda_cloud_use_runner_blocking_timeout_in_minutes",
+            soda_cloud_use_runner_blocking_timeout_in_minutes,
+        )
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+        if soda_cloud_use_runner is None:
+            soda_cloud_use_runner = False
+        if soda_cloud_use_runner_blocking_timeout_in_minutes is None:
+            soda_cloud_use_runner_blocking_timeout_in_minutes = 60
+
         logs: Logs = Logs()
 
         # Validate input contract_yaml_sources
@@ -139,7 +160,7 @@ class ContractVerificationSessionImpl:
         else:
             assert isinstance(data_source_yaml_sources, list)
             assert all(
-                isinstance(data_source_yaml_source, DataSourceYamlSource) or soda_cloud_use_agent
+                isinstance(data_source_yaml_source, DataSourceYamlSource) or soda_cloud_use_runner
                 for data_source_yaml_source in data_source_yaml_sources
             )
 
@@ -150,21 +171,21 @@ class ContractVerificationSessionImpl:
         # Validate input soda_cloud_skip_publish
         assert isinstance(soda_cloud_publish_results, bool)
 
-        # Validate input soda_cloud_use_agent
-        assert isinstance(soda_cloud_use_agent, bool)
+        # Validate input soda_cloud_use_runner
+        assert isinstance(soda_cloud_use_runner, bool)
 
-        # Validate input soda_cloud_use_agent_blocking_timeout_in_minutes
-        assert isinstance(soda_cloud_use_agent_blocking_timeout_in_minutes, int)
+        # Validate input soda_cloud_use_runner_blocking_timeout_in_minutes
+        assert isinstance(soda_cloud_use_runner_blocking_timeout_in_minutes, int)
 
         if check_selectors is None:
             check_selectors = []
 
-        if soda_cloud_use_agent:
+        if soda_cloud_use_runner:
             contract_verification_results: list[ContractVerificationResult] = cls._execute_on_agent(
                 contract_yaml_sources=contract_yaml_sources,
                 variables=variables,
                 soda_cloud_impl=soda_cloud_impl,
-                soda_cloud_use_agent_blocking_timeout_in_minutes=soda_cloud_use_agent_blocking_timeout_in_minutes,
+                soda_cloud_use_agent_blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
                 soda_cloud_publish_results=soda_cloud_publish_results,
                 soda_cloud_verbose=soda_cloud_verbose,
             )
@@ -474,7 +495,7 @@ class ContractImpl(CheckCollectionImpl):
         True when running on the Soda Cloud agent in test-scan mode (as
         determined by ``EnvConfigHelper`` env vars).
         """
-        return self.soda_config.is_running_on_agent and self.soda_config.is_contract_test_scan_definition_type
+        return self.soda_config.is_running_on_runner and self.soda_config.is_contract_test_scan_definition_type
 
     def verify_on_agent(
         self,

--- a/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
+++ b/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
@@ -37,8 +37,38 @@
                 "additionalProperties": false
             }
         },
+        "soda_runner": {
+            "description": "The runner configuration to be used within the contract file. Replaces 'soda_agent'; both keys are accepted for backwards compatibility but not at the same time.",
+            "type": "object",
+            "properties": {
+                "checks_schedule": {
+                    "type": "object",
+                    "properties": {
+                        "cron": {
+                            "type": "string",
+                            "description": "Cron expression in the format '* * * * *' (minute hour day month weekday). Requires string in quotes."
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "description": "The timezone to be used within the contract file"
+                        },
+                        "variables": {
+                            "type": "object",
+                            "description": "The variables to be used within the contract file",
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "number"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "soda_agent": {
-            "description": "The agent configuration to be used within the contract file",
+            "description": "DEPRECATED: use 'soda_runner' instead. The runner configuration to be used within the contract file. Kept for backwards compatibility.",
             "type": "object",
             "properties": {
                 "checks_schedule": {
@@ -844,6 +874,47 @@
     "required": [
         "dataset",
         "columns"
+    ],
+    "oneOf": [
+        {
+            "description": "Contract uses the canonical 'soda_runner' key.",
+            "required": [
+                "soda_runner"
+            ],
+            "not": {
+                "required": [
+                    "soda_agent"
+                ]
+            }
+        },
+        {
+            "description": "DEPRECATED: contract uses the legacy 'soda_agent' key.",
+            "required": [
+                "soda_agent"
+            ],
+            "not": {
+                "required": [
+                    "soda_runner"
+                ]
+            }
+        },
+        {
+            "description": "Contract has neither soda_runner nor soda_agent.",
+            "not": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "soda_runner"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "soda_agent"
+                        ]
+                    }
+                ]
+            }
+        }
     ],
     "$defs": {
         "generic_check_properties": {

--- a/soda-snowflake/tests/data_sources/test_warehouse_switching.py
+++ b/soda-snowflake/tests/data_sources/test_warehouse_switching.py
@@ -34,7 +34,7 @@ def stub_get_current_warehouse_none() -> Optional[str]:
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=True),
 )
 @mock.patch(
@@ -46,7 +46,7 @@ def stub_get_current_warehouse_none() -> Optional[str]:
     side_effect=stub_get_current_warehouse,
 )
 def test_warehouse_switching(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_switch_warehouse,
     mocked_get_current_warehouse,
     data_source_test_helper: DataSourceTestHelper,
@@ -77,7 +77,7 @@ def test_warehouse_switching(
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=True),
 )
 @mock.patch(
@@ -89,7 +89,7 @@ def test_warehouse_switching(
     side_effect=stub_get_current_warehouse_none,
 )
 def test_warehouse_switching_no_current_wh(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_switch_warehouse,
     mocked_get_current_warehouse,
     data_source_test_helper: DataSourceTestHelper,

--- a/soda-sparkdf/tests/data_sources/test_sparkdf.py
+++ b/soda-sparkdf/tests/data_sources/test_sparkdf.py
@@ -116,7 +116,7 @@ def test_more_complex_setup_with_existing_session(data_source_test_helper: DataS
         variables=None,
         data_source_impls=[my_data_source_impl],
         soda_cloud_impl=mock_cloud,
-        soda_cloud_use_agent=False,
+        soda_cloud_use_runner=False,
         soda_cloud_publish_results=False,
         dwh_data_source_file_path=None,
     )

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -317,7 +317,7 @@ class DataSourceTestHelper:
         self._ensured_test_tables: dict[str, TestTable] = {}
 
         self.soda_cloud: Optional[SodaCloud] = None
-        self.use_agent: bool = False
+        self.use_runner: bool = False
 
         # Session-level metadata cache (only active in record mode).
         # Tracks the metadata query SQL and a mutable QueryResult that is kept
@@ -1062,7 +1062,7 @@ class DataSourceTestHelper:
             variables=variables,
             data_source_impls=[self.data_source_impl],
             soda_cloud_impl=self.soda_cloud,
-            soda_cloud_use_agent=self.use_agent,
+            soda_cloud_use_runner=self.use_runner,
             soda_cloud_publish_results=True,
         )
 
@@ -1191,7 +1191,7 @@ class DataSourceTestHelper:
             variables=variables,
             data_source_impls=[self.data_source_impl, *extra_data_source_impls],
             soda_cloud_impl=self.soda_cloud,
-            soda_cloud_use_agent=self.use_agent,
+            soda_cloud_use_runner=self.use_runner,
             soda_cloud_publish_results=publish_results,
             dwh_data_source_file_path=dwh_data_source_file_path,
             check_paths=check_paths,
@@ -1212,10 +1212,19 @@ class DataSourceTestHelper:
         dqn: str = "/".join(dqn_parts)
         return dqn
 
+    @property
+    def use_agent(self) -> bool:
+        # Deprecated alias for backwards compatibility with existing tests.
+        return self.use_runner
+
+    @use_agent.setter
+    def use_agent(self, value: bool) -> None:
+        self.use_runner = value
+
     def test_method_ended(self) -> None:
         # self.data_source_impl.data_source_connection.rollback() #TODO: this was originally done to theoretically speed up tests, but needs some datasource-specific work.
         self.soda_cloud = None
-        self.use_agent = False
+        self.use_runner = False
         if self._snapshot_mode != "off":
             # Reset the table name cache so the next test re-queries existing tables.
             # This makes each test's snapshot self-contained (always starts with the

--- a/soda-tests/src/helpers/impl_test_helpers.py
+++ b/soda-tests/src/helpers/impl_test_helpers.py
@@ -137,6 +137,6 @@ def validate_contract(yaml_str: str, variables: Optional[dict[str, str | int | f
         only_validate_without_execute=True,
         variables=variables,
         soda_cloud_publish_results=False,
-        soda_cloud_use_agent=False,
+        soda_cloud_use_runner=False,
     )
     return result

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -485,7 +485,7 @@ def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=True),
 )
 @mock.patch(
@@ -493,7 +493,7 @@ def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source
     new_callable=mock.PropertyMock(return_value=True),
 )
 def test_failed_rows_rows_tested_query_sampling_applied(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_is_contract_test_scan_definition_type,
     data_source_test_helper: DataSourceTestHelper,
 ):
@@ -547,7 +547,7 @@ def test_failed_rows_rows_tested_query_sampling_applied(
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=False),
 )
 @mock.patch(
@@ -555,7 +555,7 @@ def test_failed_rows_rows_tested_query_sampling_applied(
     new_callable=mock.PropertyMock(return_value=False),
 )
 def test_failed_rows_rows_tested_query_sampling_not_applied(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_is_contract_test_scan_definition_type,
     data_source_test_helper: DataSourceTestHelper,
 ):

--- a/soda-tests/tests/integration/test_sampling.py
+++ b/soda-tests/tests/integration/test_sampling.py
@@ -43,7 +43,7 @@ country_test_table_specification = (
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=True),
 )
 @mock.patch(
@@ -51,7 +51,7 @@ country_test_table_specification = (
     new_callable=mock.PropertyMock(return_value=True),
 )
 def test_sampling_simple_pass(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_is_contract_test_scan_definition_type,
     data_source_test_helper: DataSourceTestHelper,
 ):
@@ -129,7 +129,7 @@ def test_sampling_simple_pass(
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=False),
 )
 @mock.patch(
@@ -137,7 +137,7 @@ def test_sampling_simple_pass(
     new_callable=mock.PropertyMock(return_value=False),
 )
 def test_sampling_not_applied_simple_pass(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_is_contract_test_scan_definition_type,
     data_source_test_helper: DataSourceTestHelper,
 ):
@@ -212,7 +212,7 @@ def test_sampling_not_applied_simple_pass(
 
 
 @mock.patch(
-    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_agent",
+    "soda_core.common.env_config_helper.EnvConfigHelper.is_running_on_runner",
     new_callable=mock.PropertyMock(return_value=True),
 )
 @mock.patch(
@@ -220,7 +220,7 @@ def test_sampling_not_applied_simple_pass(
     new_callable=mock.PropertyMock(return_value=True),
 )
 def test_sampling_custom_sql_pass(
-    mocked_is_running_on_agent,
+    mocked_is_running_on_runner,
     mocked_is_contract_test_scan_definition_type,
     data_source_test_helper: DataSourceTestHelper,
 ):

--- a/soda-tests/tests/unit/manual_test_runner_flow.py
+++ b/soda-tests/tests/unit/manual_test_runner_flow.py
@@ -1,0 +1,53 @@
+from textwrap import dedent
+
+from dotenv import load_dotenv
+from soda_core.common.logging_configuration import configure_logging
+from soda_core.common.soda_cloud import SodaCloud
+from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
+from soda_core.contracts.contract_verification import ContractVerificationSession
+
+
+def main():
+    print("Verifying contract on runner")
+    configure_logging()
+
+    project_root_dir = __file__[: -len("/soda-core/tests/soda_core/tests/components/manual_test_runner_flow.py")]
+    load_dotenv(f"{project_root_dir}/.env", override=True)
+
+    contract_yaml_str: str = dedent(
+        """
+        data_source: bus_nienu
+        dataset_prefix: [nyc, public]
+        dataset: bus_breakdown_and_delays
+        columns:
+          - name: reason
+            checks:
+              - invalid:
+                  valid_values: [ 'Heavy Traffic', 'Other', 'Mechanical Problem', 'Won`t Start', 'Problem Run' ]
+        checks:
+          - schema:
+    """
+    ).strip()
+
+    soda_cloud_yaml_str = dedent(
+        """
+        soda_cloud:
+          api_key_id: ${SODA_CLOUD_API_KEY_ID}
+          api_key_secret: ${SODA_CLOUD_API_KEY_SECRET}
+    """
+    ).strip()
+
+    soda_cloud: SodaCloud = SodaCloud.from_yaml_source(
+        SodaCloudYamlSource.from_str(soda_cloud_yaml_str), provided_variable_values={}
+    )
+
+    ContractVerificationSession.execute(
+        contract_yaml_sources=[ContractYamlSource.from_str(contract_yaml_str)],
+        soda_cloud_impl=soda_cloud,
+        soda_cloud_use_runner=True,
+        soda_cloud_use_runner_blocking_timeout_in_minutes=55,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/soda-tests/tests/unit/test_agent_path_log_propagation.py
+++ b/soda-tests/tests/unit/test_agent_path_log_propagation.py
@@ -68,7 +68,7 @@ def test_execute_on_agent_propagates_impl_init_logs_to_result(monkeypatch):
             log_records=[],
         )
 
-    monkeypatch.setattr(ContractImpl, "verify_on_agent", fake_verify_on_agent)
+    monkeypatch.setattr(ContractImpl, "verify_on_runner", fake_verify_on_agent)
 
     yaml_str = "dataset: ds/db/schema/orders\ncolumns:\n  - name: id\n"
     session_result = ContractVerificationSession.execute(
@@ -114,7 +114,7 @@ def test_execute_on_agent_does_not_leak_impl_logs_to_root_logger_across_items(mo
             log_records=[],
         )
 
-    monkeypatch.setattr(ContractImpl, "verify_on_agent", fake_verify_on_agent)
+    monkeypatch.setattr(ContractImpl, "verify_on_runner", fake_verify_on_agent)
 
     yaml_str = "dataset: ds/db/schema/orders\ncolumns:\n  - name: id\n"
     ContractVerificationSession.execute(

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -53,7 +53,7 @@ def test_handle_verify_contract_exit_codes(
         variables={},
         publish=True,
         verbose=False,
-        use_agent=False,
+        use_runner=False,
         blocking_timeout_in_minutes=10,
         check_paths=None,
         check_selectors=[],
@@ -61,6 +61,38 @@ def test_handle_verify_contract_exit_codes(
     )
 
     assert exit_code == expected_exit_code
+
+
+@patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
+@patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
+def test_handle_verify_contract_use_agent_kwarg_deprecated(mock_execute, mock_cloud_client):
+    """Backwards-compat: the legacy ``use_agent`` kwarg still works and emits a DeprecationWarning."""
+    mock_contract_result = MagicMock()
+    mock_contract_result.sending_results_to_soda_cloud_failed = False
+    mock_result = MagicMock()
+    type(mock_result).has_errors = PropertyMock(return_value=False)
+    type(mock_result).is_failed = PropertyMock(return_value=False)
+    type(mock_result).is_warned = PropertyMock(return_value=False)
+    mock_result.contract_verification_results = [mock_contract_result]
+    mock_execute.return_value = mock_result
+
+    with pytest.warns(DeprecationWarning, match="use_agent"):
+        exit_code = handle_verify_contract(
+            contract_file_path="contract.yaml",
+            dataset_identifier=None,
+            data_source_file_paths=["ds.yaml"],
+            soda_cloud_file_path="sc.yaml",
+            variables={},
+            publish=True,
+            verbose=False,
+            use_agent=False,
+            blocking_timeout_in_minutes=10,
+            check_paths=None,
+            check_selectors=[],
+            diagnostics_warehouse_file_path=None,
+        )
+
+    assert exit_code == ExitCode.OK
 
 
 @pytest.mark.parametrize(

--- a/soda-tests/tests/unit/test_contract_verification_api.py
+++ b/soda-tests/tests/unit/test_contract_verification_api.py
@@ -343,10 +343,7 @@ def test_local_flow_with_dataset_but_no_datasource_raises_error(mock_cloud_clien
 def test_verify_contract_on_agent_alias_emits_deprecation_warning(monkeypatch):
     """The legacy public ``verify_contract_on_agent`` function emits a DeprecationWarning
     and delegates to ``verify_contract_on_runner``."""
-    from soda_core.contracts.api.verify_api import (
-        verify_contract_on_agent,
-        verify_contract_on_runner,
-    )
+    from soda_core.contracts.api.verify_api import verify_contract_on_agent
 
     called = {}
 

--- a/soda-tests/tests/unit/test_contract_verification_api.py
+++ b/soda-tests/tests/unit/test_contract_verification_api.py
@@ -86,10 +86,31 @@ def test_handle_verify_contract_raises_exception_when_using_dataset_names_withou
             soda_cloud_file_path=None,
             variables={},
             publish=False,
-            use_agent=False,
+            use_runner=False,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
+
+
+def test_handle_verify_contract_raises_exception_when_using_dataset_names_without_cloud_configuration_agent_deprecated():
+    """Deprecated alias: verifies the legacy ``use_agent`` kwarg still works and emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="use_agent"):
+        with pytest.raises(
+            InvalidArgumentException,
+            match="A Soda Cloud configuration file is required to use the -d/--dataset argument."
+            "Please provide the '--soda-cloud' argument with a valid configuration file path.",
+        ):
+            _ = verify_contract(
+                contract_file_path=None,
+                dataset_identifier="some_dataset",
+                data_source_file_path="ds.yaml",
+                soda_cloud_file_path=None,
+                variables={},
+                publish=False,
+                use_agent=False,
+                verbose=False,
+                blocking_timeout_in_minutes=10,
+            )
 
 
 def test_handle_verify_contract_returns_exit_code_3_when_using_publish_without_cloud_configuration():
@@ -105,10 +126,30 @@ def test_handle_verify_contract_returns_exit_code_3_when_using_publish_without_c
             soda_cloud_file_path=None,
             variables={},
             publish=True,
-            use_agent=False,
+            use_runner=False,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
+
+
+def test_handle_verify_contract_returns_exit_code_3_when_using_publish_without_cloud_configuration_agent_deprecated():
+    with pytest.warns(DeprecationWarning, match="use_agent"):
+        with pytest.raises(
+            InvalidArgumentException,
+            match="A Soda Cloud configuration file is required to use the -p/--publish argument. "
+            "Please provide the '--soda-cloud' argument with a valid configuration file path.",
+        ):
+            _ = verify_contract(
+                contract_file_path=None,
+                dataset_identifier="some_dataset",
+                data_source_file_path="ds.yaml",
+                soda_cloud_file_path=None,
+                variables={},
+                publish=True,
+                use_agent=False,
+                verbose=False,
+                blocking_timeout_in_minutes=10,
+            )
 
 
 @patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
@@ -125,7 +166,7 @@ def test_handle_verify_contract_returns_exit_code_3_when_no_contract_file_paths_
             soda_cloud_file_path="sc.yaml",
             variables={},
             publish=True,
-            use_agent=False,
+            use_runner=False,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
@@ -145,7 +186,7 @@ def test_handle_verify_contract_returns_exit_code_3_when_no_data_source_configur
             soda_cloud_file_path="sc.yaml",
             variables={},
             publish=True,
-            use_agent=False,
+            use_runner=False,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
@@ -166,7 +207,7 @@ def test_handle_verify_contract_returns_exit_code_0_when_no_data_source_configur
             soda_cloud_file_path="sc.yaml",
             variables={},
             publish=True,
-            use_agent=True,
+            use_runner=True,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
@@ -187,7 +228,7 @@ def test_handle_verify_contract_skips_contract_when_contract_fetching_from_cloud
         soda_cloud_file_path="sc.yaml",
         variables={},
         publish=True,
-        use_agent=False,
+        use_runner=False,
         verbose=False,
         blocking_timeout_in_minutes=10,
     )
@@ -208,7 +249,7 @@ def test_handle_verify_contract_returns_exit_code_0_when_no_valid_remote_contrac
         soda_cloud_file_path="sc.yaml",
         variables={},
         publish=True,
-        use_agent=False,
+        use_runner=False,
         verbose=False,
         blocking_timeout_in_minutes=10,
     )
@@ -218,7 +259,7 @@ def test_handle_verify_contract_returns_exit_code_0_when_no_valid_remote_contrac
 
 def test_local_flow_does_not_fetch_datasource_config_from_cloud():
     """
-    In the local flow (use_agent=False), _create_datasource_yamls
+    In the local flow (use_runner=False), _create_datasource_yamls
     should NOT call fetch_data_source_configuration_for_dataset on the
     SodaCloud client. Fetching datasource configs from Cloud in the local
     flow is a security risk — it can expose host/connection info to users
@@ -230,7 +271,7 @@ def test_local_flow_does_not_fetch_datasource_config_from_cloud():
     with pytest.raises(InvalidDataSourceConfigurationException):
         _create_datasource_yamls(
             data_source_file_paths=[],
-            use_agent=False,
+            use_runner=False,
         )
 
 
@@ -244,21 +285,33 @@ def test_local_flow_with_dataset_identifier_uses_local_datasource_config(tmp_pat
 
     result = _create_datasource_yamls(
         data_source_file_paths=[str(ds_file)],
-        use_agent=False,
+        use_runner=False,
     )
 
     assert len(result) == 1
 
 
-def test_agent_flow_without_local_datasource_returns_none():
+def test_runner_flow_without_local_datasource_returns_none():
     """
-    In agent flow (use_agent=True), when no local data source files
-    are provided, return None (agent provides its own config). Should NOT
+    In runner flow (use_runner=True), when no local data source files
+    are provided, return None (runner provides its own config). Should NOT
     fetch from Cloud.
     """
     result = _create_datasource_yamls(
         data_source_file_paths=[],
-        use_agent=True,
+        use_runner=True,
+    )
+
+    assert result is None
+
+
+def test_agent_flow_without_local_datasource_returns_none_deprecated():
+    """Deprecated alias for the runner flow test above; preserved for backwards compat."""
+    # _create_datasource_yamls is a private helper with no legacy kwarg name, but the public
+    # surface that calls it accepts both. This test now just mirrors the runner-named one.
+    result = _create_datasource_yamls(
+        data_source_file_paths=[],
+        use_runner=True,
     )
 
     assert result is None
@@ -278,7 +331,52 @@ def test_local_flow_with_dataset_but_no_datasource_raises_error(mock_cloud_clien
             soda_cloud_file_path="sc.yaml",
             variables={},
             publish=False,
-            use_agent=False,
+            use_runner=False,
             verbose=False,
             blocking_timeout_in_minutes=10,
         )
+
+
+# Backwards-compat smoke tests for the deprecated public API names.
+
+
+def test_verify_contract_on_agent_alias_emits_deprecation_warning(monkeypatch):
+    """The legacy public ``verify_contract_on_agent`` function emits a DeprecationWarning
+    and delegates to ``verify_contract_on_runner``."""
+    from soda_core.contracts.api.verify_api import (
+        verify_contract_on_agent,
+        verify_contract_on_runner,
+    )
+
+    called = {}
+
+    def fake_runner(**kwargs):
+        called.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(
+        "soda_core.contracts.api.verify_api.verify_contract_on_runner",
+        fake_runner,
+    )
+
+    with pytest.warns(DeprecationWarning, match="verify_contract_on_agent"):
+        result = verify_contract_on_agent(soda_cloud_file_path="sc.yaml", contract_file_path="c.yaml")
+
+    assert result == "ok"
+    assert called["soda_cloud_file_path"] == "sc.yaml"
+
+
+def test_verify_contracts_on_agent_alias_emits_deprecation_warning(monkeypatch):
+    from soda_core.contracts.api.verify_api import verify_contracts_on_agent
+
+    monkeypatch.setattr(
+        "soda_core.contracts.api.verify_api.verify_contracts_on_runner",
+        lambda **kwargs: "ok",
+    )
+
+    with pytest.warns(DeprecationWarning, match="verify_contracts_on_agent"):
+        result = verify_contracts_on_agent(
+            soda_cloud_file_path="sc.yaml", contract_file_paths=["c.yaml"], dataset_identifiers=[]
+        )
+
+    assert result == "ok"

--- a/soda-tests/tests/unit/test_contract_verification_api.py
+++ b/soda-tests/tests/unit/test_contract_verification_api.py
@@ -305,18 +305,6 @@ def test_runner_flow_without_local_datasource_returns_none():
     assert result is None
 
 
-def test_agent_flow_without_local_datasource_returns_none_deprecated():
-    """Deprecated alias for the runner flow test above; preserved for backwards compat."""
-    # _create_datasource_yamls is a private helper with no legacy kwarg name, but the public
-    # surface that calls it accepts both. This test now just mirrors the runner-named one.
-    result = _create_datasource_yamls(
-        data_source_file_paths=[],
-        use_runner=True,
-    )
-
-    assert result is None
-
-
 @patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
 def test_local_flow_with_dataset_but_no_datasource_raises_error(mock_cloud_client):
     """

--- a/soda-tests/tests/unit/test_contract_verification_api.py
+++ b/soda-tests/tests/unit/test_contract_verification_api.py
@@ -364,16 +364,79 @@ def test_verify_contract_on_agent_alias_emits_deprecation_warning(monkeypatch):
 
 
 def test_verify_contracts_on_agent_alias_emits_deprecation_warning(monkeypatch):
+    """The legacy plural ``verify_contracts_on_agent`` delegates straight to the canonical
+    singular ``verify_contract_on_runner`` and emits exactly one DeprecationWarning (from the
+    ``@deprecated`` decorator)."""
     from soda_core.contracts.api.verify_api import verify_contracts_on_agent
 
+    called = {}
+
+    def fake_singular(**kwargs):
+        called.update(kwargs)
+        return "ok"
+
     monkeypatch.setattr(
-        "soda_core.contracts.api.verify_api.verify_contracts_on_runner",
-        lambda **kwargs: "ok",
+        "soda_core.contracts.api.verify_api.verify_contract_on_runner",
+        fake_singular,
     )
 
-    with pytest.warns(DeprecationWarning, match="verify_contracts_on_agent"):
+    with pytest.warns(DeprecationWarning, match="verify_contract_on_runner") as records:
         result = verify_contracts_on_agent(
-            soda_cloud_file_path="sc.yaml", contract_file_paths=["c.yaml"], dataset_identifiers=[]
+            soda_cloud_file_path="sc.yaml",
+            contract_file_paths=["c.yaml"],
+            dataset_identifiers=None,
         )
 
+    # Exactly one DeprecationWarning fires (from the @deprecated decorator). The previous
+    # implementation fired three: decorator + explicit warn + decorator-on-delegate.
+    assert len(records) == 1, f"expected one DeprecationWarning, got {len(records)}"
     assert result == "ok"
+    assert called["contract_file_path"] == "c.yaml"
+    assert called["soda_cloud_file_path"] == "sc.yaml"
+
+
+# Direct ContractVerificationSession.execute backwards-compat tests for the legacy kwargs.
+# These exercise the code path that previously raised TypeError on `soda_cloud_use_agent=...`
+# because of a bug in `_deprecation.deprecated_kwarg`.
+
+
+def test_contract_verification_session_execute_accepts_legacy_soda_cloud_use_agent():
+    """``ContractVerificationSession.execute(soda_cloud_use_agent=True)`` must not raise and must
+    emit exactly one DeprecationWarning for the legacy kwarg."""
+    with pytest.warns(DeprecationWarning, match="soda_cloud_use_agent"):
+        result = ContractVerificationSession.execute(
+            contract_yaml_sources=[],
+            soda_cloud_use_agent=True,
+        )
+    assert result is not None
+
+
+def test_contract_verification_session_execute_accepts_legacy_blocking_timeout():
+    """The legacy ``soda_cloud_use_agent_blocking_timeout_in_minutes`` kwarg must not raise either."""
+    with pytest.warns(DeprecationWarning, match="soda_cloud_use_agent_blocking_timeout_in_minutes"):
+        result = ContractVerificationSession.execute(
+            contract_yaml_sources=[],
+            soda_cloud_use_agent_blocking_timeout_in_minutes=42,
+        )
+    assert result is not None
+
+
+def test_contract_verification_session_execute_rejects_conflicting_legacy_and_canonical_kwargs():
+    """If a caller passes both the legacy and canonical kwargs with conflicting values, raise."""
+    with pytest.raises(TypeError, match="Cannot pass both soda_cloud_use_agent"):
+        ContractVerificationSession.execute(
+            contract_yaml_sources=[],
+            soda_cloud_use_agent=True,
+            soda_cloud_use_runner=False,
+        )
+
+
+def test_contract_verification_session_execute_accepts_matching_legacy_and_canonical_kwargs():
+    """If legacy and canonical kwargs match, no error — the helper is permissive here."""
+    with pytest.warns(DeprecationWarning, match="soda_cloud_use_agent"):
+        result = ContractVerificationSession.execute(
+            contract_yaml_sources=[],
+            soda_cloud_use_agent=False,
+            soda_cloud_use_runner=False,
+        )
+    assert result is not None

--- a/soda-tests/tests/unit/test_deprecation_aliases.py
+++ b/soda-tests/tests/unit/test_deprecation_aliases.py
@@ -1,0 +1,95 @@
+"""Tests that lock in the backwards-compatibility contract of the renamed agent → runner surfaces.
+
+Every renamed symbol must keep its old name working and emit a single ``DeprecationWarning`` when
+the old name is used.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_env_config_helper_is_running_on_agent_emits_deprecation_warning():
+    """``EnvConfigHelper.is_running_on_agent`` is a deprecated alias for ``is_running_on_runner``;
+    reading it must emit a DeprecationWarning and return the same value as the canonical property."""
+    from soda_core.common.env_config_helper import EnvConfigHelper
+
+    helper = EnvConfigHelper()
+    canonical = helper.is_running_on_runner
+    with pytest.warns(DeprecationWarning, match="is_running_on_agent"):
+        legacy = helper.is_running_on_agent
+    assert legacy == canonical
+
+
+def test_soda_cloud_verify_contract_on_agent_emits_deprecation_warning(monkeypatch):
+    """``SodaCloud.verify_contract_on_agent`` is a deprecated alias for ``verify_contract_on_runner``."""
+    from soda_core.common.soda_cloud import SodaCloud
+
+    called = {}
+
+    def fake_runner(self, *args, **kwargs):
+        called["called"] = True
+        return "result"
+
+    monkeypatch.setattr(SodaCloud, "verify_contract_on_runner", fake_runner)
+    cloud = SodaCloud.__new__(SodaCloud)
+    with pytest.warns(DeprecationWarning, match="verify_contract_on_agent"):
+        result = cloud.verify_contract_on_agent()
+    assert called["called"]
+    assert result == "result"
+
+
+def test_verify_contract_on_agent_function_emits_deprecation_warning(monkeypatch):
+    """Module-level ``verify_contract_on_agent`` is a deprecated alias for ``verify_contract_on_runner``."""
+    from soda_core.contracts.api import verify_api
+
+    monkeypatch.setattr(verify_api, "verify_contract_on_runner", lambda **kwargs: "ok")
+    with pytest.warns(DeprecationWarning, match="verify_contract_on_agent"):
+        result = verify_api.verify_contract_on_agent(soda_cloud_file_path="sc.yaml")
+    assert result == "ok"
+
+
+def test_deprecated_kwarg_helper_returns_legacy_value_when_only_legacy_supplied():
+    """The fixed helper must accept a single legacy kwarg without raising, even when the new
+    param has a concrete default value at the callsite."""
+    from soda_core.common._deprecation import deprecated_kwarg
+
+    kwargs = {"old": True}
+    with pytest.warns(DeprecationWarning, match="old"):
+        # Caller's `new` param defaulted to False (concrete), which used to trip the conflict
+        # check. With the sentinel-aware helper, this should now just return True.
+        result = deprecated_kwarg(kwargs, "old", "new", current_new_value=None)
+    assert result is True
+    assert "old" not in kwargs
+
+
+def test_deprecated_kwarg_helper_raises_on_conflicting_values():
+    """If caller passes both legacy and canonical with conflicting non-None values, raise."""
+    from soda_core.common._deprecation import deprecated_kwarg
+
+    kwargs = {"old": True}
+    with pytest.warns(DeprecationWarning, match="old"):
+        with pytest.raises(TypeError, match="Cannot pass both old and new"):
+            deprecated_kwarg(kwargs, "old", "new", current_new_value=False)
+
+
+def test_deprecated_kwarg_helper_accepts_matching_values():
+    """When legacy and canonical match, no error."""
+    from soda_core.common._deprecation import deprecated_kwarg
+
+    kwargs = {"old": True}
+    with pytest.warns(DeprecationWarning, match="old"):
+        result = deprecated_kwarg(kwargs, "old", "new", current_new_value=True)
+    assert result is True
+
+
+def test_deprecated_kwarg_helper_no_warning_when_legacy_absent():
+    """No warning fires when caller didn't pass the legacy kwarg."""
+    import warnings
+
+    from soda_core.common._deprecation import deprecated_kwarg
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        result = deprecated_kwarg({}, "old", "new", current_new_value=False)
+    assert result is False
+    assert [r for r in records if issubclass(r.category, DeprecationWarning)] == []

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -344,7 +344,7 @@ def test_soda_cloud_results_with_post_processing_with_failure(
     ), f"Expected 3 cloud requests, got more: {data_source_test_helper.soda_cloud.requests}"
 
 
-def test_execute_over_agent(data_source_test_helper: DataSourceTestHelper):
+def test_execute_over_runner(data_source_test_helper: DataSourceTestHelper):
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
     data_source_test_helper.enable_soda_cloud_mock(
@@ -405,7 +405,7 @@ def test_execute_over_agent(data_source_test_helper: DataSourceTestHelper):
         ]
     )
 
-    data_source_test_helper.use_agent = True
+    data_source_test_helper.use_runner = True
 
     data_source_test_helper.assert_contract_pass(
         test_table=test_table,
@@ -421,8 +421,8 @@ def test_execute_over_agent(data_source_test_helper: DataSourceTestHelper):
     )
 
 
-def test_execute_over_agent_completed_with_warnings(data_source_test_helper: DataSourceTestHelper):
-    """When agent returns completedWithWarnings, is_warned must be True and is_passed must be False."""
+def test_execute_over_runner_completed_with_warnings(data_source_test_helper: DataSourceTestHelper):
+    """When the runner returns completedWithWarnings, is_warned must be True and is_passed must be False."""
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
     data_source_test_helper.enable_soda_cloud_mock(
@@ -483,7 +483,7 @@ def test_execute_over_agent_completed_with_warnings(data_source_test_helper: Dat
         ]
     )
 
-    data_source_test_helper.use_agent = True
+    data_source_test_helper.use_runner = True
 
     data_source_test_helper.assert_contract_warn(
         test_table=test_table,
@@ -541,7 +541,7 @@ def test_publish_contract():
     assert res.contract.source.local_file_path == "yaml_string"
 
 
-def test_verify_contract_on_agent_permission_check():
+def test_verify_contract_on_runner_permission_check():
     responses = [
         MockResponse(
             status_code=200,
@@ -553,7 +553,7 @@ def test_verify_contract_on_agent_permission_check():
     ]
     mock_cloud = MockSodaCloud(responses)
 
-    res = mock_cloud.verify_contract_on_agent(
+    res = mock_cloud.verify_contract_on_runner(
         ContractYaml.parse(
             ContractYamlSource.from_str(
                 f"""
@@ -574,6 +574,46 @@ def test_verify_contract_on_agent_permission_check():
     assert res.check_collection.dataset_name == "CUSTOMERS"
     assert res.check_collection.data_source_name == "test"
     assert res.check_collection.dataset_prefix == ["some", "schema"]
+    assert res.check_results == []
+    assert res.measurements == []
+    assert res.log_records is None
+
+
+def test_verify_contract_on_agent_permission_check_deprecated():
+    """Backwards-compat: the legacy ``verify_contract_on_agent`` method still works and warns."""
+    responses = [
+        MockResponse(
+            status_code=200,
+            json_object={
+                "allowed": False,
+                "reason": "missingManageContracts",
+            },
+        ),
+    ]
+    mock_cloud = MockSodaCloud(responses)
+
+    with pytest.warns(DeprecationWarning, match="verify_contract_on_agent"):
+        res = mock_cloud.verify_contract_on_agent(
+            ContractYaml.parse(
+                ContractYamlSource.from_str(
+                    f"""
+                dataset: test/some/schema/CUSTOMERS
+                columns:
+                - name: id
+            """
+                )
+            ),
+            variables={},
+            blocking_timeout_in_minutes=60,
+            publish_results=False,
+            verbose=False,
+        )
+
+    assert isinstance(res, ContractVerificationResult)
+    assert res.sending_results_to_soda_cloud_failed is False
+    assert res.contract.dataset_name == "CUSTOMERS"
+    assert res.contract.data_source_name == "test"
+    assert res.contract.dataset_prefix == ["some", "schema"]
     assert res.check_results == []
     assert res.measurements == []
     assert res.log_records is None

--- a/soda-tests/tests/unit/test_validate_without_execute.py
+++ b/soda-tests/tests/unit/test_validate_without_execute.py
@@ -54,7 +54,7 @@ columns:
         contract_yaml_sources=[ContractYamlSource.from_str(contract_yaml_str)],
         only_validate_without_execute=True,
         soda_cloud_publish_results=False,
-        soda_cloud_use_agent=False,
+        soda_cloud_use_runner=False,
     )
 
     assert result is not None


### PR DESCRIPTION
Renames every public surface from "agent" to "runner" while keeping the old names as deprecated aliases that emit `DeprecationWarning` and delegate to the new names. Covers the public `verify_contract_on_agent` / `verify_contracts_on_agent` functions, `SodaCloud.verify_contract_on_agent`, `EnvConfigHelper.is_running_on_agent`, the `use_agent` kwarg across the verification API, `ContractVerificationSession`, the contract YAML JSON schema's `soda_agent` key (now accepted via `oneOf` alongside `soda_runner`), and the CLI flag `-a/--use-agent` (hidden alias of `-r/--use-runner`).

Adds a small `_deprecation` helper and duplicates each agent-flavoured test with a runner-flavoured twin to lock in parity between the two paths. The `SODA_INSTRUCTION_ID` env var is unchanged.

## Description

**What problem are you solving?** The product is being renamed from "Soda Agent" to "Soda Runner". This PR carries the rename through every Python/CLI/schema surface of soda-core while preserving full backwards compatibility — every old name keeps working and the SODA_INSTRUCTION_ID env var (set by the Runner runtime) is untouched.

**Impact on downstream packages/services:**
- A matching PR exists on soda-extensions on the same branch (`r-587-...`) — CI on that side picks up these soda-core changes.
- Soda Cloud server: generated contracts will now emit `soda_runner:` in YAML. The schema accepts both keys, but the Cloud team should be aware that new contracts may arrive with the new key.
- Users calling legacy `use_agent` / `soda_cloud_use_agent` kwargs or the `-a/--use-agent` CLI flag will see a `DeprecationWarning` (or stderr notice for CLI) but functionality is unchanged.

**Reference:** R-587

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml