### PR TITLE
fix(contracts): report scan FAILED instead of COMPLETED_WITH_ERRORS on pre-results failure

### DIFF
--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -114,6 +114,14 @@ class CheckCollectionResult:
         return self.status is CheckCollectionStatus.ERROR
 
     @property
+    def errored_without_results(self) -> bool:
+        """True when the run errored before producing any check results (e.g. the data
+        source connection failed). Such a scan must be reported to Soda Cloud as FAILED,
+        not sent as results: Cloud maps an errored result batch to COMPLETED_WITH_ERRORS,
+        a transition the backend forbids while the scan is still PENDING."""
+        return self.has_errors and not self.check_results
+
+    @property
     def is_failed(self) -> bool:
         """
         Returns true if there are checks that have failed.
@@ -860,8 +868,23 @@ class CheckCollectionImpl:
                 # the entire batch on the server-side ingestion filter).
                 sending_results_to_soda_cloud_failed = True
             elif self.combine_uploads:
-                # Session-level combined upload — executor sends after the loop.
+                # Session-level combined upload — executor sends after the loop (and applies
+                # the same errored-without-results -> mark-scan-failed handling there).
                 logger.debug(f"Deferring upload to session-level combined request " f"{Emoticons.FINGERS_CROSSED}")
+            elif verification_result.errored_without_results and self.soda_config.soda_scan_id:
+                # A runner-created (still PENDING) Cloud scan errored before producing any
+                # check results. Report it as FAILED instead of sending results: an errored,
+                # result-less batch makes Cloud attempt PENDING -> COMPLETED_WITH_ERRORS, which
+                # the scan-state machine rejects (invalid_scan_state), whereas PENDING ->
+                # FAILED is allowed — so no false RESULTS_NOT_SENT_TO_CLOUD (exit 4) is raised.
+                # Gate on the scan id (what mark_scan_as_failed needs), not is_running_on_runner:
+                # without a scan id we fall through to the normal upload below, which creates
+                # the scan and preserves the errored result's Cloud visibility.
+                # Stamp the known scan id on the result so post-processing failure reporting
+                # (run_post_processing_handlers) can update Cloud, and pass it explicitly
+                # rather than have mark_scan_as_failed re-read it from the environment.
+                verification_result.scan_id = self.soda_config.soda_scan_id
+                self.soda_cloud.mark_scan_as_failed(scan_id=verification_result.scan_id, logs=log_records)
             else:
                 # send_check_collection_results stamps scan_id + dataset_id
                 # on the result internally; we just hold the response_json

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -25,6 +25,7 @@ from soda_core.common.datetime_conversions import (
     convert_datetime_to_str,
     convert_str_to_datetime,
 )
+from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.exceptions import InvalidArgumentException
 from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import SodaCloud
@@ -244,12 +245,26 @@ def execute_check_collections(
     if soda_cloud_impl is not None and publish_results:
         combined_by_wire_source: dict[str, list[CheckCollectionResult]] = {}
         combined_suffix_by_wire_source: dict[str, Optional[str]] = {}
+        # A runner-created scan id is the precondition for reporting FAILED (it's what
+        # mark_scan_as_failed needs). Ad-hoc runs have no scan id, so for those we keep the
+        # normal upload behavior and don't special-case errored results.
+        soda_scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
+        # First collection that errored before producing any check results (e.g. the data
+        # source connection failed). Such a result must not be sent as results — see the
+        # per-file handling in CheckCollectionImpl.verify(). Held so that, if the whole scan
+        # produced nothing to send, we report it as FAILED. Keep the first match so the logs
+        # used are deterministic when several collections error.
+        errored_without_results_result: Optional[CheckCollectionResult] = None
         for (_, impl_class, _, _), result in zip(constructed, results):
             if impl_class is None or not impl_class.combine_uploads:
                 continue
             # Per-file alignment guard or data-source-missing path already
             # flagged this result; don't include it in the combined upload.
             if result.sending_results_to_soda_cloud_failed:
+                continue
+            if soda_scan_id and result.errored_without_results:
+                if errored_without_results_result is None:
+                    errored_without_results_result = result
                 continue
             file_id = (
                 result.check_collection.source.soda_cloud_file_id
@@ -267,6 +282,31 @@ def execute_check_collections(
                 results=group,
                 wire_source=wire_source,
                 scan_definition_suffix=combined_suffix_by_wire_source.get(wire_source),
+            )
+
+        # Report the (still-PENDING) scan as FAILED only when the whole scan produced nothing
+        # to send and at least one collection errored before producing results. Guarded so we
+        # never override a sibling result that already uploaded (scan_id stamped) or mask a
+        # genuine send failure (sending_results_to_soda_cloud_failed) — those must keep their
+        # own outcome. Sending an errored, result-less batch instead would make Cloud attempt
+        # PENDING -> COMPLETED_WITH_ERRORS, which the scan-state machine rejects; PENDING ->
+        # FAILED is allowed.
+        if (
+            soda_scan_id
+            and errored_without_results_result is not None
+            and not combined_by_wire_source
+            and not any(r.scan_id for r in results)
+            and not any(r.sending_results_to_soda_cloud_failed for r in results)
+        ):
+            # Stamp the known scan id (so post-processing failure reporting can update Cloud)
+            # and pass it explicitly. Forward any stored exception too: executor placeholders
+            # (build_error_result) carry result.error but log_records=None, so without this the
+            # scan would be marked FAILED in Cloud with an empty, undiagnosable log payload.
+            errored_without_results_result.scan_id = soda_scan_id
+            soda_cloud_impl.mark_scan_as_failed(
+                scan_id=soda_scan_id,
+                logs=errored_without_results_result.log_records,
+                exc=errored_without_results_result.error,
             )
 
     # Post-processing handlers — run for every successfully-VERIFIED

--- a/soda-core/src/soda_core/common/env_config_helper.py
+++ b/soda-core/src/soda_core/common/env_config_helper.py
@@ -54,6 +54,14 @@ class EnvConfigHelper:
         return os.getenv("SODA_INSTRUCTION_ID")
 
     @property
+    def soda_scan_id(self) -> str | None:
+        # Set by the Soda Runner/agent for managed scans: the id of the pre-created Cloud scan.
+        # Presence of this id is the precondition for reporting a scan as failed
+        # (mark_scan_as_failed needs it) — not is_running_on_runner, which only reflects
+        # SODA_INSTRUCTION_ID and can be set without a scan id.
+        return os.getenv("SODA_SCAN_ID")
+
+    @property
     def is_running_on_runner(self) -> bool:
         # SODA_INSTRUCTION_ID is only set when running in Soda Runner (formerly Soda Agent).
         # The env var name itself remains SODA_INSTRUCTION_ID for backwards compatibility with

--- a/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
+++ b/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
@@ -1,0 +1,147 @@
+"""
+When a contract verification fails before producing any check results — e.g. the
+data source connection fails — the run must be reported to Soda Cloud as a FAILED
+scan (``sodaCoreMarkScanFailed``), not sent as results (``sodaCoreInsertScanResults``)
+which the backend interprets as COMPLETED_WITH_ERRORS.
+
+A managed/agent scan is still in PENDING at this point, and the Cloud state machine
+forbids PENDING -> COMPLETED_WITH_ERRORS (only PENDING -> FAILED is allowed), so the
+result upload 400s with ``invalid_scan_state`` -> exit code 4. Reporting FAILED keeps
+the send valid.
+"""
+
+from unittest.mock import patch
+
+from helpers.mock_soda_cloud import MockSodaCloud
+from soda_core.common.data_source_impl import DataSourceImpl
+from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
+from soda_core.contracts.contract_verification import ContractVerificationSession
+from soda_core.contracts.impl.contract_verification_impl import ContractImpl
+
+_DATA_SOURCE_YAML = """
+type: duckdb
+name: test_ds
+connection:
+    database: ":memory:"
+    schema: main
+"""
+
+_CONTRACT_YAML = """
+dataset: test_ds/main/my_table
+columns:
+  - name: id
+"""
+
+
+def test_connection_failure_marks_scan_failed_not_completed_with_errors(monkeypatch):
+    # A runner-created scan id is the precondition for reporting FAILED; mark_scan_as_failed
+    # uses it to transition the (still PENDING) scan to FAILED.
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+
+    data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(_DATA_SOURCE_YAML))
+
+    mock_cloud = MockSodaCloud()
+    # The contract YAML file always uploads first; pin its result so the send/mark
+    # decision is the only thing under test (independent of response ordering).
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    with patch(
+        "soda_duckdb.common.data_sources.duckdb_data_source.DuckDBDataSourceConnection._create_connection",
+        side_effect=RuntimeError("Invalid access token"),
+    ):
+        session_result = ContractVerificationSession.execute(
+            contract_yaml_sources=[ContractYamlSource.from_str(_CONTRACT_YAML)],
+            data_source_impls=[data_source_impl],
+            soda_cloud_impl=mock_cloud,
+            soda_cloud_publish_results=True,
+        )
+
+    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
+
+    assert "sodaCoreInsertScanResults" not in request_types, (
+        "A scan that errored before producing any check results must NOT be sent as results "
+        f"(COMPLETED_WITH_ERRORS). Requests seen: {request_types}"
+    )
+    mark_requests = [
+        r.json
+        for r in mock_cloud.requests
+        if isinstance(r.json, dict) and r.json.get("type") == "sodaCoreMarkScanFailed"
+    ]
+    assert (
+        mark_requests
+    ), f"A scan that errored before producing any check results must be marked FAILED. {request_types}"
+    # The known scan id is passed to the mark request and stamped on the result.
+    assert mark_requests[0].get("scanId") == "scan-under-test"
+    assert session_result.contract_verification_results[0].scan_id == "scan-under-test"
+
+
+def test_combine_uploads_path_marks_scan_failed_on_connection_error(monkeypatch):
+    # Data Standards is the combine_uploads=True subtype; its results are sent via the
+    # session-level combined-upload path, not the per-file verify() path. Force combine
+    # mode on the contract impl to exercise that path with the same connection failure.
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+    monkeypatch.setattr(ContractImpl, "combine_uploads", True)
+
+    data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(_DATA_SOURCE_YAML))
+
+    mock_cloud = MockSodaCloud()
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    with patch(
+        "soda_duckdb.common.data_sources.duckdb_data_source.DuckDBDataSourceConnection._create_connection",
+        side_effect=RuntimeError("Invalid access token"),
+    ):
+        ContractVerificationSession.execute(
+            contract_yaml_sources=[ContractYamlSource.from_str(_CONTRACT_YAML)],
+            data_source_impls=[data_source_impl],
+            soda_cloud_impl=mock_cloud,
+            soda_cloud_publish_results=True,
+        )
+
+    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
+
+    assert "sodaCoreInsertScanResults" not in request_types, (
+        "Combine-uploads path must not send an errored-before-results scan as results. "
+        f"Requests seen: {request_types}"
+    )
+    mark_requests = [
+        r.json
+        for r in mock_cloud.requests
+        if isinstance(r.json, dict) and r.json.get("type") == "sodaCoreMarkScanFailed"
+    ]
+    assert mark_requests, f"Combine-uploads path must mark the scan FAILED. Requests seen: {request_types}"
+    assert mark_requests[0].get("scanId") == "scan-under-test"
+
+
+def test_ad_hoc_run_without_scan_id_still_uploads_results(monkeypatch):
+    # Ad-hoc CLI runs have no pre-created PENDING scan and no SODA_SCAN_ID, so they don't hit
+    # the invalid_scan_state transition. mark_scan_as_failed would be a no-op (losing the
+    # errored scan in Cloud), so the engine must keep uploading results to create the scan.
+    monkeypatch.delenv("SODA_SCAN_ID", raising=False)
+
+    data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(_DATA_SOURCE_YAML))
+
+    mock_cloud = MockSodaCloud()
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    with patch(
+        "soda_duckdb.common.data_sources.duckdb_data_source.DuckDBDataSourceConnection._create_connection",
+        side_effect=RuntimeError("Invalid access token"),
+    ):
+        ContractVerificationSession.execute(
+            contract_yaml_sources=[ContractYamlSource.from_str(_CONTRACT_YAML)],
+            data_source_impls=[data_source_impl],
+            soda_cloud_impl=mock_cloud,
+            soda_cloud_publish_results=True,
+        )
+
+    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
+
+    assert "sodaCoreInsertScanResults" in request_types, (
+        "Ad-hoc run (no SODA_SCAN_ID) must still upload results to create the scan in Cloud. "
+        f"Requests seen: {request_types}"
+    )
+    assert "sodaCoreMarkScanFailed" not in request_types, (
+        "Ad-hoc run has no scan id to mark failed; mark_scan_as_failed must not be used. "
+        f"Requests seen: {request_types}"
+    )


### PR DESCRIPTION
Fixes DTL-1800. Source incident: [SAS-12468](https://sodadata.atlassian.net/browse/SAS-12468).

## Problem
When a contract verification fails **before producing any check results** (e.g. the data source connection fails — Databricks 403 in the incident), core sends an errored, result-less batch to Soda Cloud. The backend maps that to `COMPLETED_WITH_ERRORS`. For a managed scan still in `PENDING`, the scan-state machine forbids `PENDING -> COMPLETED_WITH_ERRORS` (`ScanState.PENDING` allows only SUBMITTED/FAILED/CANCELED), so the upload returns `400 invalid_scan_state` → exit code 4 (`RESULTS_NOT_SENT_TO_CLOUD`) → the contract launcher raises `LibraryExecutionEngineException` and pages via Datadog.

## Fix
Report such a run as **FAILED** via `mark_scan_as_failed` (`PENDING -> FAILED` is allowed) instead of sending results. The report lands, no false `RESULTS_NOT_SENT_TO_CLOUD` is raised, and **genuine "could not send to Cloud" failures still surface** (this only changes the terminal state core requests when the run produced nothing).

- New predicate `CheckCollectionResult.errored_without_results` (errored **and** zero check results).
- `CheckCollectionImpl.verify()` (per-file/non-combine path): route to `mark_scan_as_failed`.
- `session.py` combined-upload path (`combine_uploads=True` subtypes, e.g. **Data Standards**): skip such results from the combined send and mark the scan FAILED when the whole scan produced nothing to send.

## Tests
`soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py` — covers both the per-file and combine-upload paths by patching the DuckDB connection to fail. Both assert `sodaCoreMarkScanFailed` is sent and `sodaCoreInsertScanResults` is not. Full unit suite: 871 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SAS-12468]: https://sodadata.atlassian.net/browse/SAS-12468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