### PR TITLE
fix: YAML-aware SQL snapshot comparison

### DIFF
--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -842,19 +842,39 @@ class SnapshotDataSourceConnection(DataSourceConnection):
         ``yaml.safe_load`` collapses ``\\n + indent`` to a single space and returns
         identical Python objects either way.
 
-        For every single-quoted SQL literal that parses as structured YAML (dict
-        or list), substitute its sorted-key JSON canonical form, so that
+        For every single-quoted SQL literal that parses as **multi-line**
+        structured YAML (dict or list, with at least one newline in the inner
+        content), substitute its sorted-key JSON canonical form, so that
         downstream string comparison is insensitive to YAML pretty-print drift.
-        Literals that fail to parse, or parse to a bare scalar, are left
-        untouched — keeping the rewrite confined to values that actually
-        embedded YAML data on purpose.
+
+        Two guards constrain when the rewrite fires:
+
+        - **Multi-line only** (``"\\n" in inner``): a YAML wrap-drift difference
+          can only arise from a YAML dump that's actually wrapped, which means
+          multi-line. Single-line flow-style literals like ``'[1,2,3]'`` or
+          ``'{a: 1}'`` are left untouched so legitimate whitespace/ordering
+          differences in flow-style payloads still surface as mismatches.
+
+        - **JSON-serialisable parsed value**: ``yaml.safe_load`` happily parses
+          bare ISO timestamps into ``datetime`` objects and other tagged YAML
+          types that ``json.dumps`` can't natively encode. Fall back to a
+          string coercion via ``default=str`` so canonicalisation never crashes
+          on these — and tolerate any residual unexpected type by catching
+          ``TypeError``/``ValueError`` and leaving the literal as-is.
         """
         import json
 
         import yaml as _yaml
 
         def _try_yaml_structured(content: str):
-            """Return parsed dict/list if ``content`` is structured YAML; else None."""
+            """Return parsed dict/list if ``content`` is *multi-line* structured YAML.
+
+            Single-line flow-style scalars (``'[1,2,3]'``, ``'{a:1}'``) and bare
+            scalars are explicitly NOT eligible — the wrap-drift bug only
+            manifests on YAML dumps that span multiple lines.
+            """
+            if "\n" not in content:
+                return None
             try:
                 parsed = _yaml.safe_load(content)
             except _yaml.YAMLError:
@@ -880,7 +900,13 @@ class SnapshotDataSourceConnection(DataSourceConnection):
                 parsed = _try_yaml_structured(inner[1:-1])
             if parsed is None:
                 return literal
-            canonical = json.dumps(parsed, sort_keys=True)
+            try:
+                # ``default=str`` coerces non-JSON-serialisable values (e.g.
+                # ``datetime`` parsed from unquoted ISO timestamps) to their
+                # str() form so canonicalisation produces a stable text.
+                canonical = json.dumps(parsed, sort_keys=True, default=str)
+            except (TypeError, ValueError):
+                return literal
             return "'" + canonical.replace("'", "''") + "'"
 
         return re.sub(r"'(?:[^']|'')*'", _repl, sql)

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -829,11 +829,61 @@ class SnapshotDataSourceConnection(DataSourceConnection):
         sql = _SODA_TEMP_RE.sub(_SODA_TEMP_PLACEHOLDER, sql)
         return sql
 
+    @staticmethod
+    def _canonicalize_yaml_literals(sql: str) -> str:
+        """Replace YAML-formatted single-quoted string literals with canonical JSON.
+
+        Some columns persist structured data as a YAML dump (notably
+        ``check_results.check_definition``). YAML's plain-scalar line-wrap column
+        depends on content length, so the same logical value can serialize to
+        different textual forms across runs when the surrounding content changes
+        length (e.g. a different test-session schema name length shifts the wrap
+        point). Such whitespace-only differences are semantically irrelevant —
+        ``yaml.safe_load`` collapses ``\\n + indent`` to a single space and returns
+        identical Python objects either way.
+
+        For every single-quoted SQL literal that parses as structured YAML (dict
+        or list), substitute its sorted-key JSON canonical form, so that
+        downstream string comparison is insensitive to YAML pretty-print drift.
+        Literals that fail to parse, or parse to a bare scalar, are left
+        untouched — keeping the rewrite confined to values that actually
+        embedded YAML data on purpose.
+        """
+        import json
+
+        import yaml as _yaml
+
+        def _repl(match: "re.Match[str]") -> str:
+            literal = match.group(0)
+            # SQL single-quote escaping: '' inside a literal represents a single '
+            inner = literal[1:-1].replace("''", "'")
+            try:
+                parsed = _yaml.safe_load(inner)
+            except _yaml.YAMLError:
+                return literal
+            if not isinstance(parsed, (dict, list)):
+                return literal
+            canonical = json.dumps(parsed, sort_keys=True)
+            return "'" + canonical.replace("'", "''") + "'"
+
+        return re.sub(r"'(?:[^']|'')*'", _repl, sql)
+
     def _sql_matches(self, stored_sql: str, incoming_sql: str) -> bool:
-        """Compare two SQL strings, optionally normalizing dynamic values first."""
+        """Compare two SQL strings, optionally normalizing dynamic values first.
+
+        Strict equality is the fast path. On miss, a YAML-aware fallback
+        canonicalizes any single-quoted literals that embed structured YAML so
+        that cosmetic line-wrap differences (e.g. in the ``check_definition``
+        column) don't trigger spurious mismatches.
+        """
         if self.normalize_timestamps:
-            return self._normalize_dynamic_values(stored_sql) == self._normalize_dynamic_values(incoming_sql)
-        return stored_sql == incoming_sql
+            stored = self._normalize_dynamic_values(stored_sql)
+            incoming = self._normalize_dynamic_values(incoming_sql)
+        else:
+            stored, incoming = stored_sql, incoming_sql
+        if stored == incoming:
+            return True
+        return self._canonicalize_yaml_literals(stored) == self._canonicalize_yaml_literals(incoming)
 
     def _next_replay_entry(self, expected_type: str, expected_sql: str) -> SnapshotEntry:
         """Get the next entry from the replay data and verify it matches.

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -855,16 +855,23 @@ class SnapshotDataSourceConnection(DataSourceConnection):
           ``'{a: 1}'`` are left untouched so legitimate whitespace/ordering
           differences in flow-style payloads still surface as mismatches.
 
