### PR TITLE
fix: return ContractVerificationResult on upload failure in verify_co…

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -643,7 +643,8 @@ class SodaCloud:
         file_id: Optional[str] = self._upload_contract_yaml_file(contract_yaml_str_original)
         if not file_id:
             logger.critical("Contract wasn't uploaded so skipping sending the results to Soda Cloud")
-            return []
+            verification_result.sending_results_to_soda_cloud_failed = True
+            return verification_result
 
         verify_contract_command: dict = {
             "type": "sodaCoreVerifyContract" if publish_results else "sodaCoreTestContract",

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -696,7 +696,8 @@ class SodaCloud:
         file_id: Optional[str] = self._upload_contract_yaml_file(contract_yaml_str_original)
         if not file_id:
             logger.critical("Contract wasn't uploaded so skipping sending the results to Soda Cloud")
-            return []
+            verification_result.sending_results_to_soda_cloud_failed = True
+            return verification_result
 
         verify_contract_command: dict = {
             "type": "sodaCoreVerifyContract" if publish_results else "sodaCoreTestContract",

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -803,8 +803,8 @@ def test_build_token_usage_dicts_empty_when_no_usage():
 def test_verify_contract_on_runner_returns_result_when_upload_fails():
     """If uploading the contract file fails (no fileId), the method must return a ContractVerificationResult
     and set sending_results_to_soda_cloud_failed=True rather than returning a list or other type."""
-    from soda_core.contracts.impl.contract_yaml import ContractYaml
     from soda_core.common.yaml import ContractYamlSource
+    from soda_core.contracts.impl.contract_yaml import ContractYaml
 
     # First response: permission check allowed
     # Second response: upload contract returns 200 but without fileId → treated as upload failure

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -798,3 +798,37 @@ def test_build_token_usage_dicts_empty_when_no_usage():
 
     mock_result.token_usage = []
     assert _build_token_usage_dicts(mock_result) == []
+
+
+def test_verify_contract_on_runner_returns_result_when_upload_fails():
+    """If uploading the contract file fails (no fileId), the method must return a ContractVerificationResult
+    and set sending_results_to_soda_cloud_failed=True rather than returning a list or other type."""
+    from soda_core.contracts.impl.contract_yaml import ContractYaml
+    from soda_core.common.yaml import ContractYamlSource
+
+    # First response: permission check allowed
+    # Second response: upload contract returns 200 but without fileId → treated as upload failure
+    responses = [
+        MockResponse(status_code=200, json_object={"allowed": True}),
+        MockResponse(method=MockHttpMethod.POST, status_code=200, json_object={}),
+    ]
+    mock_cloud = MockSodaCloud(responses)
+
+    result = mock_cloud.verify_contract_on_runner(
+        ContractYaml.parse(
+            ContractYamlSource.from_str(
+                """
+            dataset: test/some/schema/CUSTOMERS
+            columns:
+            - name: id
+        """
+            )
+        ),
+        variables={},
+        blocking_timeout_in_minutes=60,
+        publish_results=False,
+        verbose=False,
+    )
+
+    assert isinstance(result, ContractVerificationResult)
+    assert result.sending_results_to_soda_cloud_failed is True

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -1045,8 +1045,8 @@ def test_execute_dataset_query_non_json_200_body_returns_empty_dict():
 def test_verify_contract_on_runner_returns_result_when_upload_fails():
     """If uploading the contract file fails (no fileId), the method must return a ContractVerificationResult
     and set sending_results_to_soda_cloud_failed=True rather than returning a list or other type."""
-    from soda_core.contracts.impl.contract_yaml import ContractYaml
     from soda_core.common.yaml import ContractYamlSource
+    from soda_core.contracts.impl.contract_yaml import ContractYaml
 
     # First response: permission check allowed
     # Second response: upload contract returns 200 but without fileId → treated as upload failure

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -1040,3 +1040,37 @@ def test_execute_dataset_query_non_json_error_body_raises_soda_cloud_exception_n
 def test_execute_dataset_query_non_json_200_body_returns_empty_dict():
     soda_cloud = _soda_cloud_with_query_response(_query_response(200, json_raises=True))
     assert soda_cloud.execute_dataset_query("sodaCoreGetSomething", "postgres_ds/public/orders", "get_something") == {}
+
+
+def test_verify_contract_on_runner_returns_result_when_upload_fails():
+    """If uploading the contract file fails (no fileId), the method must return a ContractVerificationResult
+    and set sending_results_to_soda_cloud_failed=True rather than returning a list or other type."""
+    from soda_core.contracts.impl.contract_yaml import ContractYaml
+    from soda_core.common.yaml import ContractYamlSource
+
+    # First response: permission check allowed
+    # Second response: upload contract returns 200 but without fileId → treated as upload failure
+    responses = [
+        MockResponse(status_code=200, json_object={"allowed": True}),
+        MockResponse(method=MockHttpMethod.POST, status_code=200, json_object={}),
+    ]
+    mock_cloud = MockSodaCloud(responses)
+
+    result = mock_cloud.verify_contract_on_runner(
+        ContractYaml.parse(
+            ContractYamlSource.from_str(
+                """
+            dataset: test/some/schema/CUSTOMERS
+            columns:
+            - name: id
+        """
+            )
+        ),
+        variables={},
+        blocking_timeout_in_minutes=60,
+        publish_results=False,
+        verbose=False,
+    )
+
+    assert isinstance(result, ContractVerificationResult)
+    assert result.sending_results_to_soda_cloud_failed is True


### PR DESCRIPTION
## Description

- Fixes a wrong return type in [SodaCloud.verify_contract_on_runner()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-core/src/soda_core/common/soda_cloud.py:595:4-762:34) when the contract upload to Soda Cloud fails.
- Previously, the method returned an empty list `[]` on upload failure, while the function is annotated (and expected) to return a `ContractVerificationResult`. This could cause runtime errors or subtle type bugs for callers handling the result.

### Problem being solved
- On a failed contract upload (missing `fileId` in response), [verify_contract_on_runner()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-core/src/soda_core/common/soda_cloud.py:595:4-762:34) returned `[]` instead of a `ContractVerificationResult`.

### Expected impact on downstream packages/services
- Very low risk. This only changes behavior on an error path (upload failure).
- Return type is now consistent with the annotation and with the surrounding call sites' expectations.
- No CLI changes, no external API changes, and no plugin interfaces changed.

## Changes

- In [soda-core/src/soda_core/common/soda_cloud.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-core/src/soda_core/common/soda_cloud.py:0:0-0:0):
  - On missing `fileId` after uploading the contract YAML, set `verification_result.sending_results_to_soda_cloud_failed = True` and return `verification_result` instead of `[]`.

- Tests:
  - Added [test_verify_contract_on_runner_returns_result_when_upload_fails](cci:1://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-tests/tests/unit/test_soda_cloud.py:802:0-833:62) in [soda-tests/tests/unit/test_soda_cloud.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-tests/tests/unit/test_soda_cloud.py:0:0-0:0).
  - The test simulates:
    - Permission check allowed.
    - Upload returns 200 without `fileId` (upload failure).
    - Asserts a `ContractVerificationResult` is returned and `sending_results_to_soda_cloud_failed` is `True`.

## How I verified

- Ran the targeted unit test:
  - [pytest -q soda-tests/tests/unit/test_soda_cloud.py::test_verify_contract_on_runner_returns_result_when_upload_fails](cci:1://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-tests/tests/unit/test_soda_cloud.py:802:0-833:62)
  - Result: passed.

## Affected areas

- Remote verification flow via Soda Runner only in the upload-failure path.
- No effect on successful paths or local verification flows.

## Backward compatibility and risks

- Backward compatible for correct callers; previously returning `[]` was a bug.
- Risk is limited to making the error path consistent and type-safe.
- No dependency changes, no schema or protocol changes.

## Files changed

- [soda-core/src/soda_core/common/soda_cloud.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-core/src/soda_core/common/soda_cloud.py:0:0-0:0)
- [soda-tests/tests/unit/test_soda_cloud.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-tests/tests/unit/test_soda_cloud.py:0:0-0:0)

## Checklist

- [x] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions](https://github.com/sodadata/soda-extensions) (no interface changes; low risk).

## Release notes

- Fix: [SodaCloud.verify_contract_on_runner()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/soda-core/soda-core/src/soda_core/common/soda_cloud.py:595:4-762:34) now returns a `ContractVerificationResult` (with `sending_results_to_soda_cloud_failed=True`) when the contract upload fails, instead of returning `[]`.