### PR TITLE
PLATL-703: warn when account_info_json is provided alongside use_context_auth

### DIFF
--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -91,7 +91,7 @@ class BigQueryDataSourceConnection(DataSourceConnection):
     def _load_project_id_and_credentials(self, config: BigQueryConnectionProperties):
         if isinstance(config, BigQueryContextAuth):
             if config.account_info_json and config.account_info_json.get_secret_value():
-                logger.warning("account_info_json was provided but is ignored because use_context_auth is enabled.")
+                logger.info("account_info_json was provided but is ignored because use_context_auth is enabled.")
             logger.info("Using application default credentials.")
             self.credentials, self.project_id = default()
             return

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -62,10 +62,16 @@ class BigQueryContextAuth(BigQueryConnectionProperties):
     """BigQuery authentication using context.
 
     If use_context_auth is True, then application default credentials will be used.
-    The user may optionally provide JSON credentials; they will be ignored.
+    account_info_json is accepted (so a single connection form can carry both auth modes
+    without losing the user's input when toggling) but is ignored at credential resolution
+    time; a warning is logged when both are present.
     """
 
     use_context_auth: Literal[True] = Field(description=CONTEXT_AUTHENTICATION_DESCRIPTION)
+    account_info_json: Optional[SecretStr] = Field(
+        None,
+        description="Ignored when use_context_auth is True; accepted to round-trip form state",
+    )
 
 
 class BigQueryDataSource(DataSourceBase, ABC):
@@ -84,6 +90,10 @@ class BigQueryDataSourceConnection(DataSourceConnection):
 
     def _load_project_id_and_credentials(self, config: BigQueryConnectionProperties):
         if isinstance(config, BigQueryContextAuth):
+            if config.account_info_json and config.account_info_json.get_secret_value():
+                logger.warning(
+                    "account_info_json was provided but is ignored because use_context_auth is enabled."
+                )
             logger.info("Using application default credentials.")
             self.credentials, self.project_id = default()
             return

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -91,9 +91,7 @@ class BigQueryDataSourceConnection(DataSourceConnection):
     def _load_project_id_and_credentials(self, config: BigQueryConnectionProperties):
         if isinstance(config, BigQueryContextAuth):
             if config.account_info_json and config.account_info_json.get_secret_value():
-                logger.warning(
-                    "account_info_json was provided but is ignored because use_context_auth is enabled."
-                )
+                logger.warning("account_info_json was provided but is ignored because use_context_auth is enabled.")
             logger.info("Using application default credentials.")
             self.credentials, self.project_id = default()
             return

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -62,15 +62,14 @@ class BigQueryContextAuth(BigQueryConnectionProperties):
     """BigQuery authentication using context.
 
     If use_context_auth is True, then application default credentials will be used.
-    account_info_json is accepted (so a single connection form can carry both auth modes
-    without losing the user's input when toggling) but is ignored at credential resolution
-    time; a warning is logged when both are present.
+    account_info_json is accepted but ignored at credential resolution time; an info log
+    is emitted when both are present.
     """
 
     use_context_auth: Literal[True] = Field(description=CONTEXT_AUTHENTICATION_DESCRIPTION)
     account_info_json: Optional[SecretStr] = Field(
         None,
-        description="Ignored when use_context_auth is True; accepted to round-trip form state",
+        description="Ignored when use_context_auth is True; declared so we can detect it being passed and log an info message.",
     )
 
 

--- a/soda-bigquery/tests/data_sources/test_bigquery.py
+++ b/soda-bigquery/tests/data_sources/test_bigquery.py
@@ -83,8 +83,9 @@ test_connections: list[TestConnection] = [
         valid_connection_params=False,
         expected_connection_error="Your default credentials were not found",
     ),