-        - **JSON-serialisable parsed value**: ``yaml.safe_load`` happily parses
+        - **JSON-serialisable parsed value**: the YAML loader happily parses
           bare ISO timestamps into ``datetime`` objects and other tagged YAML
           types that ``json.dumps`` can't natively encode. Fall back to a
           string coercion via ``default=str`` so canonicalisation never crashes
           on these — and tolerate any residual unexpected type by catching
           ``TypeError``/``ValueError`` and leaving the literal as-is.
+
+        Uses ``ruamel.yaml`` (a declared soda-core dependency) rather than
+        PyYAML, which isn't pulled in transitively by ``soda-tests`` and would
+        be ``ModuleNotFoundError`` in a clean install.
         """
         import json
 
-        import yaml as _yaml
+        from ruamel.yaml import YAML as _YAML
+        from ruamel.yaml import YAMLError as _YAMLError
+
+        _yaml_loader = _YAML(typ="safe")
 
         def _try_yaml_structured(content: str):
             """Return parsed dict/list if ``content`` is *multi-line* structured YAML.
@@ -876,8 +883,8 @@ class SnapshotDataSourceConnection(DataSourceConnection):
             if "\n" not in content:
                 return None
             try:
-                parsed = _yaml.safe_load(content)
-            except _yaml.YAMLError:
+                parsed = _yaml_loader.load(content)
+            except _YAMLError:
                 return None
             if isinstance(parsed, (dict, list)):
                 return parsed

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -863,10 +863,36 @@ class SnapshotDataSourceConnection(DataSourceConnection):
         ):
             # Show denormalized forms in error for readability
             denormalized = self._denormalize_from_snapshot(stored_entry)
