### PR TITLE
feat(sparkdf): catalog mode + Spark Connect modes for Databricks DWH

### DIFF
--- a/soda-sparkdf/pyproject.toml
+++ b/soda-sparkdf/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "soda-core==4.12.1rc0",
     "freezegun",
-    "pyspark>=3.5.0",
+    "pyspark[connect]>=3.5.0",
     "soda-databricks==4.12.1rc0",
 ]
 

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -161,10 +161,16 @@ class SparkDataFrameSqlDialect(DatabricksSqlDialect, sqlglot_dialect="spark"):
 
     def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: bool = True) -> str:
         if self.use_catalog:
+            if len(prefixes) < 2:
+                raise ValueError(
+                    f"Catalog-mode SparkDF requires 2 prefixes [catalog, schema]; got {len(prefixes)}: {prefixes}"
+                )
             catalog_name: str = prefixes[0]
             schema_name: str = prefixes[1]
             quoted = f"{self.quote_default(catalog_name)}.{self.quote_default(schema_name)}"
         else:
+            if len(prefixes) < 1:
+                raise ValueError(f"SparkDF requires at least 1 prefix [schema]; got {len(prefixes)}: {prefixes}")
             quoted = self.quote_default(prefixes[0])
         return f"CREATE SCHEMA IF NOT EXISTS {quoted}" + (";" if add_semicolon else "")
 
@@ -225,8 +231,10 @@ class SparkDataFrameDataSourceConnection(DataSourceConnection):
                 raise ValueError(
                     "SparkDataFrame is configured with use_active_session=True but no active "
                     "SparkSession was found. Build a session (e.g. SparkSession.builder.…"
-                    "getOrCreate()) before opening this connection, or switch to the "
-                    "existing_session / remote / new_session connection mode."
+                    "getOrCreate()) before opening this connection, or switch to another "
+                    "connection mode: pass ``spark_session`` (existing session), "
+                    "``host`` + ``token`` + ``cluster_id`` (remote Spark Connect), or "
+                    "``new_session: true`` (local session)."
                 )
         elif isinstance(config, SparkDataFrameRemoteSessionProperties):
             # Spark Connect URI. ``token`` becomes a gRPC bearer header (handled by

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -21,13 +21,13 @@ from soda_databricks.common.statements.hive_metadata_tables_query import (
     HiveMetadataTablesQuery,
 )
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
+    SparkDataFrameActiveSessionProperties,
     SparkDataFrameConnectionProperties,
 )
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
     SparkDataFrameDataSource as SparkDataFrameDataSourceModel,
 )
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
-    SparkDataFrameActiveSessionProperties,
     SparkDataFrameExistingSessionProperties,
     SparkDataFrameNewSessionProperties,
     SparkDataFrameRemoteSessionProperties,
@@ -412,9 +412,7 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
         )
 
     @classmethod
-    def from_existing_session(
-        cls, session: SparkSession, name: str, use_catalog: bool = False
-    ) -> DataSourceImpl:
+    def from_existing_session(cls, session: SparkSession, name: str, use_catalog: bool = False) -> DataSourceImpl:
         # Locally-owned dict so we never mutate caller-shared state via the
         # ``connection_properties`` plumbing.
         connection_properties = {

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -27,8 +27,10 @@ from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
     SparkDataFrameDataSource as SparkDataFrameDataSourceModel,
 )
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
+    SparkDataFrameActiveSessionProperties,
     SparkDataFrameExistingSessionProperties,
     SparkDataFrameNewSessionProperties,
+    SparkDataFrameRemoteSessionProperties,
 )
 
 _in_memory_connection = None
@@ -142,16 +144,27 @@ class SparkDataFrameSqlDialect(DatabricksSqlDialect, sqlglot_dialect="spark"):
     # parent dialect.
     SUPPORTS_DROP_TABLE_CASCADE: bool = False
 
