### PR TITLE
fix: use COUNT_BIG on SQL Server / Synapse / Fabric to avoid INT overflow on large tables

### DIFF
--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -1,5 +1,5 @@
 from soda_core.common.metadata_types import SqlDataType
-from soda_core.common.sql_ast import CREATE_TABLE_COLUMN
+from soda_core.common.sql_ast import COUNT, CREATE_TABLE_COLUMN, STAR
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_fabric.common.data_sources.fabric_data_source import FabricSqlDialect
 
@@ -8,6 +8,11 @@ def test_random():
     sql_dialect: FabricSqlDialect = FabricSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+def test_count_renders_as_count_big():
+    # Inherits the COUNT_BIG override from SqlServerSqlDialect — guards against accidental regressions.
+    assert FabricSqlDialect().build_expression_sql(COUNT(STAR())) == "COUNT_BIG(*)"
 
 
 # ---------------------------------------------------------------------------

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -163,6 +163,11 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
     def _build_length_sql(self, length: LENGTH) -> str:
         return f"LEN({self.build_expression_sql(length.expression)})"
 
+    def _build_count_sql(self, count: COUNT) -> str:
+        # T-SQL COUNT returns INT and overflows above 2,147,483,647 rows. COUNT_BIG is the
+        # BIGINT-returning equivalent with identical null/distinct semantics.
+        return f"COUNT_BIG({self.build_expression_sql(count.expression)})"
+
     def sql_expr_timestamp_literal(self, datetime_in_iso8601: str) -> str:
         return f"'{datetime_in_iso8601}'"
 

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -1,5 +1,5 @@
 from soda_core.common.metadata_types import SqlDataType
-from soda_core.common.sql_ast import CREATE_TABLE_COLUMN
+from soda_core.common.sql_ast import COUNT, CREATE_TABLE_COLUMN, STAR
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerSqlDialect
 
@@ -8,6 +8,11 @@ def test_random():
     sql_dialect: SqlServerSqlDialect = SqlServerSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+def test_count_renders_as_count_big():
+    # T-SQL COUNT returns INT and overflows above 2.1B rows; the dialect must emit COUNT_BIG.
+    assert SqlServerSqlDialect().build_expression_sql(COUNT(STAR())) == "COUNT_BIG(*)"
 
 
 # ---------------------------------------------------------------------------

--- a/soda-synapse/tests/unit/test_synapse_dialect.py
+++ b/soda-synapse/tests/unit/test_synapse_dialect.py
@@ -1,3 +1,4 @@
+from soda_core.common.sql_ast import COUNT, STAR
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_synapse.common.data_sources.synapse_data_source import SynapseSqlDialect
 
@@ -6,3 +7,8 @@ def test_random():
     sql_dialect: SynapseSqlDialect = SynapseSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+def test_count_renders_as_count_big():
+    # Inherits the COUNT_BIG override from SqlServerSqlDialect — guards against accidental regressions.
+    assert SynapseSqlDialect().build_expression_sql(COUNT(STAR())) == "COUNT_BIG(*)"


### PR DESCRIPTION
## Summary
- T-SQL `COUNT(...)` returns INT and raises arithmetic overflow (error 8115) on tables with more than 2,147,483,647 rows, breaking unfiltered `row_count` (and other count-based) checks on SQL Server, Synapse, and Fabric.
- Override `_build_count_sql` in `SqlServerSqlDialect` to emit `COUNT_BIG(...)`, which returns BIGINT with identical null/distinct semantics. Synapse and Fabric inherit the fix via their subclassing.
- Adds one unit test per dialect (sqlserver / synapse / fabric) asserting `COUNT(*)` renders as `COUNT_BIG(*)`.

Linear: [SAS-12355](https://sodadata.atlassian.net/browse/SAS-12355)

## Test plan
- [x] `pytest soda-sqlserver/tests/unit soda-synapse/tests/unit soda-fabric/tests/unit` passes locally (26/26)
- [ ] CI green on SQL Server / Synapse / Fabric integration suites

Running with soda-extensions here: https://github.com/sodadata/soda-extensions/actions/runs/26517239953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SAS-12355]: https://sodadata.atlassian.net/browse/SAS-12355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