+            # Diagnostic dump: write the FULL Expected/Got pair to disk so it can
+            # be captured as a CI artifact (the in-error truncation makes the
+            # actual diff invisible for long INSERT statements).
+            import os as _os
+
+            diag_dir = _os.environ.get("SODA_TEST_SNAPSHOT_DIAG_DIR")
+            if diag_dir:
+                try:
+                    _os.makedirs(diag_dir, exist_ok=True)
+                    safe_test = (self._current_test_id or "unknown").replace("/", "_").replace(":", "_")[:200]
+                    diag_path = _os.path.join(diag_dir, f"{safe_test}_op{self._replay_index}.txt")
+                    with open(diag_path, "w", encoding="utf-8") as _f:
+                        _f.write(f"Test: {self._current_test_id}\n")
+                        _f.write(f"Operation index: {self._replay_index}\n")
+                        _f.write(f"Stored op_type: {stored_entry.op_type}\n")
+                        _f.write(f"Got op_type:    {expected_type}\n\n")
+                        _f.write("=== Expected SQL (denormalized) ===\n")
+                        _f.write(denormalized.sql)
+                        _f.write("\n\n=== Got SQL (current run) ===\n")
+                        _f.write(expected_sql)
+                        _f.write("\n\n=== Stored SQL (normalized — as in snapshot file) ===\n")
+                        _f.write(stored_entry.sql)
+                        _f.write("\n\n=== Incoming SQL (normalized — what comparison sees) ===\n")
+                        _f.write(incoming_normalized.sql)
+                except Exception:
+                    pass  # best-effort diagnostic
             raise SnapshotMismatchError(
                 f"Snapshot mismatch at operation #{self._replay_index} for test {self._current_test_id}.\n"
-                f"  Expected ({denormalized.op_type}): {denormalized.sql[:200]}\n"
-                f"  Got      ({expected_type}): {expected_sql[:200]}\n"
+                f"  Expected ({denormalized.op_type}): {denormalized.sql[:4000]}\n"
+                f"  Got      ({expected_type}): {expected_sql[:4000]}\n"
                 f"  To re-record, run: SODA_TEST_SNAPSHOT=record pytest ..."
             )
         # Return denormalized entry so callers get usable result data

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -853,15 +853,32 @@ class SnapshotDataSourceConnection(DataSourceConnection):
 
         import yaml as _yaml
 
+        def _try_yaml_structured(content: str):
+            """Return parsed dict/list if ``content`` is structured YAML; else None."""
+            try:
+                parsed = _yaml.safe_load(content)
+            except _yaml.YAMLError:
+                return None
+            if isinstance(parsed, (dict, list)):
+                return parsed
+            return None
+
         def _repl(match: "re.Match[str]") -> str:
             literal = match.group(0)
             # SQL single-quote escaping: '' inside a literal represents a single '
             inner = literal[1:-1].replace("''", "'")
-            try:
-                parsed = _yaml.safe_load(inner)
-            except _yaml.YAMLError:
-                return literal
-            if not isinstance(parsed, (dict, list)):
+            parsed = _try_yaml_structured(inner)
+            # One-level extra unwrap: some dialects (notably BigQuery's
+            # do_bulk_insert) wrap string values in an extra layer of single-quote
+            # escaping, so the SQL literal carries content like ``'YAML-here'`` —
+            # i.e. the structured YAML wrapped in literal single quotes. YAML
+            # parses such content as a single-quoted SCALAR (folding newlines
+            # into spaces), which loses the structure. Detect this pattern by
+            # checking for inner content that starts AND ends with a single
+            # quote, strip that layer, and retry the structured parse.
+            if parsed is None and len(inner) >= 2 and inner.startswith("'") and inner.endswith("'"):
+                parsed = _try_yaml_structured(inner[1:-1])
+            if parsed is None:
                 return literal
             canonical = json.dumps(parsed, sort_keys=True)
             return "'" + canonical.replace("'", "''") + "'"

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -1008,6 +1008,102 @@ class TestTimestampNormalization:
             conn.execute_update("CREATE TABLE __soda_temp_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2 AS SELECT 1")
 
 