+    def __init__(self, use_catalog: bool = False):
+        super().__init__()
+        # In catalog mode, prefixes are [catalog, schema] (Unity-Catalog style 3-level
+        # namespace). In legacy mode, prefixes are [schema] only — local Spark has no
+        # catalog concept beyond ``spark_catalog``.
+        self.use_catalog = use_catalog
+
     def get_database_prefix_index(self) -> int | None:
-        return None
+        return 0 if self.use_catalog else None
 
     def get_schema_prefix_index(self) -> int | None:
-        return 0
+        return 1 if self.use_catalog else 0
 
     def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: bool = True) -> str:
-        schema_name: str = prefixes[0]
-        quoted_schema_name: str = self.quote_default(schema_name)
-        return f"CREATE SCHEMA IF NOT EXISTS {quoted_schema_name}" + (";" if add_semicolon else "")
+        if self.use_catalog:
+            catalog_name: str = prefixes[0]
+            schema_name: str = prefixes[1]
+            quoted = f"{self.quote_default(catalog_name)}.{self.quote_default(schema_name)}"
+        else:
+            quoted = self.quote_default(prefixes[0])
+        return f"CREATE SCHEMA IF NOT EXISTS {quoted}" + (";" if add_semicolon else "")
 
     def post_schema_create_sql(self, prefixes: list[str]) -> Optional[list[str]]:
         pass  # Do nothing, Spark does not have a post-schema-create concept
@@ -200,6 +213,35 @@ class SparkDataFrameDataSourceConnection(DataSourceConnection):
         session = None
         if isinstance(config, SparkDataFrameExistingSessionProperties):
             session = config.spark_session
+        elif isinstance(config, SparkDataFrameActiveSessionProperties):
+            # Pick up the thread-local active SparkSession (the Databricks notebook's
+            # ``spark``, or whatever the caller last did ``.getOrCreate()`` on). No URI,
+            # no credentials, no global state we own — just pyspark's existing notion
+            # of which session is active in this thread.
+            session = SparkSession.getActiveSession()
+            if session is None:
+                raise ValueError(
+                    "SparkDataFrame is configured with use_active_session=True but no active "
+                    "SparkSession was found. Build a session (e.g. SparkSession.builder.…"
+                    "getOrCreate()) before opening this connection, or switch to the "
+                    "existing_session / remote / new_session connection mode."
+                )
+        elif isinstance(config, SparkDataFrameRemoteSessionProperties):
+            # Spark Connect URI. ``token`` becomes a gRPC bearer header (handled by
+            # pyspark.sql.connect.ChannelBuilder); ``x-databricks-cluster-id`` is forwarded
+            # as gRPC metadata, which is how Databricks routes the session to a cluster.
+            # ``getOrCreate`` caches per URI in-process, so multiple data sources pointing
+            # at the same workspace+cluster end up sharing one underlying session.
+            # NB: ``config.token`` is a SecretStr — unwrap only when assembling the URI
+            # (which is kept as a local variable, never logged).
+            uri = (
+                f"sc://{config.host}:443/"
+                f";use_ssl=true"
+                f";token={config.token.get_secret_value()}"
+                f";x-databricks-cluster-id={config.cluster_id}"
+            )
+            session = SparkSession.builder.remote(uri).getOrCreate()
+            session.sql("SET TIME ZONE 'UTC'")
         elif isinstance(config, SparkDataFrameNewSessionProperties):
             session = (
                 SparkSession.builder.master("local")
@@ -348,7 +390,14 @@ class SparkDataFrameMetadataTablesQuery(HiveMetadataTablesQuery):
 
 class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDataSourceModel):
     def _create_sql_dialect(self) -> SqlDialect:
-        return SparkDataFrameSqlDialect()
+        return SparkDataFrameSqlDialect(use_catalog=self._read_use_catalog_flag())
+
+    def _read_use_catalog_flag(self) -> bool:
+        # Pydantic model when fully parsed, dict during the from_existing_session bootstrap.
+        props = self.data_source_model.connection_properties
+        if isinstance(props, dict):
+            return bool(props.get("use_catalog", False))
+        return bool(getattr(props, "use_catalog", False))
 
     def _create_data_source_connection(self) -> DataSourceConnection:
         return SparkDataFrameDataSourceConnection(
@@ -361,8 +410,10 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
         )
 
     @classmethod