-    TestConnection(  # ADC plus an optional account_info_json — the JSON must be silently
-        # ignored (same env caveat as app_default_creds above)
+    TestConnection(  # ADC plus an optional account_info_json — the JSON must be ignored at
+        # credential resolution, with an info log noting the conflict
+        # (same env caveat as app_default_creds above)
         test_name="app_default_creds_with_optional_json",
         connection_yaml_str="""
                 type: bigquery

--- a/soda-bigquery/tests/data_sources/test_bigquery.py
+++ b/soda-bigquery/tests/data_sources/test_bigquery.py
@@ -83,6 +83,19 @@ test_connections: list[TestConnection] = [
         valid_connection_params=False,
         expected_connection_error="Your default credentials were not found",
     ),
+    TestConnection(  # ADC plus an optional account_info_json — the JSON must be silently
+        # ignored (same env caveat as app_default_creds above)
+        test_name="app_default_creds_with_optional_json",
+        connection_yaml_str="""
+                type: bigquery
+                name: BIGQUERY_TEST_DS
+                connection:
+                    use_context_auth: true
+                    account_info_json: 'optional-fallback-json'
+            """,
+        valid_connection_params=False,
+        expected_connection_error="Your default credentials were not found",
+    ),
     TestConnection(  # impersonation account, should fail at query stage
         test_name="impersonation_account",
         connection_yaml_str=f"""

--- a/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
+++ b/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
@@ -25,8 +25,11 @@ def test_logs_info_when_account_info_json_provided_under_context_auth(caplog, mo
         connection._load_project_id_and_credentials(config)
 
     assert any(
-        "account_info_json" in record.message and "ignored" in record.message for record in caplog.records
-    ), f"Expected a warning about ignored account_info_json. Records: {[r.message for r in caplog.records]}"
+        record.levelno == logging.INFO
+        and "account_info_json" in record.message
+        and "ignored" in record.message
+        for record in caplog.records
+    ), f"Expected an info log about ignored account_info_json. Records: {[(r.levelname, r.message) for r in caplog.records]}"
 
 
 def test_no_log_when_only_use_context_auth_is_provided(caplog, monkeypatch):

--- a/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
+++ b/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
@@ -25,8 +25,7 @@ def test_logs_warning_when_account_info_json_provided_under_context_auth(caplog,
         connection._load_project_id_and_credentials(config)
 
     assert any(
-        "account_info_json" in record.message and "ignored" in record.message
-        for record in caplog.records
+        "account_info_json" in record.message and "ignored" in record.message for record in caplog.records
     ), f"Expected a warning about ignored account_info_json. Records: {[r.message for r in caplog.records]}"
 
 
@@ -41,6 +40,4 @@ def test_no_warning_when_only_use_context_auth_is_provided(caplog, monkeypatch):
     with caplog.at_level(logging.WARNING, logger="soda"):
         connection._load_project_id_and_credentials(config)
 
-    assert not any(
-        "account_info_json" in record.message for record in caplog.records
-    )
+    assert not any("account_info_json" in record.message for record in caplog.records)

--- a/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
+++ b/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
@@ -25,9 +25,7 @@ def test_logs_info_when_account_info_json_provided_under_context_auth(caplog, mo
         connection._load_project_id_and_credentials(config)
 
     assert any(
-        record.levelno == logging.INFO
-        and "account_info_json" in record.message
-        and "ignored" in record.message
+        record.levelno == logging.INFO and "account_info_json" in record.message and "ignored" in record.message
         for record in caplog.records
     ), f"Expected an info log about ignored account_info_json. Records: {[(r.levelname, r.message) for r in caplog.records]}"
 

--- a/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
+++ b/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
@@ -1,0 +1,46 @@
+import logging
+
+from soda_bigquery.common.data_sources.bigquery_data_source_connection import (
+    BigQueryContextAuth,
+    BigQueryDataSourceConnection,
+)
+
+
+def _fake_default():
+    return ("fake-credentials", "fake-project-id")
+
+
+def test_logs_warning_when_account_info_json_provided_under_context_auth(caplog, monkeypatch):
+    monkeypatch.setattr(
+        "soda_bigquery.common.data_sources.bigquery_data_source_connection.default",
+        _fake_default,
+    )
+    config = BigQueryContextAuth(
+        use_context_auth=True,
+        account_info_json="ignored-fallback-json",
+    )
+    connection = BigQueryDataSourceConnection.__new__(BigQueryDataSourceConnection)
+
+    with caplog.at_level(logging.WARNING, logger="soda"):
+        connection._load_project_id_and_credentials(config)
+
+    assert any(
+        "account_info_json" in record.message and "ignored" in record.message
+        for record in caplog.records
+    ), f"Expected a warning about ignored account_info_json. Records: {[r.message for r in caplog.records]}"
+
+
+def test_no_warning_when_only_use_context_auth_is_provided(caplog, monkeypatch):
+    monkeypatch.setattr(
+        "soda_bigquery.common.data_sources.bigquery_data_source_connection.default",
+        _fake_default,
+    )
+    config = BigQueryContextAuth(use_context_auth=True)
+    connection = BigQueryDataSourceConnection.__new__(BigQueryDataSourceConnection)
+
+    with caplog.at_level(logging.WARNING, logger="soda"):
+        connection._load_project_id_and_credentials(config)
+
+    assert not any(
+        "account_info_json" in record.message for record in caplog.records
+    )

--- a/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
+++ b/soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py
@@ -10,7 +10,7 @@ def _fake_default():
     return ("fake-credentials", "fake-project-id")
 
 
-def test_logs_warning_when_account_info_json_provided_under_context_auth(caplog, monkeypatch):
+def test_logs_info_when_account_info_json_provided_under_context_auth(caplog, monkeypatch):
     monkeypatch.setattr(
         "soda_bigquery.common.data_sources.bigquery_data_source_connection.default",
         _fake_default,
@@ -21,7 +21,7 @@ def test_logs_warning_when_account_info_json_provided_under_context_auth(caplog,
     )
     connection = BigQueryDataSourceConnection.__new__(BigQueryDataSourceConnection)
 
-    with caplog.at_level(logging.WARNING, logger="soda"):
+    with caplog.at_level(logging.INFO, logger="soda"):
         connection._load_project_id_and_credentials(config)
 
     assert any(
@@ -29,7 +29,7 @@ def test_logs_warning_when_account_info_json_provided_under_context_auth(caplog,
     ), f"Expected a warning about ignored account_info_json. Records: {[r.message for r in caplog.records]}"
 
 
-def test_no_warning_when_only_use_context_auth_is_provided(caplog, monkeypatch):
+def test_no_log_when_only_use_context_auth_is_provided(caplog, monkeypatch):
     monkeypatch.setattr(
         "soda_bigquery.common.data_sources.bigquery_data_source_connection.default",
         _fake_default,
@@ -37,7 +37,7 @@ def test_no_warning_when_only_use_context_auth_is_provided(caplog, monkeypatch):
     config = BigQueryContextAuth(use_context_auth=True)
     connection = BigQueryDataSourceConnection.__new__(BigQueryDataSourceConnection)
 
-    with caplog.at_level(logging.WARNING, logger="soda"):
+    with caplog.at_level(logging.INFO, logger="soda"):
         connection._load_project_id_and_credentials(config)
 
     assert not any("account_info_json" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

The Soda Cloud UI work for PLATL-703 carries both auth modes' input fields in a single BigQuery connection form. Users can type a service-account JSON value, then switch to Application Default Credentials. Under that toggle the FE hides the JSON field and omits the value from the YAML — but if either the FE guard breaks or the YAML is hand-edited, the value would reach soda-core and be silently ignored, which is confusing.

This PR makes soda-core surface that situation:

- `BigQueryContextAuth` gains an explicit `Optional[SecretStr]` `account_info_json` field so the value is parsed and exposed on the model (previously it was dropped as a Pydantic extra), and the docstring documents the round-trip-for-form-state intent.
- `_load_project_id_and_credentials` logs a warning when both `use_context_auth` and a non-empty `account_info_json` are present, then proceeds with `default()` exactly as before.

## Tests

- New `soda-bigquery/tests/unit/test_bigquery_context_auth_logging.py` — caplog-based unit tests cover the warning path (ADC + JSON) and the no-warning path (ADC alone), with `google.auth.default()` monkeypatched.
- `soda-bigquery/tests/data_sources/test_bigquery.py` — new `app_default_creds_with_optional_json` `TestConnection` next to the existing `app_default_creds` case, pinning that the YAML parses cleanly under the new variant (same env caveat: requires no GCP credentials in the test environment).

## Cross-repo

Paired with `sodadata/soda` PR on the matching branch name `platl-703-show-bigquery-wif-settings-on-ui` (cross-repo branch-name convention). The Soda webapp also hides the Account Information JSON field under ADC and omits the value from the YAML serializer; this PR is defence-in-depth for the case where that guard isn't in effect.

## Test plan

- [x] `pytest tests/unit/test_bigquery_context_auth_logging.py tests/data_sources/test_bigquery.py -k 'context_auth_logging or app_default_creds' -v` — 4/4 pass locally.
- [ ] CI green.