+class TestYamlAwareSqlMatching:
+    """Tests for the YAML-aware fallback in _sql_matches.
+
+    Some SQL columns persist structured data as a YAML dump (notably
+    check_results.check_definition). YAML's plain-scalar line-wrap column
+    depends on surrounding content length, so the same logical value can
+    serialize to different textual forms across runs. The fallback path
+    in _sql_matches canonicalizes such literals via ``yaml.safe_load`` →
+    sorted-key JSON, so cosmetic wrap differences match.
+    """
+
+    def _conn(self):
+        manager = SnapshotManager("postgres", ".test_snapshots_temp")
+        return SnapshotDataSourceConnection(real_connection=None, snapshot_manager=manager, mode="replay")
+
+    def test_yaml_literal_wrap_difference_matches(self):
+        """Same YAML value, different line-wrap columns → matches."""
+        conn = self._conn()
+        stored = "INSERT INTO t (def) VALUES ('checks:\n" '- query: select * from "schema"."table" where x = 5\n\')'
+        # Same YAML content, but PyYAML chose to wrap at a different column.
+        incoming = (
+            "INSERT INTO t (def) VALUES ('checks:\n" '- query: select * from \n    "schema"."table" where x = 5\n\')'
+        )
+        assert stored != incoming, "literals must differ textually for the test to be meaningful"
+        assert conn._sql_matches(stored, incoming)
+
+    def test_yaml_literal_real_difference_does_not_match(self):
+        """Structurally different YAML in a literal → no match."""
+        conn = self._conn()
+        stored = "INSERT INTO t (def) VALUES ('checks:\n- query: select 1\n')"
+        incoming = "INSERT INTO t (def) VALUES ('checks:\n- query: select 2\n')"
+        assert not conn._sql_matches(stored, incoming)
+
+    def test_bare_scalar_literal_not_canonicalized(self):
+        """Single-quoted literal that parses to a bare scalar is left untouched.
+
+        Without this guard, ``'just_a_string'`` and ``'just a string'`` would
+        both parse as Python strings via yaml.safe_load and incorrectly
+        compare equal.
+        """
+        conn = self._conn()
+        stored = "INSERT INTO t (s) VALUES ('hello world')"
+        incoming = "INSERT INTO t (s) VALUES ('hello  world')"  # two spaces
+        # Plain scalars are NOT canonicalized → still differ.
+        assert not conn._sql_matches(stored, incoming)
+
+    def test_malformed_yaml_literal_left_untouched(self):
+        """A literal that doesn't parse as YAML falls back to strict comparison."""
+        conn = self._conn()
+        # Unbalanced braces — not valid YAML
+        stored = "INSERT INTO t (raw) VALUES ('{[broken')"
+        incoming = "INSERT INTO t (raw) VALUES ('[broken')"
+        assert not conn._sql_matches(stored, incoming)
+
+    def test_yaml_with_placeholders_inside_matches(self):
+        """Placeholders inside YAML strings carry through canonicalization."""
+        conn = self._conn()
+        stored = (
+            "INSERT INTO t (def) VALUES ('checks:\n"
+            '- query: select * from "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
+            "    where x = 5\n')"
+        )
+        incoming = (
+            "INSERT INTO t (def) VALUES ('checks:\n"
+            "- query: select * from \n"
+            '    "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
+            "    where x = 5\n')"
+        )
+        assert conn._sql_matches(stored, incoming)
+
+    def test_yaml_aware_match_respects_timestamps_when_enabled(self):
+        """Timestamp normalization runs before the YAML fallback."""
+        conn = self._conn()
+        conn.normalize_timestamps = True
+        # Different timestamps + YAML wrap drift in different literals
+        stored = (
+            "INSERT INTO t (ts, def) VALUES ('2026-03-16T18:24:35.151223', " "'checks:\n- query: select 1 from t\n')"
+        )
+        incoming = (
+            "INSERT INTO t (ts, def) VALUES ('2026-04-22T09:00:00.000000', "
+            "'checks:\n- query: select 1\n    from t\n')"
+        )
+        assert conn._sql_matches(stored, incoming)
+
+    def test_canonicalize_static_helper_idempotent(self):
+        """Canonicalizing twice yields the same result (sanity)."""
+        sql = "INSERT INTO t VALUES ('checks:\n- query: select 1\n')"
+        once = SnapshotDataSourceConnection._canonicalize_yaml_literals(sql)
+        twice = SnapshotDataSourceConnection._canonicalize_yaml_literals(once)
+        assert once == twice
+
+    def test_canonicalize_static_helper_leaves_non_yaml_alone(self):
+        sql = "INSERT INTO t VALUES ('plain text', 42, NULL)"
+        assert SnapshotDataSourceConnection._canonicalize_yaml_literals(sql) == sql
+
+
 # ---------------------------------------------------------------------------
 # Unconsumed entries detection
 # ---------------------------------------------------------------------------

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -1129,6 +1129,47 @@ class TestYamlAwareSqlMatching:
         incoming = "INSERT INTO t (def) VALUES ('''checks:\n- query: select 2\n''')"
         assert not conn._sql_matches(stored, incoming)
 