-    def from_existing_session(cls, session: SparkSession, name: str) -> DataSourceImpl:
-        connection_properties = {"spark_session": session, "schema_": name}
+    def from_existing_session(
+        cls, session: SparkSession, name: str, use_catalog: bool = False
+    ) -> DataSourceImpl:
+        connection_properties = {"spark_session": session, "schema_": name, "use_catalog": use_catalog}
         ds_model = SparkDataFrameDataSourceModel(
             name=name,
             connection_properties=connection_properties,
@@ -392,6 +443,22 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
         return False
 
     def test_schema_exists(self, prefixes: list[str]) -> bool:
+        # Catalog-mode prefixes are [catalog, schema]; we check existence within the catalog so
+        # the SHOW SCHEMAS result is scoped (and a missing/empty catalog returns False cleanly).
+        if self.sql_dialect.get_database_prefix_index() is not None and len(prefixes) >= 2:
+            catalog_name = prefixes[0]
+            schema_name = prefixes[1]
+            try:
+                result = self.connection.session.sql(
+                    f"SHOW SCHEMAS IN {catalog_name} LIKE '{schema_name}'"
+                ).collect()
+            except Exception:
+                # Catalog does not yet exist — pre_schema_create_sql will create it.
+                return False
+            for row in result:
+                if row[0] and row[0].lower() == schema_name.lower():
+                    return True
+            return False
         result = self.connection.session.sql(f"SHOW SCHEMAS LIKE '{prefixes[0]}'").collect()
         for row in result:
             if row[0] and row[0].lower() == prefixes[0].lower():

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -139,9 +139,9 @@ class SparkDataFrameSqlDialect(DatabricksSqlDialect, sqlglot_dialect="spark"):
         (SodaDataTypeName.NUMERIC, SodaDataTypeName.DECIMAL),
         (SodaDataTypeName.TIMESTAMP_TZ, SodaDataTypeName.TIMESTAMP),
     )
-    # Local Spark SQL rejects ``DROP TABLE ... CASCADE`` (ParseException). The
-    # Databricks SQL connector accepts it, hence the divergence from the
-    # parent dialect.
+    # Class-level default: legacy local-Spark rejects ``DROP TABLE ... CASCADE``
+    # with a ParseException. In catalog mode (Databricks) CASCADE is supported, so
+    # __init__ promotes this to True via an instance attribute that shadows the class.
     SUPPORTS_DROP_TABLE_CASCADE: bool = False
 
     def __init__(self, use_catalog: bool = False):
@@ -150,6 +150,8 @@ class SparkDataFrameSqlDialect(DatabricksSqlDialect, sqlglot_dialect="spark"):
         # namespace). In legacy mode, prefixes are [schema] only — local Spark has no
         # catalog concept beyond ``spark_catalog``.
         self.use_catalog = use_catalog
+        # Instance override — see class-level comment above.
+        self.SUPPORTS_DROP_TABLE_CASCADE = use_catalog
 
     def get_database_prefix_index(self) -> int | None:
         return 0 if self.use_catalog else None
@@ -413,7 +415,13 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
     def from_existing_session(
         cls, session: SparkSession, name: str, use_catalog: bool = False
     ) -> DataSourceImpl:
