### PR TITLE
Add public SodaCloud.execute_query seam (superseded by #2734)

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1106,10 +1106,19 @@ class SodaCloud:
             request_log_name="get_scan_logs",
         )
 
-    def _execute_query(self, query_json_dict: dict, request_log_name: str) -> Response:
+    def execute_query(self, query_json_dict: dict, request_log_name: str) -> Response:
+        """Public seam for issuing a CQRS query to Soda Cloud.
+
+        Generic and feature-neutral: callers issue their own typed queries through
+        this method rather than reaching into the private request helpers.
+        """
         return self._execute_cqrs_request(
             request_type="query", request_log_name=request_log_name, request_body=query_json_dict, is_retry=True
         )
+
+    def _execute_query(self, query_json_dict: dict, request_log_name: str) -> Response:
+        # Backwards-compatible private alias for existing internal callers.
+        return self.execute_query(query_json_dict, request_log_name)
 
     def _execute_command(self, command_json_dict: dict, request_log_name: str) -> Response:
         return self._execute_cqrs_request(

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -798,3 +798,21 @@ def test_build_token_usage_dicts_empty_when_no_usage():
 
     mock_result.token_usage = []
     assert _build_token_usage_dicts(mock_result) == []
+
+
+@mock.patch("requests.post")
+def test_execute_query_public_seam_posts_to_query_endpoint(mock_post):
+    soda_cloud = SodaCloud.from_yaml_source(YAML_SOURCE, provided_variable_values={})
+    soda_cloud.token = "some_token"
+    mock_post.return_value = MockResponse(status_code=200, json_object={"ok": True})
+
+    response = soda_cloud.execute_query(
+        {"type": "someQueryType", "dataset": {"name": "x"}},
+        request_log_name="some_query",
+    )
+
+    assert response.status_code == 200
+    called = mock_post.call_args
+    assert called.kwargs["url"].endswith("/api/query")
+    assert called.kwargs["json"]["type"] == "someQueryType"
+    assert called.kwargs["json"]["token"] == "some_token"


### PR DESCRIPTION
Superseded by #2734 — same change, recreated on a renamed branch. This one is closed; please use #2734.