+    def test_single_line_flow_list_left_untouched(self):
+        """Single-line YAML flow-style list literals must NOT be canonicalised.
+
+        Without the multi-line guard, ``yaml.safe_load("[1,2,3]")`` returns a
+        list and would be treated as structured YAML — making ``'[1, 2, 3]'``
+        and ``'[1,2,3]'`` falsely-equal. That would mask real differences in
+        columns that legitimately persist textual lists.
+        """
+        conn = self._conn()
+        stored = "INSERT INTO t (arr) VALUES ('[1, 2, 3]')"
+        incoming = "INSERT INTO t (arr) VALUES ('[1,2,3]')"
+        assert not conn._sql_matches(stored, incoming)
+
+    def test_single_line_flow_dict_left_untouched(self):
+        """Single-line YAML flow-style dict literals must NOT be canonicalised.
+
+        Without the guard, key-order differences in ``'{a:1,b:2}'`` vs
+        ``'{b:2,a:1}'`` would be silently flattened by ``sort_keys=True``.
+        """
+        conn = self._conn()
+        stored = "INSERT INTO t (m) VALUES ('{a: 1, b: 2}')"
+        incoming = "INSERT INTO t (m) VALUES ('{b: 2, a: 1}')"
+        assert not conn._sql_matches(stored, incoming)
+
+    def test_yaml_with_unquoted_iso_timestamp_does_not_crash(self):
+        """YAML containing an unquoted ISO timestamp must not crash.
+
+        ``yaml.safe_load`` parses bare ISO timestamps into ``datetime`` objects,
+        which ``json.dumps`` cannot natively serialise. The canonicaliser falls
+        back to ``str()`` coercion (via ``default=str``) so the comparison
+        proceeds instead of raising ``TypeError``.
+        """
+        conn = self._conn()
+        stored = "INSERT INTO t (def) VALUES ('checks:\n- created: 2026-03-16T18:24:35.151223\n')"
+        # Identical content — strict-equality fast path covers this. The point
+        # of the test is that the canonicaliser doesn't crash when it does run.
+        assert conn._sql_matches(stored, stored)
+        # And different content with timestamps still doesn't match.
+        incoming = "INSERT INTO t (def) VALUES ('checks:\n- created: 2026-04-22T09:00:00.000000\n')"
+        assert not conn._sql_matches(stored, incoming)
+
 
 # ---------------------------------------------------------------------------
 # Unconsumed entries detection

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -1103,6 +1103,32 @@ class TestYamlAwareSqlMatching:
         sql = "INSERT INTO t VALUES ('plain text', 42, NULL)"
         assert SnapshotDataSourceConnection._canonicalize_yaml_literals(sql) == sql
 
+    def test_bigquery_style_double_wrapped_yaml_matches(self):
+        """BigQuery's bulk-insert wraps string values in an extra layer of single-
+        quote escaping, so a YAML check_definition value appears as ``'''YAML'''``
+        at the SQL surface. After SQL unescape that decodes to ``'YAML'`` — a YAML
+        single-quoted scalar that ``safe_load`` returns as a string, not a dict.
+        The one-level recursive unwrap re-parses the string so structured YAML
+        nested under the extra escape layer still canonicalizes.
+        """
+        conn = self._conn()
+        stored = (
+            "INSERT INTO t (def) VALUES ('''checks:\n" '- query: select * from "schema"."table" where x = 5\n\'\'\')'
+        )
+        incoming = (
+            "INSERT INTO t (def) VALUES ('''checks:\n"
+            '- query: select * from \n    "schema"."table" where x = 5\n\'\'\')'
+        )
+        assert stored != incoming
+        assert conn._sql_matches(stored, incoming)
+
+    def test_double_wrapped_real_difference_does_not_match(self):
+        """Structurally different YAML inside a double-wrapped literal → no match."""
+        conn = self._conn()
+        stored = "INSERT INTO t (def) VALUES ('''checks:\n- query: select 1\n''')"
+        incoming = "INSERT INTO t (def) VALUES ('''checks:\n- query: select 2\n''')"
+        assert not conn._sql_matches(stored, incoming)
+
 
 # ---------------------------------------------------------------------------
 # Unconsumed entries detection

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -1026,10 +1026,10 @@ class TestYamlAwareSqlMatching:
     def test_yaml_literal_wrap_difference_matches(self):
         """Same YAML value, different line-wrap columns → matches."""
         conn = self._conn()