-        connection_properties = {"spark_session": session, "schema_": name, "use_catalog": use_catalog}
+        # Locally-owned dict so we never mutate caller-shared state via the
+        # ``connection_properties`` plumbing.
+        connection_properties = {
+            "spark_session": session,
+            "schema_": name,
+            "use_catalog": use_catalog,
+        }
         ds_model = SparkDataFrameDataSourceModel(
             name=name,
             connection_properties=connection_properties,
@@ -443,23 +451,25 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
         return False
 
     def test_schema_exists(self, prefixes: list[str]) -> bool:
-        # Catalog-mode prefixes are [catalog, schema]; we check existence within the catalog so
-        # the SHOW SCHEMAS result is scoped (and a missing/empty catalog returns False cleanly).
+        # Catalog-mode prefixes are [catalog, schema]; we list schemas in the catalog and do
+        # exact-match in Python rather than ``LIKE '<schema>'`` so a schema named
+        # ``soda_diagnostics`` doesn't false-positive against ``sodaXdiagnostics`` via the
+        # ``_`` wildcard. Quote the catalog so names with hyphens (legal in UC) parse cleanly.
         if self.sql_dialect.get_database_prefix_index() is not None and len(prefixes) >= 2:
             catalog_name = prefixes[0]
             schema_name = prefixes[1]
+            quoted_catalog = self.sql_dialect.quote_default(catalog_name)
             try:
-                result = self.connection.session.sql(
-                    f"SHOW SCHEMAS IN {catalog_name} LIKE '{schema_name}'"
-                ).collect()
+                result = self.connection.session.sql(f"SHOW SCHEMAS IN {quoted_catalog}").collect()
             except Exception:
-                # Catalog does not yet exist — pre_schema_create_sql will create it.
+                # Catalog doesn't exist (or we can't see into it) — the subsequent
+                # ``CREATE SCHEMA IF NOT EXISTS <cat>.<schema>`` will surface the real error.
                 return False
             for row in result:
                 if row[0] and row[0].lower() == schema_name.lower():
                     return True
             return False
-        result = self.connection.session.sql(f"SHOW SCHEMAS LIKE '{prefixes[0]}'").collect()
+        result = self.connection.session.sql("SHOW SCHEMAS").collect()
         for row in result:
             if row[0] and row[0].lower() == prefixes[0].lower():
                 return True

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Any, Literal, Optional, Union
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
@@ -13,6 +13,15 @@ class SparkDataFrameConnectionProperties(DataSourceConnectionProperties, ABC):
         "main", description="Optional schema name to use for the SparkDataFrame connection", alias="schema"
     )
     test_dir: Optional[str] = Field(None, description="The directory to use for the test")
+    use_catalog: bool = Field(
+        False,
+        description=(
+            "When True, treat DWH prefixes as [catalog, schema] so DWH tables land in a "
+            "Unity-Catalog-style 3-level namespace. The dialect emits CREATE CATALOG IF "
+            "NOT EXISTS ahead of CREATE SCHEMA and qualifies all DDL/DML with the catalog. "
+            "Leave False for local Spark which has no catalog concept."
+        ),
+    )
 
 
 class SparkDataFrameNewSessionProperties(SparkDataFrameConnectionProperties):
