### PR TITLE
fix: sparkdf adds connection.catalog field for DWH catalog-mode resolution

### DIFF
--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -420,13 +420,20 @@ class SparkDataFrameDataSourceImpl(DataSourceImpl, model_class=SparkDataFrameDat
         )
 
     @classmethod
-    def from_existing_session(cls, session: SparkSession, name: str, use_catalog: bool = False) -> DataSourceImpl:
+    def from_existing_session(
+        cls,
+        session: SparkSession,
+        name: str,
+        use_catalog: bool = False,
+        catalog: Optional[str] = None,
+    ) -> DataSourceImpl:
         # Locally-owned dict so we never mutate caller-shared state via the
         # ``connection_properties`` plumbing.
         connection_properties = {
             "spark_session": session,
             "schema_": name,
             "use_catalog": use_catalog,
+            "catalog": catalog,
         }
         ds_model = SparkDataFrameDataSourceModel(
             name=name,

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -24,6 +24,14 @@ class SparkDataFrameConnectionProperties(DataSourceConnectionProperties, ABC):
             "False for local Spark which has no catalog concept."
         ),
     )
+    catalog: Optional[str] = Field(
+        None,
+        description=(
+            "Catalog to write DWH/diagnostics tables into when ``use_catalog=true``. When "
+            "unset, the catalog is resolved at runtime from ``SELECT current_catalog()`` "
+            "against the active SparkSession. Ignored when ``use_catalog=false``."
+        ),
+    )
 
 
 class SparkDataFrameNewSessionProperties(SparkDataFrameConnectionProperties):

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -27,9 +27,11 @@ class SparkDataFrameConnectionProperties(DataSourceConnectionProperties, ABC):
     catalog: Optional[str] = Field(
         None,
         description=(
-            "Catalog to write DWH/diagnostics tables into when ``use_catalog=true``. When "
-            "unset, the catalog is resolved at runtime from ``SELECT current_catalog()`` "
-            "against the active SparkSession. Ignored when ``use_catalog=false``."
+            "Explicit catalog binding for downstream consumers that need a 3-level "
+            "Unity-Catalog identifier (e.g. soda-extensions' diagnostics-warehouse writer "
+            "when ``use_catalog=true``). soda-core itself does not interpret this field; "
+            "consumers are expected to fall back to ``SELECT current_catalog()`` against "
+            "the active SparkSession when it is unset. Ignored when ``use_catalog=false``."
         ),
     )
 

--- a/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_connection_modes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 from soda_sparkdf.common.data_sources.sparkdf_data_source import (
     SparkDataFrameDataSourceConnection,
+    SparkDataFrameDataSourceImpl,
 )
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
     SparkDataFrameActiveSessionProperties,
@@ -80,6 +81,50 @@ def test_remote_session_token_is_masked_in_repr_and_str():
     assert "**********" in repr(props)
     # The actual value must still be retrievable inside the adapter when building URIs.
     assert props.token.get_secret_value() == "dapi_some_real_looking_secret"
+
+
+def test_catalog_field_defaults_to_none_and_routes_to_each_mode():
+    # All four connection modes inherit the shared base, so the field must be optional
+    # everywhere — present on the model, defaulting to None when the YAML omits it.
+    active = _build_model({"use_active_session": True, "use_catalog": True})
+    assert active.connection_properties.catalog is None
+
+    remote = _build_model(
+        {
+            "host": "dbc-x.cloud.databricks.com",
+            "token": "secret",
+            "cluster_id": "0000-000000-aaaa",
+            "use_catalog": True,
+            "catalog": "my_catalog",
+        }
+    )
+    assert remote.connection_properties.catalog == "my_catalog"
+
+
+def test_from_existing_session_propagates_catalog_into_connection_properties():
+    # Pure Pythonic build (no SparkSession at the cluster level) — we only care that
+    # ``catalog`` lands in ``connection_properties`` so downstream consumers
+    # (soda-extensions) can read it without round-tripping through YAML.
+    fake_session = object()  # Treated as opaque by the dict path; never .sql()'d.
+    impl = SparkDataFrameDataSourceImpl.from_existing_session(
+        session=fake_session,
+        name="my_source",
+        use_catalog=True,
+        catalog="my_catalog",
+    )
+    props = impl.data_source_connection.connection_properties
+    assert props["catalog"] == "my_catalog"
+    assert props["use_catalog"] is True
+
+
+def test_from_existing_session_catalog_defaults_to_none():
+    fake_session = object()
+    impl = SparkDataFrameDataSourceImpl.from_existing_session(
+        session=fake_session,
+        name="my_source",
+        use_catalog=True,
+    )
+    assert impl.data_source_connection.connection_properties["catalog"] is None
 
 
 def test_active_session_mode_raises_when_no_active_session(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- Adds an optional `catalog` field on `SparkDataFrameConnectionProperties` (YAML `connection.catalog: …`) and a matching `catalog=` kwarg on `SparkDataFrameDataSourceImpl.from_existing_session`.
- Lets users explicitly bind which Unity Catalog the DWH/diagnostics tables land in. When unset, soda-extensions falls back to `SELECT current_catalog()` against the active SparkSession (fixing the bug where a single-prefix `dwhPrefixes` from Soda Cloud got misread as a catalog name).
- Companion PR in soda-extensions (uses this new field): https://github.com/sodadata/soda-extensions — branch `r-596-fix-for-single-catalog-on-spark`.

## Test plan
- [x] No-op when `catalog` is unset (default `None`) — existing sparkdf tests in soda-core remain green.
- [x] Field propagates through `from_existing_session(catalog=…)` and through YAML parsing — exercised by the soda-extensions integration tests against a live Databricks cluster (run locally; CI-skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)