-        stored = "INSERT INTO t (def) VALUES ('checks:\n" '- query: select * from "schema"."table" where x = 5\n\')'
-        # Same YAML content, but PyYAML chose to wrap at a different column.
+        stored = "INSERT INTO t (def) VALUES ('checks:\n" + '- query: select * from "schema"."table" where x = 5\n\')'
+        # Same YAML content, but the YAML dumper chose to wrap at a different column.
         incoming = (
-            "INSERT INTO t (def) VALUES ('checks:\n" '- query: select * from \n    "schema"."table" where x = 5\n\')'
+            "INSERT INTO t (def) VALUES ('checks:\n" + '- query: select * from \n    "schema"."table" where x = 5\n\')'
         )
         assert stored != incoming, "literals must differ textually for the test to be meaningful"
         assert conn._sql_matches(stored, incoming)
@@ -1067,14 +1067,14 @@ class TestYamlAwareSqlMatching:
         conn = self._conn()
         stored = (
             "INSERT INTO t (def) VALUES ('checks:\n"
-            '- query: select * from "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
-            "    where x = 5\n')"
+            + '- query: select * from "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
+            + "    where x = 5\n')"
         )
         incoming = (
             "INSERT INTO t (def) VALUES ('checks:\n"
-            "- query: select * from \n"
-            '    "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
-            "    where x = 5\n')"
+            + "- query: select * from \n"
+            + '    "__$$__soda_test_schema__$$__"."SODATEST_x"\n'
+            + "    where x = 5\n')"
         )
         assert conn._sql_matches(stored, incoming)
 
@@ -1084,11 +1084,11 @@ class TestYamlAwareSqlMatching:
         conn.normalize_timestamps = True
         # Different timestamps + YAML wrap drift in different literals
         stored = (
-            "INSERT INTO t (ts, def) VALUES ('2026-03-16T18:24:35.151223', " "'checks:\n- query: select 1 from t\n')"
+            "INSERT INTO t (ts, def) VALUES ('2026-03-16T18:24:35.151223', " + "'checks:\n- query: select 1 from t\n')"
         )
         incoming = (
             "INSERT INTO t (ts, def) VALUES ('2026-04-22T09:00:00.000000', "
-            "'checks:\n- query: select 1\n    from t\n')"
+            + "'checks:\n- query: select 1\n    from t\n')"
         )
         assert conn._sql_matches(stored, incoming)
 