@@ -25,20 +34,78 @@ class SparkDataFrameExistingSessionProperties(SparkDataFrameConnectionProperties
     spark_session: Any = Field(..., description="The existing Spark session to use")
 
 
+class SparkDataFrameRemoteSessionProperties(SparkDataFrameConnectionProperties):
+    """SparkSession built via Spark Connect against a remote workspace (e.g. Databricks).
+
+    The connection builds ``SparkSession.builder.remote(<uri>).getOrCreate()`` using a
+    Spark Connect URI assembled from ``host``, ``token``, and ``cluster_id``. Because
+    pyspark's Spark Connect builder caches sessions by URI per Python process, two
+    DataSourceImpls configured against the same workspace+cluster share one underlying
+    session — which is what we want for between-source DWH against Databricks.
+    """
+
+    host: str = Field(..., description="Workspace host (e.g. dbc-12345.cloud.databricks.com)")
+    # SecretStr so the PAT renders as '**********' in repr/str — soda-core logs
+    # connection_properties at DEBUG, which would otherwise leak the token verbatim
+    # whenever verbose logging is on.
+    token: SecretStr = Field(..., description="Personal access token, sent as gRPC bearer auth")
+    cluster_id: str = Field(
+        ...,
+        description=(
+            "All-purpose cluster id, forwarded as ``x-databricks-cluster-id`` gRPC metadata "
+            "to route the Spark Connect session to a specific cluster"
+        ),
+    )
+
+
+class SparkDataFrameActiveSessionProperties(SparkDataFrameConnectionProperties):
+    """SparkSession picked up from ``SparkSession.getActiveSession()`` at connect time.
+
+    Lets a DWH YAML reuse the SparkSession that's already active in the current thread —
+    typically the Databricks notebook's ``spark``, or a session a caller built via
+    ``SparkSession.builder.…getOrCreate()`` before invoking contract verification. No
+    credentials in YAML, no module-level registry, no monkey-patching: pyspark already
+    tracks the active session per thread and we just retrieve it.
+
+    The connection raises a clear error when no active session is found.
+    """
+
+    use_active_session: Literal[True] = Field(
+        ...,
+        description=(
+            "Must be ``true``. Discriminator for picking this connection mode in YAML; the "
+            "session itself is fetched via SparkSession.getActiveSession() at connect time."
+        ),
+    )
+
+
 class SparkDataFrameDataSource(DataSourceBase, ABC):
     type: Literal["sparkdf"] = Field("sparkdf")
-    connection_properties: Union[SparkDataFrameExistingSessionProperties, SparkDataFrameNewSessionProperties] = Field(
-        ..., alias="connection", description="SparkDataFrame connection configuration"
-    )
+    connection_properties: Union[
+        SparkDataFrameExistingSessionProperties,
+        SparkDataFrameRemoteSessionProperties,
+        SparkDataFrameActiveSessionProperties,
+        SparkDataFrameNewSessionProperties,
+    ] = Field(..., alias="connection", description="SparkDataFrame connection configuration")
 
     @field_validator("connection_properties", mode="before")
     @classmethod
     def infer_connection_type(cls, value):
         if isinstance(value, SparkDataFrameNewSessionProperties):
             return value
+        if isinstance(value, SparkDataFrameExistingSessionProperties):
+            return value
+        if isinstance(value, SparkDataFrameRemoteSessionProperties):
+            return value
+        if isinstance(value, SparkDataFrameActiveSessionProperties):
+            return value
 
         if "spark_session" in value:
             return SparkDataFrameExistingSessionProperties(**value)
+        elif value.get("use_active_session") is True:
+            return SparkDataFrameActiveSessionProperties(**value)
+        elif "host" in value and "cluster_id" in value:
+            return SparkDataFrameRemoteSessionProperties(**value)
         elif "new_session" in value:
             return SparkDataFrameNewSessionProperties(**value)
         raise ValueError("Could not infer SparkDataFrame connection type from input")

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 from typing import Any, Literal, Optional, Union
 
@@ -58,6 +59,17 @@ class SparkDataFrameRemoteSessionProperties(SparkDataFrameConnectionProperties):
         ),
     )
 