@@ -1113,11 +1113,11 @@ class TestYamlAwareSqlMatching:
         """
         conn = self._conn()
         stored = (
-            "INSERT INTO t (def) VALUES ('''checks:\n" '- query: select * from "schema"."table" where x = 5\n\'\'\')'
+            "INSERT INTO t (def) VALUES ('''checks:\n" + '- query: select * from "schema"."table" where x = 5\n\'\'\')'
         )
         incoming = (
             "INSERT INTO t (def) VALUES ('''checks:\n"
-            '- query: select * from \n    "schema"."table" where x = 5\n\'\'\')'
+            + '- query: select * from \n    "schema"."table" where x = 5\n\'\'\')'
         )
         assert stored != incoming
         assert conn._sql_matches(stored, incoming)


### PR DESCRIPTION
## Summary

Makes `SnapshotDataSourceConnection._sql_matches` tolerant of cosmetic YAML pretty-print drift in SQL string literals, fixing a class of snapshot replay failures in cross-source DWH tests. Also adds an opt-in on-disk diagnostic dump for snapshot mismatches.

The strict-equality fast path is **unchanged** — currently-passing snapshots take the same path. Every new behaviour fires only when strict equality misses.

Paired with [soda-extensions#406](https://github.com/sodadata/soda-extensions/pull/406) — the soda-extensions cross-source CI consumes this branch via the `resolve-soda-core-branch` matching-ref-name mechanism.

## Root cause

The `check_results.check_definition` column persists a YAML dump of the user's check definition. PyYAML's plain-scalar line-wrap column depends on content length: when surrounding content shifts (e.g. a different test-session schema name length pushes the wrap a few characters further), the same logical YAML value serialises to two textually-different strings.

After the existing schema-name placeholder substitution runs, the wrap-point difference still remains as a `\n + indent` vs single-space difference inside the snapshot SQL. Strict equality fails, even though YAML's folded-scalar semantics treat both forms as the same string.

In soda-extensions cross-source CI this surfaced as `test_dwh_cross_source_frq` failing for Oracle and Trino source jobs on every target. Postgres and Snowflake source happen to have a longer 3-part qualified-name format that pushes the wrap point past the schema reference, so they don't trip on it. BigQuery as target adds an extra single-quote escape layer that turns the YAML into a single-quoted scalar, which needs its own handling.

## What this PR adds

### 1. YAML-aware `_sql_matches` fallback (`_canonicalize_yaml_literals`)

On strict-equality miss, scan each single-quoted SQL literal with regex `r"'(?:[^']|'')*'"`, attempt `yaml.safe_load`, and substitute the parsed value's sorted-key JSON canonical form before comparing.

Guards constrain when the rewrite fires:

- **Multi-line only** (`"\n" in inner`) — the wrap-drift bug only manifests on multi-line YAML dumps. Single-line flow-style literals like `'[1,2,3]'` or `'{a: 1}'` are explicitly left untouched so legitimate whitespace/ordering differences in those payloads still surface as mismatches.
- **Structured value only** — bare scalars, malformed YAML, etc. fall through to the literal.
- **JSON-serialisable** — `default=str` on `json.dumps` handles `yaml.safe_load` parsing bare ISO timestamps to `datetime` objects (and similar tagged YAML types). Residual `TypeError`/`ValueError` are caught and fall through.

### 2. One-level extra-escape unwrap for BigQuery-style triple-quoting

BigQuery's `do_bulk_insert` wraps string values in an extra layer of single-quote escaping, so the SQL literal carries content like `'YAML-here'` — i.e. the structured YAML wrapped in literal single quotes. YAML's quoted-scalar form folds newlines and loses structure on parse. When the first structured-parse attempt misses **and** the inner content starts and ends with a single quote, strip that layer and retry the structured parse.

### 3. Diagnostic dump for snapshot mismatches

When `SODA_TEST_SNAPSHOT_DIAG_DIR` is set, every `SnapshotMismatchError` writes a per-test file with the full Expected/Got SQL pair plus their normalised forms. Lets CI pipelines (notably soda-extensions cross-source) upload mismatch details as an artifact for downstream inspection — the truncated in-error message hides the actual diff for long INSERT statements. The in-error truncation is bumped from 200 → 4000 chars too.

This is diagnostic-only — env var unset = no behaviour change.

## Test plan

- [x] `soda-tests/tests/unit/test_snapshot.py::TestYamlAwareSqlMatching` — 13 cases covering: wrap-difference match, structural-difference no-match, bare scalar untouched, malformed YAML left alone, placeholders inside YAML, timestamp normalisation composes, idempotence, non-YAML SQL untouched, BigQuery-style double-wrap match, double-wrap real-difference no-match, single-line flow list untouched, single-line flow dict untouched, YAML with unquoted ISO timestamp doesn't crash.
- [x] Full `test_snapshot.py` suite passes (121 tests).
- [x] Local `test_dwh_cross_source_frq[oracle-postgres]` and `[duckdb-postgres]` record+strict-replay cleanly.
- [x] soda-extensions PR #406 cross-source CI dropped from 285 failures to 0 once this branch was consumed.

## Commits in this PR

1. `chore: dump full SQL pair to disk on snapshot mismatch` — diagnostic infrastructure
2. `fix: YAML-aware SQL snapshot comparison` — core fallback + canonicalisation
3. `fix: YAML-aware match handles BigQuery's extra single-quote escape layer` — one-level extra unwrap
4. `fix: tighten YAML-aware match — multi-line only + tolerate non-JSON types` — multi-line guard + `default=str`

🤖 Generated with [Claude Code](https://claude.com/claude-code)