+    @field_validator("host", mode="before")
+    @classmethod
+    def _strip_host_scheme(cls, value):
+        # Users naturally paste workspace URLs like ``https://dbc-12345.cloud.databricks.com``.
+        # The Spark Connect URI hard-codes its own ``sc://`` scheme and ``use_ssl=true``, so a
+        # scheme in the host would produce ``sc://https://...:443/`` and surface as an opaque
+        # gRPC error. Strip the scheme and trailing slash up-front.
+        if isinstance(value, str):
+            return re.sub(r"^https?://", "", value.strip()).rstrip("/")
+        return value
+
 
 class SparkDataFrameActiveSessionProperties(SparkDataFrameConnectionProperties):
     """SparkSession picked up from ``SparkSession.getActiveSession()`` at connect time.
@@ -100,6 +112,26 @@ class SparkDataFrameDataSource(DataSourceBase, ABC):
             return value
         if isinstance(value, SparkDataFrameActiveSessionProperties):
             return value
+
+        # Reject ambiguous combinations up-front rather than letting the first matching
+        # branch win silently. Each mode has a unique discriminator; mixing them is
+        # almost always a typo or a half-finished YAML edit.
+        modes_present = []
+        if "spark_session" in value:
+            modes_present.append("spark_session (existing_session mode)")
+        if value.get("use_active_session") is True:
+            modes_present.append("use_active_session (active_session mode)")
+        if "host" in value or "cluster_id" in value:
+            modes_present.append("host/cluster_id (remote_session mode)")
+        if "new_session" in value:
+            modes_present.append("new_session mode")
+        if len(modes_present) > 1:
+            raise ValueError(
+                "Conflicting SparkDataFrame connection config — multiple modes detected: "
+                + ", ".join(modes_present)
+                + ". Pick exactly one of: spark_session, use_active_session=true, "
+                "host+cluster_id, or new_session."
+            )
 
         if "spark_session" in value:
             return SparkDataFrameExistingSessionProperties(**value)

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -17,9 +17,10 @@ class SparkDataFrameConnectionProperties(DataSourceConnectionProperties, ABC):
         False,
         description=(
             "When True, treat DWH prefixes as [catalog, schema] so DWH tables land in a "
-            "Unity-Catalog-style 3-level namespace. The dialect emits CREATE CATALOG IF "
-            "NOT EXISTS ahead of CREATE SCHEMA and qualifies all DDL/DML with the catalog. "
-            "Leave False for local Spark which has no catalog concept."
+            "Unity-Catalog-style 3-level namespace. The dialect qualifies CREATE SCHEMA and "
+            "schema-existence checks with the catalog (e.g. ``catalog.schema``); the catalog "
+            "itself is assumed to already exist (Soda does not auto-create catalogs). Leave "
+            "False for local Spark which has no catalog concept."
         ),
     )
 

--- a/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
@@ -1,0 +1,72 @@
+"""Unit coverage for the SparkDF connection-mode discriminator + active-session lookup.
+
+These tests do not start a SparkSession against any cluster — they verify that:
+  - the YAML-shaped dict routes to the right Pydantic properties class
+  - ``_create_connection`` for active-session mode either returns
+    ``SparkSession.getActiveSession()`` or raises a clear error when none is active.
+"""
+from __future__ import annotations
+
+import pytest
+from soda_sparkdf.common.data_sources.sparkdf_data_source import (
+    SparkDataFrameDataSourceConnection,
+)
+from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
+    SparkDataFrameActiveSessionProperties,
+    SparkDataFrameDataSource,
+    SparkDataFrameRemoteSessionProperties,
+)
+
+
+def _build_model(connection_dict: dict) -> SparkDataFrameDataSource:
+    return SparkDataFrameDataSource(name="x", connection=connection_dict)
+
+
+def test_use_active_session_routes_to_active_properties():
+    model = _build_model({"use_active_session": True, "use_catalog": True})
+    assert isinstance(model.connection_properties, SparkDataFrameActiveSessionProperties)
+    assert model.connection_properties.use_active_session is True
+    assert model.connection_properties.use_catalog is True
+
+
+def test_remote_session_still_routes_correctly_with_active_mode_present():
+    model = _build_model(
+        {
+            "host": "dbc-x.cloud.databricks.com",
+            "token": "secret",
+            "cluster_id": "0000-000000-aaaa",
+            "use_catalog": True,
+        }
+    )
+    assert isinstance(model.connection_properties, SparkDataFrameRemoteSessionProperties)
+
+
+def test_remote_session_token_is_masked_in_repr_and_str():
+    # soda-core logs connection_properties at DEBUG — if the token isn't a SecretStr,
+    # it leaks verbatim into any verbose test or production log.
+    props = SparkDataFrameRemoteSessionProperties(
+        host="dbc-x.cloud.databricks.com",
+        token="dapi_some_real_looking_secret",
+        cluster_id="0000-000000-aaaa",
+    )
+    assert "dapi_some_real_looking_secret" not in repr(props)
+    assert "dapi_some_real_looking_secret" not in str(props)
+    assert "**********" in repr(props)
+    # The actual value must still be retrievable inside the adapter when building URIs.
+    assert props.token.get_secret_value() == "dapi_some_real_looking_secret"
+
+
+def test_active_session_mode_raises_when_no_active_session(monkeypatch: pytest.MonkeyPatch):
+    # Ensure SparkSession.getActiveSession() returns None for this test, regardless of
+    # what other tests in the session have done.
+    from pyspark.sql import SparkSession
+
+    monkeypatch.setattr(SparkSession, "getActiveSession", staticmethod(lambda: None))
+
+    conn = SparkDataFrameDataSourceConnection(
+        name="x",
+        connection_properties={"use_active_session": True},
+    )
+    props = SparkDataFrameActiveSessionProperties(use_active_session=True)
+    with pytest.raises(ValueError, match="no active SparkSession was found"):
+        conn._create_connection(props)

--- a/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
@@ -29,7 +29,7 @@ def test_use_active_session_routes_to_active_properties():
     assert model.connection_properties.use_catalog is True
 
 
-def test_remote_session_still_routes_correctly_with_active_mode_present():
+def test_remote_session_config_routes_to_remote_properties():
     model = _build_model(
         {
             "host": "dbc-x.cloud.databricks.com",
@@ -39,6 +39,32 @@ def test_remote_session_still_routes_correctly_with_active_mode_present():
         }
     )
     assert isinstance(model.connection_properties, SparkDataFrameRemoteSessionProperties)
+
+
+def test_conflicting_modes_raise_clear_error():
+    # use_active_session + host used to be silently resolved to active by discriminator
+    # order. Both being present is almost always a typo — we want an actionable error.
+    with pytest.raises(ValueError, match="Conflicting SparkDataFrame connection config"):
+        _build_model(
+            {
+                "use_active_session": True,
+                "host": "dbc-x.cloud.databricks.com",
+                "token": "secret",
+                "cluster_id": "0000-000000-aaaa",
+            }
+        )
+
+
+def test_remote_session_host_strips_scheme_and_trailing_slash():
+    # Users naturally paste the workspace URL with scheme; the Spark Connect URI hard-codes
+    # ``sc://...:443/`` so a scheme on host would yield ``sc://https://...:443/`` and a
+    # confusing gRPC error. The model normalises the host on validation.
+    props = SparkDataFrameRemoteSessionProperties(
+        host="https://dbc-x.cloud.databricks.com/",
+        token="secret",
+        cluster_id="0000-000000-aaaa",
+    )
+    assert props.host == "dbc-x.cloud.databricks.com"
 
 
 def test_remote_session_token_is_masked_in_repr_and_str():

--- a/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
@@ -40,3 +40,17 @@ def test_catalog_mode_create_schema_sql_no_semicolon_option():
     dialect = SparkDataFrameSqlDialect(use_catalog=True)
     sql = dialect.create_schema_if_not_exists_sql(["my_cat", "my_schema"], add_semicolon=False)
     assert sql == "CREATE SCHEMA IF NOT EXISTS `my_cat`.`my_schema`"
+
+
+def test_drop_table_cascade_disabled_in_legacy_mode():
+    # Local Spark rejects DROP TABLE ... CASCADE with a ParseException, so the dialect
+    # must NOT emit the CASCADE suffix when running on a local SparkSession.
+    dialect = SparkDataFrameSqlDialect()
+    assert dialect.SUPPORTS_DROP_TABLE_CASCADE is False
+
+
+def test_drop_table_cascade_enabled_in_catalog_mode():
+    # In catalog mode the engine is Databricks (or another UC-aware Spark), which accepts
+    # DROP TABLE ... CASCADE. The dialect promotes the class default to True per-instance.
+    dialect = SparkDataFrameSqlDialect(use_catalog=True)
+    assert dialect.SUPPORTS_DROP_TABLE_CASCADE is True

--- a/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
@@ -8,3 +8,35 @@ def test_random():
     sql_dialect: SparkDataFrameSqlDialect = SparkDataFrameSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT RAND()\nFROM `a`;"
+
+
+def test_legacy_mode_prefix_indexes_unchanged():
+    dialect = SparkDataFrameSqlDialect()
+    assert dialect.use_catalog is False
+    assert dialect.get_database_prefix_index() is None
+    assert dialect.get_schema_prefix_index() == 0
+
+
+def test_catalog_mode_prefix_indexes():
+    dialect = SparkDataFrameSqlDialect(use_catalog=True)
+    assert dialect.use_catalog is True
+    assert dialect.get_database_prefix_index() == 0
+    assert dialect.get_schema_prefix_index() == 1
+
+
+def test_legacy_create_schema_sql_uses_single_prefix():
+    dialect = SparkDataFrameSqlDialect()
+    sql = dialect.create_schema_if_not_exists_sql(["my_schema"])
+    assert sql == "CREATE SCHEMA IF NOT EXISTS `my_schema`;"
+
+
+def test_catalog_mode_create_schema_sql_qualifies_with_catalog():
+    dialect = SparkDataFrameSqlDialect(use_catalog=True)
+    sql = dialect.create_schema_if_not_exists_sql(["my_cat", "my_schema"])
+    assert sql == "CREATE SCHEMA IF NOT EXISTS `my_cat`.`my_schema`;"
+
+
+def test_catalog_mode_create_schema_sql_no_semicolon_option():
+    dialect = SparkDataFrameSqlDialect(use_catalog=True)
+    sql = dialect.create_schema_if_not_exists_sql(["my_cat", "my_schema"], add_semicolon=False)
+    assert sql == "CREATE SCHEMA IF NOT EXISTS `my_cat`.`my_schema`"

--- a/uv.lock
+++ b/uv.lock
@@ -1795,6 +1795,18 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/bf/58ee13add151469c25825b7125bbf62c3bdcec05eec4d458fcb5c5516066/pyspark-4.1.1.tar.gz", hash = "sha256:77f78984aa84fbe865c717dd37b49913b4e5c97d76ef6824f932f1aefa6621ec", size = 455359625, upload-time = "2026-01-09T09:38:38.28Z" }
 
+[package.optional-dependencies]
+connect = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "zstandard" },
+]
+
 [[package]]
 name = "pytest"
 version = "9.0.2"
@@ -2323,7 +2335,7 @@ version = "4.12.1rc0"
 source = { editable = "soda-sparkdf" }
 dependencies = [
     { name = "freezegun" },
-    { name = "pyspark" },
+    { name = "pyspark", extra = ["connect"] },
     { name = "soda-core" },
     { name = "soda-databricks" },
 ]
@@ -2331,7 +2343,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "freezegun" },
-    { name = "pyspark", specifier = ">=3.5.0" },
+    { name = "pyspark", extras = ["connect"], specifier = ">=3.5.0" },
     { name = "soda-core", editable = "soda-core" },
     { name = "soda-databricks", editable = "soda-databricks" },
 ]


### PR DESCRIPTION
## Summary

- Adds an opt-in ``use_catalog`` flag to the SparkDF dialect so DWH writes can land in a Unity-Catalog 3-level namespace (``catalog.schema.table``). Default off — local SparkDF behaviour unchanged.
- Adds two new YAML-friendly SparkDF connection modes:
  - ``remote_session`` (host / token / cluster_id) builds a Spark Connect session against a Databricks all-purpose cluster.
  - ``active_session`` (``use_active_session: true``) picks up ``SparkSession.getActiveSession()`` at connect time — no credentials in YAML, ideal for notebooks.
- ``token`` is a Pydantic ``SecretStr`` so the PAT no longer leaks into soda-core's DEBUG log of ``connection_properties`` under verbose logging.

Together these let Soda's Diagnostics Warehouse run end-to-end on Databricks via a single Spark session, with both source reads and DWH writes flowing through ``spark.sql(...)``. The companion PR in soda-extensions wires this into the DWH prefix builder and adds a live integration test against a real cluster.

## Test plan

- [x] ``soda-sparkdf/tests/unit/`` — 12 unit tests covering both modes (legacy + catalog), DDL generation, prefix indexing, token masking, active-session discriminator, and conditional ``SUPPORTS_DROP_TABLE_CASCADE``
- [x] ``test_dwh_sparkdf.py`` (legacy local-Spark DWH) still passes — no regression
- [x] Live integration test against a real Databricks cluster (in the soda-extensions companion PR): in-source + between-source (parametrised over ``remote_session`` and ``active_session`` DWH YAML modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)