### PR TITLE
fix: per-collection log isolation via a single contextvar-routed capturer

### DIFF
--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -425,6 +425,14 @@ class CheckCollectionImpl:
         ``collection_id``). Soda Cloud surfaces it as a per-scan log filter."""
         return f"{self.wire_source}.{self.collection_id}" if self.collection_id else self.wire_source
 
+    @property
+    def source_description(self) -> str:
+        """Human identifier for this collection's yaml source in console lines:
+        the file path when the yaml came from a local file, else the collection
+        id (e.g. a Cloud-fetched data standard's DQN, where there is no path),
+        else the yaml source's generic description — never ``None``."""
+        return self.yaml.yaml_source.file_path or self.collection_id or self.yaml.yaml_source.description
+
     def __init__(
         self,
         yaml: CheckCollectionYaml,
@@ -754,7 +762,7 @@ class CheckCollectionImpl:
         verb: str = "Validating" if self.only_validate_without_execute else "Verifying"
         logger.info(
             f"{verb} {self.display_name} {Emoticons.SCROLL} "
-            f"{self.yaml.yaml_source.file_path} {Emoticons.FINGERS_CROSSED}"
+            f"{self.source_description} {Emoticons.FINGERS_CROSSED}"
         )
 
         if self.data_source_impl:

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -412,6 +412,13 @@ class CheckCollectionImpl:
         """
         return None
 
+    @property
+    def thread_label(self) -> str:
+        """Per-collection ``thread`` value stamped on each captured record:
+        ``"{wire_source}.{collection_id}"`` (or the bare ``wire_source`` without a
+        ``collection_id``). Soda Cloud surfaces it as a per-scan log filter."""
+        return f"{self.wire_source}.{self.collection_id}" if self.collection_id else self.wire_source
+
     def __init__(
         self,
         yaml: CheckCollectionYaml,
@@ -436,6 +443,8 @@ class CheckCollectionImpl:
         self.logs: Logs = logs if logs is not None else Logs()
         self.yaml: CheckCollectionYaml = yaml
         self.only_validate_without_execute: bool = only_validate_without_execute
+        # Stamp this collection's ``thread`` label on every record it emits.
+        self.logs.label = self.thread_label
         self.data_source_impl: Optional[DataSourceImpl] = data_source_impl
         self.all_data_source_impls: dict[str, DataSourceImpl] = all_data_source_impls or {}
         self.soda_cloud: Optional[SodaCloud] = soda_cloud_impl
@@ -906,14 +915,6 @@ class CheckCollectionImpl:
         if not self.combine_uploads:
             self.run_post_processing_handlers(verification_result, soda_cloud_response_json)
 
-        # Stamp per-file thread label on log records (covers query/upload/
-        # in-verify-handler emissions). Combine subtypes get a second
-        # relabel pass at the end of ``run_post_processing_handlers``
-        # because phase 3 invokes that AFTER verify() returns and any
-        # logs the handlers emit then would otherwise carry raw OS thread
-        # ids and break the Cloud-side per-file grouping.
-        self._apply_thread_label_to_log_records(log_records)
-
         return verification_result
 
     def run_post_processing_handlers(
@@ -950,30 +951,6 @@ class CheckCollectionImpl:
             except Exception as e:
                 logger.error(f"Error in {self.display_name} verification handler: {e}", exc_info=True)
                 self._handle_post_processing_failure(scan_id=scan_id, exc=e, contract_verification_handler=handler)
-
-        # Re-stamp the per-file thread label on any records appended by
-        # the handler loop above. Non-combine path: verify() relabels
-        # again right after returning from here, so this is idempotent.
-        # Combine path: handlers run in phase 3 AFTER verify() already
-        # relabelled, so without this pass the handler-emitted records
-        # would carry raw OS thread ids — the Cloud-side wire grouping
-        # by ``thread`` field would then misbucket them.
-        self._apply_thread_label_to_log_records(verification_result.log_records)
-
-    def _apply_thread_label_to_log_records(self, log_records: Optional[list[LogRecord]]) -> None:
-        """Stamp the per-file label on every log record so combined uploads
-        group records by file via the wire's ``thread`` field.
-
-        Idempotent — safe to call multiple times as more records get
-        appended to the same list (the gatherer's live list is shared
-        across emit sites, including the post-pop YAML upload + handler
-        emissions).
-        """
-        if not log_records:
-            return
-        thread_label = f"{self.wire_source}.{self.collection_id}" if self.collection_id else self.wire_source
-        for record in log_records:
-            record.thread = thread_label
 
     def verify_on_runner(
         self,

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -761,8 +761,7 @@ class CheckCollectionImpl:
 
         verb: str = "Validating" if self.only_validate_without_execute else "Verifying"
         logger.info(
-            f"{verb} {self.display_name} {Emoticons.SCROLL} "
-            f"{self.source_description} {Emoticons.FINGERS_CROSSED}"
+            f"{verb} {self.display_name} {Emoticons.SCROLL} " f"{self.source_description} {Emoticons.FINGERS_CROSSED}"
         )
 
         if self.data_source_impl:

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -821,7 +821,9 @@ class CheckCollectionImpl:
             for line in log_lines:
                 logger.info(line)
 
-        log_records: Optional[list[LogRecord]] = self.logs.pop_log_records()
+        # The gatherer's live list: records emitted after this point (upload,
+        # post-processing handlers) still surface on the held result.
+        log_records: Optional[list[LogRecord]] = self.logs.get_log_records()
 
         soda_cloud_file_id: Optional[str] = None
         sending_results_to_soda_cloud_failed: bool = False
@@ -829,7 +831,9 @@ class CheckCollectionImpl:
         soda_cloud_response_json: Optional[dict] = None
 
         if self.soda_cloud and self.publish_results:
-            soda_cloud_file_id = self.soda_cloud._upload_contract_yaml_file(yaml_source_str_original)
+            soda_cloud_file_id = self.soda_cloud._upload_contract_yaml_file(
+                yaml_source_str_original, file_label=self.display_name
+            )
 
         post_processing_stages: list[PostProcessingStage] = []
         for handler in ContractVerificationHandlerRegistry.post_processing_stages.values():
@@ -1068,7 +1072,7 @@ class CheckCollectionImpl:
         else:
             table_lines.append(["Runtime Errors", error_count, Emoticons.WHITE_CHECK_MARK])
 
-        summary_lines.append(f"\n### Contract results for {soda_qualified_dataset_name}")
+        summary_lines.append(f"\n### {self.display_name.capitalize()} results for {soda_qualified_dataset_name}")
         summary_lines.append(self.build_summary_table(check_results))
 
         overview_table = tabulate(table_lines, tablefmt="github", stralign="left")
@@ -1145,10 +1149,9 @@ class CheckCollectionImpl:
         if not offending:
             return True
 
-        # ``Logs`` is the per-collection log buffer; we also push directly
-        # via ``logger.error`` so the records are queryable through the
-        # normal ``LogRecord`` stream (so launchers see them via
-        # ``result.get_errors()``).
+        # These records land on ``verification_result.log_records`` directly:
+        # that list is the live gatherer list, so launchers see them via
+        # ``result.get_errors()`` with no re-collection.
         for check_result in offending:
             logger.error(
                 f"Source mismatch — check '{check_result.check.full_path}' has "
@@ -1156,14 +1159,6 @@ class CheckCollectionImpl:
                 f"declares wire_source={self.wire_source!r}. Skipping Cloud upload to avoid "
                 f"a backend-side source-mismatch failure on the whole batch."
             )
-
-        # Re-collect the log records we just emitted so they land on the
-        # verification result the launcher inspects.
-        new_records: Optional[list[LogRecord]] = self.logs.pop_log_records()
-        if new_records:
-            if verification_result.log_records is None:
-                verification_result.log_records = []
-            verification_result.log_records.extend(new_records)
 
         verification_result.sending_results_to_soda_cloud_failed = True
         return False

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -12,7 +12,6 @@ with a 1-element ``contract_yaml_sources`` list) sets
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from datetime import datetime
 from typing import Optional, Union
 
@@ -34,14 +33,6 @@ from soda_core.common.yaml import CheckCollectionYamlSource
 from soda_core.contracts.impl.diagnostics_warehouse_files import (
     DiagnosticsWarehouseFiles,
 )
-
-
-def _capturing(impl: CheckCollectionImpl):
-    """Activate this impl's ``Logs`` for a block so its verify()/handler records
-    land in (and are labelled for) the right collection. No-op for lightweight
-    test doubles that carry no ``Logs``."""
-    impl_logs = getattr(impl, "logs", None)
-    return impl_logs.activate(impl.thread_label) if impl_logs is not None else nullcontext()
 
 
 # Each owned impl's Logs activates on construction and is never individually
@@ -138,12 +129,10 @@ def execute_check_collections(
 
     results: list[CheckCollectionResult] = []
 
-    # Each impl's ``Logs`` becomes active as it is constructed, capturing its
-    # construction logs; phase 2/3 re-activate it around verify()/handlers via
-    # ``_capturing(impl)``. Only one gatherer is ever active, so siblings can't
-    # cross-capture.
-
     # ---- Phase 1: parse + construct every impl, per-file isolated. ----
+    # Each impl's ``Logs`` becomes active as it is constructed, capturing its
+    # construction logs; phase 2/3 re-activate it around verify()/handlers.
+    # Only one gatherer is ever active, so siblings can't cross-capture.
     # Entries: ``(impl, impl_class, None, yaml_source)`` on success,
     # ``(None, impl_class_or_None, exc, yaml_source)`` on failure. The
     # ``yaml_source`` slot lets phase 1.5 filter ``constructed`` without
@@ -240,7 +229,7 @@ def execute_check_collections(
             results.append(builder.build_error_result(yaml_source, construct_exc))
             continue
         # Capture this verify()'s records into this collection's gatherer.
-        with _capturing(impl):
+        with impl.logs.activate(impl.thread_label):
             try:
                 results.append(impl.verify())
             except Exception as exc:
@@ -346,7 +335,7 @@ def execute_check_collections(
         )
         # Handlers run after verify() returned; re-activate so their records are
         # captured for this collection.
-        with _capturing(impl):
+        with impl.logs.activate(impl.thread_label):
             impl.run_post_processing_handlers(result, response_for_file)
 
     return CheckCollectionSessionResult(results)

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -12,6 +12,7 @@ with a 1-element ``contract_yaml_sources`` list) sets
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from datetime import datetime
 from typing import Optional, Union
 
@@ -27,7 +28,7 @@ from soda_core.common.datetime_conversions import (
 )
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.exceptions import InvalidArgumentException
-from soda_core.common.logs import Logs
+from soda_core.common.logs import Logs, preserve_active_logs
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import CheckCollectionYamlSource
 from soda_core.contracts.impl.diagnostics_warehouse_files import (
@@ -35,6 +36,18 @@ from soda_core.contracts.impl.diagnostics_warehouse_files import (
 )
 
 
+def _capturing(impl: CheckCollectionImpl):
+    """Activate this impl's ``Logs`` for a block so its verify()/handler records
+    land in (and are labelled for) the right collection. No-op for lightweight
+    test doubles that carry no ``Logs``."""
+    impl_logs = getattr(impl, "logs", None)
+    return impl_logs.activate(impl.thread_label) if impl_logs is not None else nullcontext()
+
+
+# Each owned impl's Logs activates on construction and is never individually
+# closed, so restore the active capture target to its pre-call value on exit
+# (no Logs left dangling as active after the session).
+@preserve_active_logs()
 def execute_check_collections(
     yaml_sources: list[CheckCollectionYamlSource],
     data_source_impl: Optional[DataSourceImpl],
@@ -124,6 +137,11 @@ def execute_check_collections(
     )
 
     results: list[CheckCollectionResult] = []
+
+    # Each impl's ``Logs`` becomes active as it is constructed, capturing its
+    # construction logs; phase 2/3 re-activate it around verify()/handlers via
+    # ``_capturing(impl)``. Only one gatherer is ever active, so siblings can't
+    # cross-capture.
 
     # ---- Phase 1: parse + construct every impl, per-file isolated. ----
     # Entries: ``(impl, impl_class, None, yaml_source)`` on success,
@@ -221,12 +239,14 @@ def execute_check_collections(
             )
             results.append(builder.build_error_result(yaml_source, construct_exc))
             continue
-        try:
-            results.append(impl.verify())
-        except Exception as exc:
-            if abort_on_first_error:
-                raise
-            results.append(impl_class.build_error_result(yaml_source, exc))
+        # Capture this verify()'s records into this collection's gatherer.
+        with _capturing(impl):
+            try:
+                results.append(impl.verify())
+            except Exception as exc:
+                if abort_on_first_error:
+                    raise
+                results.append(impl_class.build_error_result(yaml_source, exc))
 
     # ---- Phase 3: combined upload (cloud-gated) + post-processing handlers (always). ----
     # ``constructed`` is positionally aligned with ``results``, so we iterate
@@ -324,7 +344,10 @@ def execute_check_collections(
         response_for_file = (
             response_json_by_wire_source.get(impl_class.wire_source) if id(result) in uploaded_ids else None
         )
-        impl.run_post_processing_handlers(result, response_for_file)
+        # Handlers run after verify() returned; re-activate so their records are
+        # captured for this collection.
+        with _capturing(impl):
+            impl.run_post_processing_handlers(result, response_for_file)
 
     return CheckCollectionSessionResult(results)
 

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -6,7 +6,7 @@ from typing import Optional
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.logging_constants import Emoticons, soda_logger
-from soda_core.common.logs import LogCapturer
+from soda_core.common.logs import Logs
 from soda_core.common.logs_queue import LogsQueue
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import DataSourceYamlSource, SodaCloudYamlSource
@@ -88,19 +88,15 @@ def handle_test_data_source(
 class _TestConnectionLogUploader:
     """Wires Soda Cloud log upload around the test-connection flow.
 
-    Holds a LogsQueue bound to the given scan_id and a LogCapturer that
-    forwards root-logger records to it. Must be closed to flush the final batch.
-    """
+    Holds a ``Logs`` backed by a ``LogsQueue`` bound to the given scan_id, so
+    root-logger records during the test stream to Cloud. Must be closed to flush
+    the final batch."""
 
-    def __init__(self, logs_queue, log_capturer):
-        self._logs_queue = logs_queue
-        self._log_capturer = log_capturer
+    def __init__(self, logs: Logs):
+        self._logs = logs
 
     def close(self) -> None:
-        try:
-            self._log_capturer.remove_from_root_logger()
-        finally:
-            self._logs_queue.close()
+        self._logs.close()
 
 
 def _build_log_uploader(
@@ -134,5 +130,4 @@ def _build_log_uploader(
         scan_id=scan_id,
         dataset="",
     )
-    log_capturer = LogCapturer(logs_queue)
-    return _TestConnectionLogUploader(logs_queue=logs_queue, log_capturer=log_capturer)
+    return _TestConnectionLogUploader(logs=Logs(gatherer=logs_queue))

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -54,9 +54,10 @@ def handle_test_data_source(
     soda_logger.info(f"Testing data source configuration file {data_source_file_path}")
     from soda_core.common.data_source_impl import DataSourceImpl
 
-    # Attach the uploader before parsing so logs emitted while loading/validating the data
-    # source YAML — often the most relevant when a connection test fails early — are captured.
-    log_uploader: Optional["_TestConnectionLogUploader"] = _build_log_uploader(
+    # Build the upload Logs before parsing so logs emitted while loading/validating the
+    # data source YAML — often the most relevant when a connection test fails early — are
+    # captured and streamed to Soda Cloud.
+    upload_logs: Optional[Logs] = _build_log_uploader(
         soda_cloud_file_path=soda_cloud_file_path,
     )
 
@@ -81,27 +82,17 @@ def handle_test_data_source(
             )
             return ExitCode.OK
     finally:
-        if log_uploader is not None:
-            log_uploader.close()
-
-
-class _TestConnectionLogUploader:
-    """Wires Soda Cloud log upload around the test-connection flow.
-
-    Holds a ``Logs`` backed by a ``LogsQueue`` bound to the given scan_id, so
-    root-logger records during the test stream to Cloud. Must be closed to flush
-    the final batch."""
-
-    def __init__(self, logs: Logs):
-        self._logs = logs
-
-    def close(self) -> None:
-        self._logs.close()
+        if upload_logs is not None:
+            upload_logs.close()
 
 
 def _build_log_uploader(
     soda_cloud_file_path: Optional[str],
-) -> Optional[_TestConnectionLogUploader]:
+) -> Optional[Logs]:
+    """Returns a ``Logs`` backed by a ``LogsQueue`` bound to the scan id, so
+    root-logger records during the test stream to Soda Cloud — or None when
+    there is no scan id / cloud config. Must be closed to flush the final batch.
+    """
     # The scan id is a Cloud-only concept set by the Runner/launcher as SODA_SCAN_ID; it is
     # read from the env helper rather than a CLI argument so the generic CLI stays Cloud-agnostic.
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
@@ -130,4 +121,4 @@ def _build_log_uploader(
         scan_id=scan_id,
         dataset="",
     )
-    return _TestConnectionLogUploader(logs=Logs(gatherer=logs_queue))
+    return Logs(gatherer=logs_queue)

--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -55,6 +55,13 @@ def configure_logging(
         handlers=[SodaConsoleHandler()],
     )
 
+    # force=True just cleared every root handler, including the capture router.
+    # Re-attach it so any live ``Logs`` keeps capturing. Function-local import:
+    # ``logs`` imports (via logs_collector) from this module.
+    from soda_core.common.logs import _ensure_root_capturer
+
+    _ensure_root_capturer()
+
 
 _masked_values = set()
 

--- a/soda-core/src/soda_core/common/logs.py
+++ b/soda-core/src/soda_core/common/logs.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import contextvars
 import logging
-import threading
+from contextlib import contextmanager
 from logging import Handler, LogRecord
 from typing import Optional
 
@@ -28,40 +29,104 @@ class Location:
         return {"file_path": self.file_path, "line": self.line, "column": self.column}
 
 
-class LogCapturer(Handler):
-    """
-    Captures logging records for the current thread and sends them to the provided LogsBase gatherer.
-    """
+# The capture target for the current context. A ``Logs`` becomes active when it
+# is constructed and (re)activated via ``Logs.activate()``. Contextvars are
+# per-thread, so a thread that never sets it simply isn't captured.
+_active_logs: contextvars.ContextVar[Optional["Logs"]] = contextvars.ContextVar("soda_active_logs", default=None)
 
-    def __init__(self, gatherer: LogsBase):
-        super().__init__()
-        self.gatherer: LogsBase = gatherer
-        self.threading_ident: int = threading.get_ident()
-        logging.root.addHandler(self)
 
-    def remove_from_root_logger(self) -> None:
-        logging.root.removeHandler(self)
+class _RootCapturer(Handler):
+    """The single root-logger handler. While a labelled ``Logs`` is active it
+    routes every record reaching the root logger to that Logs' gatherer and
+    stamps the Logs' ``label`` on ``record.thread`` (the Cloud per-collection
+    grouping key); with no active Logs, records go to the console handler only.
+    (When soda-core is embedded, a host's records reaching root during an active
+    scope are captured/re-stamped too — same scope the engine has always had.)"""
 
-    def emit(self, record: LogRecord):
-        if self.threading_ident == record.thread:
-            self.gatherer.emit(record)
+    def emit(self, record: LogRecord) -> None:
+        active: Optional[Logs] = _active_logs.get()
+        if active is None:
+            return
+        if active.label is not None:
+            record.thread = active.label
+        try:
+            active.gatherer.emit(record)
+        except Exception:
+            self.handleError(record)
+
+
+_root_capturer: Optional[_RootCapturer] = None
+
+
+def _ensure_root_capturer() -> None:
+    """Install the single root capturer once."""
+    global _root_capturer
+    if _root_capturer is None:
+        _root_capturer = _RootCapturer()
+        logging.root.addHandler(_root_capturer)
+
+
+@contextmanager
+def preserve_active_logs():
+    """Restore the active capture target to its value at entry on exit. Brackets
+    a block that constructs Logs (which activate on construction) so it doesn't
+    leave one dangling as the active target afterwards — used by the executor,
+    whose per-collection Logs are activated but never individually closed."""
+    token = _active_logs.set(_active_logs.get())
+    try:
+        yield
+    finally:
+        try:
+            _active_logs.reset(token)
+        except (ValueError, LookupError):
+            _active_logs.set(None)
+
+
+class _Activation:
+    """Context manager returned by ``Logs.activate()``: makes ``logs`` the
+    active target for the block and restores the previous one on exit."""
+
+    def __init__(self, logs: "Logs", label: Optional[str]):
+        self._logs = logs
+        self._label = label
+        self._token: Optional[contextvars.Token] = None
+
+    def __enter__(self) -> "Logs":
+        if self._label is not None:
+            self._logs.label = self._label
+        self._token = _active_logs.set(self._logs)
+        return self._logs
+
+    def __exit__(self, *exc) -> None:
+        if self._token is not None:
+            try:
+                _active_logs.reset(self._token)
+            except (ValueError, LookupError):
+                _active_logs.set(None)
+            self._token = None
 
 
 class Logs:
-    """
-    Configuration manager and entry point for log handling in soda core.
-    On creation, it attaches a LogCapturer to the root logger to capture logs for the current thread.
-    By default, it uses in-memory LogCollector to gather all logs.
+    """Owns a gatherer and is a capture target.
+
+    Constructing a ``Logs`` makes it the active capture target, so
+    ``logs = Logs(); logger.info(...)`` captures with no extra ceremony. The
+    optional ``label`` is stamped on each captured record's ``thread`` at emit
+    time (combined Cloud uploads group records per collection by it).
     """
 
-    def __init__(self, gatherer: Optional[LogsBase] = None):
-        if gatherer is None:
-            gatherer = LogsCollector()
-        self.gatherer: LogsBase = gatherer
-        self.log_capturer: LogCapturer = LogCapturer(gatherer)
+    def __init__(self, gatherer: Optional[LogsBase] = None, label: Optional[str] = None):
+        self.gatherer: LogsBase = gatherer if gatherer is not None else LogsCollector()
+        self.label: Optional[str] = label
+        _ensure_root_capturer()
+        self._token: Optional[contextvars.Token] = _active_logs.set(self)
 
-    def remove_from_root_logger(self) -> None:
-        self.log_capturer.remove_from_root_logger()
+    def activate(self, label: Optional[str] = None) -> _Activation:
+        """Re-arm this Logs as the active target for a ``with`` block, optionally
+        (re)setting its label. The executor uses this to bracket a collection's
+        verify() and post-processing after the up-front construction phase has
+        moved the active target on to later collections."""
+        return _Activation(self, label)
 
     def __str__(self) -> str:
         return self.get_logs_str()
@@ -86,9 +151,23 @@ class Logs:
         return len(self.get_errors()) > 0
 
     def pop_log_records(self) -> list[LogRecord]:
+        # Returns the gatherer's live list (LogsCollector.close is a no-op), so
+        # records appended after the pop — e.g. post-processing handler emissions —
+        # still surface on the held result. Intentional, not a true "pop".
         log_records: list[LogRecord] = self.get_log_records()
         self.gatherer.close()
         return log_records
 
     def close(self) -> None:
+        """Stop being the active capture target and close the gatherer (flushing
+        it for streaming gatherers). Assumes this Logs is the current active
+        target — the construct/verify flows keep activations LIFO. ``reset`` is
+        guarded so a stray cross-context/out-of-order close degrades to a no-op
+        rather than raising; logging must never crash the caller."""
+        if self._token is not None:
+            try:
+                _active_logs.reset(self._token)
+            except (ValueError, LookupError):
+                _active_logs.set(None)
+            self._token = None
         self.gatherer.close()

--- a/soda-core/src/soda_core/common/logs.py
+++ b/soda-core/src/soda_core/common/logs.py
@@ -1,3 +1,18 @@
+"""Log capture for soda-core.
+
+The model, in one read: ONE permanent handler on the root logger
+(``_RootCapturer``, re-attached if something like ``logging.basicConfig(force=
+True)`` clears the root handlers) routes every record to the *active* ``Logs``
+selected by a ContextVar. CONSTRUCTING a ``Logs`` makes it active — capture
+needs no extra ceremony and cannot be silently forgotten. ``activate(label)``
+re-arms a ``Logs`` for a ``with`` block (the executor brackets each
+collection's verify/post-processing with it); ``close()`` flushes the gatherer
+and releases the active slot only if this ``Logs`` still holds it. The var is
+per-thread, so worker threads that never set it are not captured. Each captured
+record's ``thread`` is stamped with the active ``label`` — the per-collection
+key Soda Cloud exposes as a log filter.
+"""
+
 from __future__ import annotations
 
 import contextvars
@@ -29,19 +44,15 @@ class Location:
         return {"file_path": self.file_path, "line": self.line, "column": self.column}
 
 
-# The capture target for the current context. A ``Logs`` becomes active when it
-# is constructed and (re)activated via ``Logs.activate()``. Contextvars are
-# per-thread, so a thread that never sets it simply isn't captured.
 _active_logs: contextvars.ContextVar[Optional["Logs"]] = contextvars.ContextVar("soda_active_logs", default=None)
 
 
 class _RootCapturer(Handler):
-    """The single root-logger handler. While a labelled ``Logs`` is active it
-    routes every record reaching the root logger to that Logs' gatherer and
-    stamps the Logs' ``label`` on ``record.thread`` (the Cloud per-collection
-    grouping key); with no active Logs, records go to the console handler only.
-    (When soda-core is embedded, a host's records reaching root during an active
-    scope are captured/re-stamped too — same scope the engine has always had.)"""
+    """Routes records to the active ``Logs`` and stamps its ``label`` on
+    ``record.thread``. With no active Logs, records pass through to the console
+    handler only. (When soda-core is embedded, a host's records reaching root
+    during an active scope are captured/re-stamped too — same scope the engine
+    has always had.)"""
 
     def emit(self, record: LogRecord) -> None:
         active: Optional[Logs] = _active_logs.get()
@@ -55,15 +66,10 @@ class _RootCapturer(Handler):
             self.handleError(record)
 
 
-_root_capturer: Optional[_RootCapturer] = None
-
-
 def _ensure_root_capturer() -> None:
-    """Install the single root capturer once."""
-    global _root_capturer
-    if _root_capturer is None:
-        _root_capturer = _RootCapturer()
-        logging.root.addHandler(_root_capturer)
+    """Install the root capturer if it is not currently attached."""
+    if not any(isinstance(handler, _RootCapturer) for handler in logging.root.handlers):
+        logging.root.addHandler(_RootCapturer())
 
 
 @contextmanager
@@ -72,38 +78,11 @@ def preserve_active_logs():
     a block that constructs Logs (which activate on construction) so it doesn't
     leave one dangling as the active target afterwards — used by the executor,
     whose per-collection Logs are activated but never individually closed."""
-    token = _active_logs.set(_active_logs.get())
+    prev: Optional[Logs] = _active_logs.get()
     try:
         yield
     finally:
-        try:
-            _active_logs.reset(token)
-        except (ValueError, LookupError):
-            _active_logs.set(None)
-
-
-class _Activation:
-    """Context manager returned by ``Logs.activate()``: makes ``logs`` the
-    active target for the block and restores the previous one on exit."""
-
-    def __init__(self, logs: "Logs", label: Optional[str]):
-        self._logs = logs
-        self._label = label
-        self._token: Optional[contextvars.Token] = None
-
-    def __enter__(self) -> "Logs":
-        if self._label is not None:
-            self._logs.label = self._label
-        self._token = _active_logs.set(self._logs)
-        return self._logs
-
-    def __exit__(self, *exc) -> None:
-        if self._token is not None:
-            try:
-                _active_logs.reset(self._token)
-            except (ValueError, LookupError):
-                _active_logs.set(None)
-            self._token = None
+        _active_logs.set(prev)
 
 
 class Logs:
@@ -111,22 +90,31 @@ class Logs:
 
     Constructing a ``Logs`` makes it the active capture target, so
     ``logs = Logs(); logger.info(...)`` captures with no extra ceremony. The
-    optional ``label`` is stamped on each captured record's ``thread`` at emit
+    ``label`` attribute is stamped on each captured record's ``thread`` at emit
     time (combined Cloud uploads group records per collection by it).
     """
 
-    def __init__(self, gatherer: Optional[LogsBase] = None, label: Optional[str] = None):
+    def __init__(self, gatherer: Optional[LogsBase] = None):
         self.gatherer: LogsBase = gatherer if gatherer is not None else LogsCollector()
-        self.label: Optional[str] = label
+        self.label: Optional[str] = None
         _ensure_root_capturer()
-        self._token: Optional[contextvars.Token] = _active_logs.set(self)
+        self._prev: Optional[Logs] = _active_logs.get()
+        _active_logs.set(self)
 
-    def activate(self, label: Optional[str] = None) -> _Activation:
+    @contextmanager
+    def activate(self, label: Optional[str] = None):
         """Re-arm this Logs as the active target for a ``with`` block, optionally
         (re)setting its label. The executor uses this to bracket a collection's
         verify() and post-processing after the up-front construction phase has
         moved the active target on to later collections."""
-        return _Activation(self, label)
+        if label is not None:
+            self.label = label
+        prev: Optional[Logs] = _active_logs.get()
+        _active_logs.set(self)
+        try:
+            yield self
+        finally:
+            _active_logs.set(prev)
 
     def __str__(self) -> str:
         return self.get_logs_str()
@@ -150,24 +138,11 @@ class Logs:
     def has_errors(self) -> bool:
         return len(self.get_errors()) > 0
 
-    def pop_log_records(self) -> list[LogRecord]:
-        # Returns the gatherer's live list (LogsCollector.close is a no-op), so
-        # records appended after the pop — e.g. post-processing handler emissions —
-        # still surface on the held result. Intentional, not a true "pop".
-        log_records: list[LogRecord] = self.get_log_records()
-        self.gatherer.close()
-        return log_records
-
     def close(self) -> None:
         """Stop being the active capture target and close the gatherer (flushing
-        it for streaming gatherers). Assumes this Logs is the current active
-        target — the construct/verify flows keep activations LIFO. ``reset`` is
-        guarded so a stray cross-context/out-of-order close degrades to a no-op
-        rather than raising; logging must never crash the caller."""
-        if self._token is not None:
-            try:
-                _active_logs.reset(self._token)
-            except (ValueError, LookupError):
-                _active_logs.set(None)
-            self._token = None
+        it for streaming gatherers). Releases the active slot only when this
+        Logs still holds it, so an out-of-order close (e.g. on a shared
+        session-level Logs) leaves a newer active Logs untouched."""
+        if _active_logs.get() is self:
+            _active_logs.set(self._prev)
         self.gatherer.close()

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -756,7 +756,7 @@ class SodaCloud:
         if contract_dataset_cloud_url:
             logger.info(f"See contract dataset on Soda Cloud: {contract_dataset_cloud_url}")
 
-        logs.remove_from_root_logger()
+        logs.close()
         verification_result.log_records = logs.get_log_records()
 
         return verification_result

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -433,9 +433,13 @@ class SodaCloud:
 
             logger.debug(f"Response from Soda Cloud: {response.json()}")
 
-    def _upload_contract_yaml_file(self, contract_yaml: str) -> Optional[str]:
+    def _upload_contract_yaml_file(self, contract_yaml: str, file_label: str = "contract") -> Optional[str]:
         """
         Returns a Soda Cloud fileId or None if something is wrong.
+
+        ``file_label`` is the user-facing word for the uploaded file in error
+        logs — the upload serves every check-collection subtype (contracts,
+        data standards, ...), so callers pass their ``display_name``.
         """
         try:
             upload_contract_command: dict = {
@@ -453,7 +457,7 @@ class SodaCloud:
                 return None
         except Exception as e:
             logger.critical(
-                msg=f"Soda cloud error: Could not upload contract file to Soda Cloud: {e}",
+                msg=f"Soda cloud error: Could not upload {file_label} file to Soda Cloud: {e}",
                 exc_info=True,
             )
             return None

--- a/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
@@ -92,7 +92,7 @@ class SchemaCheckImpl(CheckImpl):
             check_yaml=check_yaml,
         )
 
-        logger.info(f"Found {len(contract_impl.column_impls)} columns in contract.")
+        logger.info(f"Found {len(contract_impl.column_impls)} columns in {contract_impl.display_name}.")
 
         self.expected_columns: list[ColumnMetadata] = [
             ColumnMetadata(
@@ -111,7 +111,7 @@ class SchemaCheckImpl(CheckImpl):
             )
             for column_impl in contract_impl.column_impls
         ]
-        logger.info(f"Built {len(self.expected_columns)} expected columns from contract.")
+        logger.info(f"Built {len(self.expected_columns)} expected columns from {contract_impl.display_name}.")
         self.allow_extra_columns: bool = bool(check_yaml.allow_extra_columns)
         self.allow_other_column_order: bool = bool(check_yaml.allow_other_column_order)
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -353,7 +353,7 @@ class ContractVerificationSessionImpl:
                     only_validate_without_execute=True,
                 )
                 init_log_records = contract_impl.logs.pop_log_records()
-                contract_impl.logs.remove_from_root_logger()
+                contract_impl.logs.close()
 
                 contract_verification_result: ContractVerificationResult = contract_impl.verify_on_runner(
                     soda_cloud_impl=soda_cloud_impl,

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -77,7 +77,7 @@ class ContractVerificationHandlerRegistry(ABC):
         for stage in verification_handler.provides_post_processing_stages():
             stage_name = stage.name
             if stage_name in cls.post_processing_stages:
-                logger.warning(f"Overriding existing contract verification handler for check type {stage_name}")
+                logger.warning(f"Overriding existing verification handler for post-processing stage {stage_name}")
             cls.post_processing_stages[stage_name] = verification_handler
 
 
@@ -352,7 +352,7 @@ class ContractVerificationSessionImpl:
                     yaml=contract_yaml,
                     only_validate_without_execute=True,
                 )
-                init_log_records = contract_impl.logs.pop_log_records()
+                init_log_records = contract_impl.logs.get_log_records()
                 contract_impl.logs.close()
 
                 contract_verification_result: ContractVerificationResult = contract_impl.verify_on_runner(

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -139,9 +139,7 @@ class ContractVerificationHandler(ABC):
                 except Exception as e:
                     # Same message shape as the per-file path (run_post_processing_handlers) so log
                     # parsing / monitoring stays consistent across the combine and non-combine paths.
-                    logger.error(
-                        f"Error in {item.contract_impl.display_name} verification handler: {e}", exc_info=True
-                    )
+                    logger.error(f"Error in {item.contract_impl.display_name} verification handler: {e}", exc_info=True)
                     item.contract_impl._handle_post_processing_failure(
                         scan_id=item.verification_result.scan_id,
                         exc=e,

--- a/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
+++ b/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
@@ -72,7 +72,7 @@ class TestSnowflakeSessionTimezoneNoValueColumn:
         try:
             result = instance._fetch_session_timezone()
         finally:
-            captured.remove_from_root_logger()
+            captured.close()
 
         assert result is timezone.utc
         warnings = [r for r in captured.get_log_records() if r.levelno >= logging.WARNING]

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -298,7 +298,7 @@ class DataSourceTestHelper:
         self.dataset_prefix: list[str] = self._create_dataset_prefix()
         logs: Logs = Logs()
         self.data_source_impl: "DataSourceImpl" = self._create_data_source_impl()
-        logs.remove_from_root_logger()
+        logs.close()
         if logs.has_errors:
             raise RuntimeError(f"Couldn't create DataSource: {logs}")
         self.is_cicd = os.getenv("GITHUB_ACTIONS") is not None
@@ -582,7 +582,7 @@ class DataSourceTestHelper:
     def start_test_session_open_connection(self) -> None:
         logs: Logs = Logs()
         self.data_source_impl.open_connection()
-        logs.remove_from_root_logger()
+        logs.close()
         if logs.has_errors:
             raise AssertionError(f"Connection creation has errors. See logs.")
 

--- a/soda-tests/src/helpers/impl_test_helpers.py
+++ b/soda-tests/src/helpers/impl_test_helpers.py
@@ -76,7 +76,7 @@ def build_contract_impl(
         return contract_impl
     finally:
         if own_logs:
-            logs.remove_from_root_logger()
+            logs.close()
 
 
 def get_check_impl(

--- a/soda-tests/src/helpers/test_fixtures.py
+++ b/soda-tests/src/helpers/test_fixtures.py
@@ -59,7 +59,7 @@ def logs() -> Logs:
     try:
         yield logs
     finally:
-        logs.remove_from_root_logger()
+        logs.close()
 
 
 @pytest.fixture(scope="session")

--- a/soda-tests/tests/integration/test_logs.py
+++ b/soda-tests/tests/integration/test_logs.py
@@ -13,7 +13,7 @@ def test_catch_args_in_logs_messages():
     logging.debug("This is a test message 1")
     logging.warning("This is a test %s", "message 2")
     logging.error("This is a test %s", "message 3")
-    l.remove_from_root_logger()
+    l.close()
     logs = l.get_logs()
     assert len(logs) == 3, f"Expected 3 error log, got {len(logs)}"
     assert "This is a test message 1" in logs
@@ -53,7 +53,7 @@ def test_avoid_empty_string(caplog):
     logging.debug("This is a test message 1")
     logging.warning("This is a test %s", "message 2")
     logging.error("This is a test message 3", exc_info=Exception("This is a test message exception"))
-    l.remove_from_root_logger()
+    l.close()
     logs = l.get_logs()
     assert len(logs) == 3, f"Expected 3 error log, got {len(logs)}"
     assert "This is a test message 1" in logs
@@ -89,7 +89,7 @@ def test_mask_values_in_logs_messages(caplog):
     logging.debug("This is a test message 1")
     logging.warning("This is a test %s", "message 2")
     logging.error("This is a test message 3", exc_info=Exception("This is a test message exception"))
-    l.remove_from_root_logger()
+    l.close()
     logs = l.get_logs()
     assert len(logs) == 3, f"Expected 3 error log, got {len(logs)}"
     assert "This is a test *** 1" in logs

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -105,7 +105,7 @@ def test_fetch_session_timezone_emits_no_errors(data_source_test_helper: DataSou
     try:
         result = connection._fetch_session_timezone()
     finally:
-        captured_logs.remove_from_root_logger()
+        captured_logs.close()
 
     assert isinstance(result, tzinfo), (
         f"_fetch_session_timezone() returned {result!r} (type {type(result).__name__}); " "expected a tzinfo instance"

--- a/soda-tests/tests/unit/contract_yaml/test_variables_yaml_parsing.py
+++ b/soda-tests/tests/unit/contract_yaml/test_variables_yaml_parsing.py
@@ -117,7 +117,7 @@ def test_required_variable_without_value_logs_error():
         error_str = logs.get_errors_str()
         assert "required_var" in error_str, f"Expected 'required_var' in error message: {error_str}"
     finally:
-        logs.remove_from_root_logger()
+        logs.close()
 
 
 def test_variables_env_resolution(env_vars: dict):

--- a/soda-tests/tests/unit/test_agent_path_log_propagation.py
+++ b/soda-tests/tests/unit/test_agent_path_log_propagation.py
@@ -122,11 +122,10 @@ def test_execute_on_agent_does_not_leak_impl_logs_to_root_logger_across_items(mo
         soda_cloud_use_agent=True,
     )
 
-    # After the session returns, the only root-logger handler delta should
-    # be the session-level Logs() (which is itself cleaned up by the public
-    # entry's lifecycle). The impl's own LogCapturer must have been removed.
-    # Allow at most one residual (the session-level capturer) above baseline.
+    # Capture is routed through one process-wide root capturer; no per-impl or
+    # per-session handler is added. At most one handler appears above baseline
+    # (that shared capturer, installed once).
     assert len(logging.root.handlers) <= handler_count_before + 1, (
-        f"Impl LogCapturer leaked to root logger. "
+        f"Unexpected root-logger handler growth. "
         f"Before: {handler_count_before}, after: {len(logging.root.handlers)}"
     )

--- a/soda-tests/tests/unit/test_alignment_guard.py
+++ b/soda-tests/tests/unit/test_alignment_guard.py
@@ -146,6 +146,9 @@ def test_alignment_guard_skips_upload_on_source_mismatch():
             _make_check_result(source="soda-contract"),  # MISMATCH — parent is "data-standard"
         ]
     )
+    # Model production: ``verify()`` builds the result from the impl's live
+    # gatherer list, so guard-emitted errors land on it directly.
+    result.log_records = impl.logs.get_log_records()
     assert impl._verify_check_sources_aligned(result) is False
     assert result.sending_results_to_soda_cloud_failed is True
     # An error log record was appended so the launcher can surface the issue.
@@ -168,6 +171,7 @@ def test_alignment_guard_reports_every_offending_check():
             _make_check_result(source="some-other-future-source"),
         ]
     )
+    result.log_records = impl.logs.get_log_records()
     assert impl._verify_check_sources_aligned(result) is False
     error_messages = [r.getMessage() for r in result.log_records if r.levelno >= 40]
     assert len(error_messages) == 3, f"Expected 3 mismatch errors; got: {error_messages}"

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -19,6 +19,7 @@ from soda_core.check_collections.base import (
     CheckCollectionYaml,
 )
 from soda_core.check_collections.session import execute_check_collections
+from soda_core.common.logs import Logs
 from soda_core.contracts.contract_verification import (
     CheckCollectionStatus,
     Contract,
@@ -106,6 +107,7 @@ class _FakeImpl(CheckCollectionImpl):
         # is inherited from the base class as a ``@property`` returning
         # ``None`` — no instance attribute needed.
         self.yaml = yaml
+        self.logs = Logs()
         # ``raise_on_verify`` lives on the yaml_source for per-instance control;
         # the FakeYaml wrapper carries the source reference through.
         source = getattr(yaml, "yaml_source", None)
@@ -280,6 +282,7 @@ def test_check_collection_impl_default_verify_on_runner_raises_not_implemented()
             verbose=False,
         )
     assert "fake" in str(exc_info.value)
+    impl.logs.close()  # release the active-capture slot taken at construction
 
 
 def test_for_kind_returns_registered_impl_class():

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -20,6 +20,7 @@ from soda_core.check_collections.base import (
 )
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.logs import Logs
+from soda_core.common.yaml import CheckCollectionYamlSource
 from soda_core.contracts.contract_verification import (
     CheckCollectionStatus,
     Contract,
@@ -337,3 +338,38 @@ def test_verify_raises_when_wire_source_is_empty():
 
     with pytest.raises(ValueError, match="wire_source"):
         _NoWireSourceImpl().verify()
+
+
+class _FakeImplWithCollectionId(_FakeImpl):
+    """Sentinel with a collection id, like a data standard's DQN."""
+
+    kind = _FAKE_KIND + "-with-id"
+
+    @property
+    def collection_id(self) -> Optional[str]:
+        return "dqn://fake/standard-1"
+
+
+def test_source_description_prefers_the_file_path():
+    """A file-sourced collection is identified by its path in console lines —
+    even when a collection id is also available."""
+    source = CheckCollectionYamlSource.from_str("kind: data_standard", file_path="/path/to/standard.yml")
+    impl = _FakeImplWithCollectionId(yaml=_FakeYaml(yaml_source=source))
+    assert impl.source_description == "/path/to/standard.yml"
+
+
+def test_source_description_falls_back_to_collection_id_for_string_sources():
+    """A Cloud-fetched yaml has no file path; console lines must show the
+    collection id (e.g. a data standard's DQN) instead of 'None'."""
+    source = CheckCollectionYamlSource.from_str("kind: data_standard")
+    impl = _FakeImplWithCollectionId(yaml=_FakeYaml(yaml_source=source))
+    assert impl.source_description == "dqn://fake/standard-1"
+
+
+def test_source_description_last_resort_is_the_yaml_source_description():
+    """No file path and no collection id (e.g. a contract string on the agent
+    path) still yields a human-readable identifier, never 'None'."""
+    source = CheckCollectionYamlSource.from_str("kind: contract")
+    impl = _FakeImpl(yaml=_FakeYaml(yaml_source=source))  # collection_id is None
+    assert impl.source_description == source.description
+    assert "None" not in impl.source_description

--- a/soda-tests/tests/unit/test_cli_data_source_handlers.py
+++ b/soda-tests/tests/unit/test_cli_data_source_handlers.py
@@ -64,7 +64,7 @@ def test_test_data_source_returns_none(mock_from_file):
 
 
 @patch("soda_core.cli.handlers.data_source.EnvConfigHelper")
-@patch("soda_core.cli.handlers.data_source.LogCapturer")
+@patch("soda_core.cli.handlers.data_source.Logs")
 @patch("soda_core.cli.handlers.data_source.LogsQueue")
 @patch("soda_core.cli.handlers.data_source.SodaCloud")
 @patch("soda_core.cli.handlers.data_source.SodaCloudYamlSource")
@@ -74,7 +74,7 @@ def test_test_data_source_uploads_logs_when_scan_id_provided(
     mock_yaml_source_cls,
     mock_soda_cloud_cls,
     mock_logs_queue_cls,
-    mock_log_capturer_cls,
+    mock_logs_cls,
     mock_env_config_helper_cls,
 ):
     mock_instance = MagicMock()
@@ -86,8 +86,8 @@ def test_test_data_source_uploads_logs_when_scan_id_provided(
     mock_soda_cloud_cls.from_yaml_source.return_value = mock_soda_cloud
     mock_logs_queue = MagicMock()
     mock_logs_queue_cls.return_value = mock_logs_queue
-    mock_log_capturer = MagicMock()
-    mock_log_capturer_cls.return_value = mock_log_capturer
+    mock_logs = MagicMock()
+    mock_logs_cls.return_value = mock_logs
 
     exit_code = handle_test_data_source("ds.yaml", soda_cloud_file_path="sc.yaml")
 
@@ -98,9 +98,8 @@ def test_test_data_source_uploads_logs_when_scan_id_provided(
         scan_id="scan-id-123",
         dataset="",
     )
-    mock_log_capturer_cls.assert_called_once_with(mock_logs_queue)
-    mock_log_capturer.remove_from_root_logger.assert_called_once()
-    mock_logs_queue.close.assert_called_once()
+    mock_logs_cls.assert_called_once_with(gatherer=mock_logs_queue)
+    mock_logs.close.assert_called_once()
 
 
 @patch("soda_core.cli.handlers.data_source.EnvConfigHelper")
@@ -150,7 +149,7 @@ def test_test_data_source_skips_log_upload_when_soda_cloud_missing(
 
 
 @patch("soda_core.cli.handlers.data_source.EnvConfigHelper")
-@patch("soda_core.cli.handlers.data_source.LogCapturer")
+@patch("soda_core.cli.handlers.data_source.Logs")
 @patch("soda_core.cli.handlers.data_source.LogsQueue")
 @patch("soda_core.cli.handlers.data_source.SodaCloud")
 @patch("soda_core.cli.handlers.data_source.SodaCloudYamlSource")
@@ -160,20 +159,19 @@ def test_test_data_source_uploader_captures_and_flushes_when_parsing_raises(
     mock_yaml_source_cls,
     mock_soda_cloud_cls,
     mock_logs_queue_cls,
-    mock_log_capturer_cls,
+    mock_logs_cls,
     mock_env_config_helper_cls,
 ):
     mock_env_config_helper_cls.return_value.soda_scan_id = "scan-id-123"
     mock_logs_queue = MagicMock()
     mock_logs_queue_cls.return_value = mock_logs_queue
-    mock_log_capturer = MagicMock()
-    mock_log_capturer_cls.return_value = mock_log_capturer
+    mock_logs = MagicMock()
+    mock_logs_cls.return_value = mock_logs
     mock_data_source_impl_cls.from_yaml_source.side_effect = RuntimeError("bad data source yaml")
 
     with pytest.raises(RuntimeError):
         handle_test_data_source("ds.yaml", soda_cloud_file_path="sc.yaml")
 
     # Uploader is attached before parsing, so an early parse failure is still captured and flushed.
-    mock_log_capturer_cls.assert_called_once_with(mock_logs_queue)
-    mock_log_capturer.remove_from_root_logger.assert_called_once()
-    mock_logs_queue.close.assert_called_once()
+    mock_logs_cls.assert_called_once_with(gatherer=mock_logs_queue)
+    mock_logs.close.assert_called_once()

--- a/soda-tests/tests/unit/test_contract_parser_api.py
+++ b/soda-tests/tests/unit/test_contract_parser_api.py
@@ -56,6 +56,6 @@ def test_minimal_contract():
         """
         )
     )
-    logs.remove_from_root_logger()
+    logs.close()
 
     assert not logs.get_errors_str()

--- a/soda-tests/tests/unit/test_contract_verification_logs.py
+++ b/soda-tests/tests/unit/test_contract_verification_logs.py
@@ -34,7 +34,9 @@ def test_split_log_lines(data_source_test_helper: DataSourceTestHelper):
     log_lines = contract_verification_result.get_logs()
 
     expected = [
-        "Verifying contract 📜 None 🤞",
+        # A string-sourced contract (no local file path, no collection id) falls
+        # back to the yaml source's description instead of printing 'None'.
+        "Verifying contract 📜 Contract YAML string 🤞",
         # some (many) non-deterministic log lines are skipped, we just need to make sure table is correctly split over multiple lines
         "+-----------------+------------------------------------+-------------+-----------+--------------+------------+------------------------+",
         "| Column          | Check                              | Threshold   | Outcome   | Check Type   | Identity   | Diagnostics            |",

--- a/soda-tests/tests/unit/test_dup_collection_id_validation.py
+++ b/soda-tests/tests/unit/test_dup_collection_id_validation.py
@@ -24,6 +24,7 @@ from soda_core.check_collections.base import (
 )
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.exceptions import InvalidArgumentException
+from soda_core.common.logs import Logs
 from soda_core.contracts.contract_verification import (
     CheckCollectionStatus,
     Contract,
@@ -88,6 +89,7 @@ class _StubImpl(CheckCollectionImpl):
     def __init__(self, yaml, **kwargs):
         # Skip the heavy base ``__init__``; tests control state directly.
         self.yaml = yaml
+        self.logs = Logs()
         self._collection_id = getattr(yaml.yaml_source, "collection_id_override", None)
         # Track verify() invocations so tests can assert it didn't run.
         type(self).verify_call_count = getattr(type(self), "verify_call_count", 0)

--- a/soda-tests/tests/unit/test_expected_kinds.py
+++ b/soda-tests/tests/unit/test_expected_kinds.py
@@ -23,6 +23,7 @@ from soda_core.check_collections.base import (
 )
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.exceptions import InvalidArgumentException
+from soda_core.common.logs import Logs
 
 _KIND_A = "expected-kinds-stub-a"
 _KIND_B = "expected-kinds-stub-b"
@@ -50,6 +51,7 @@ class _StubImplA(CheckCollectionImpl):
 
     def __init__(self, yaml, **kwargs):
         self.yaml = yaml
+        self.logs = Logs()
         type(self).verify_call_count = getattr(type(self), "verify_call_count", 0)
 
     def verify(self) -> _StubResultA:

--- a/soda-tests/tests/unit/test_phase3_handler_skip_on_error.py
+++ b/soda-tests/tests/unit/test_phase3_handler_skip_on_error.py
@@ -23,6 +23,7 @@ from soda_core.check_collections.base import (
     CheckCollectionYaml,
 )
 from soda_core.check_collections.session import execute_check_collections
+from soda_core.common.logs import Logs
 from soda_core.contracts.contract_verification import (
     CheckCollectionStatus,
     Contract,
@@ -86,6 +87,7 @@ class _StubImpl(CheckCollectionImpl):
         # Skip the heavy base ``__init__``; the executor only needs the
         # yaml + a reachable run_post_processing_handlers method.
         self.yaml = yaml
+        self.logs = Logs()
 
     @property
     def collection_id(self) -> Optional[str]:

--- a/soda-tests/tests/unit/test_session_log_isolation.py
+++ b/soda-tests/tests/unit/test_session_log_isolation.py
@@ -144,7 +144,7 @@ class _LoggingImpl(CheckCollectionImpl):
 
     def verify(self) -> _FakeResult:
         soda_logger.info(f"verify-{self._label}")
-        return _make_result(self._label, self.logs.pop_log_records())
+        return _make_result(self._label, self.logs.get_log_records())
 
 
 class _RaisingConstructImpl(CheckCollectionImpl):
@@ -269,6 +269,10 @@ def test_failed_construction_leaves_capture_intact_for_siblings(_isolate_logging
     """A construction that raises must not break capture for the other
     collections or accumulate handlers on the root logger (there is one
     process-permanent root capturer; a failed construct adds none)."""
+    # Install the process-wide capturer before sampling so the count is not
+    # order-dependent (running this test alone would otherwise install it
+    # mid-run and legitimately grow the count by one).
+    logs_module._ensure_root_capturer()
     handler_count_before = len(logging.root.handlers)
 
     sources = [

--- a/soda-tests/tests/unit/test_session_log_isolation.py
+++ b/soda-tests/tests/unit/test_session_log_isolation.py
@@ -1,0 +1,292 @@
+"""Per-collection log isolation in the check-collections executor.
+
+When N collections run in one ``execute_check_collections`` session on one
+thread, each collection's log records must land in — and be labelled for — only
+that collection, with no duplicates in the combined upload payload.
+
+Capture is routed through a single root-logger handler to the *active* ``Logs``
+(a contextvar), and a ``Logs`` becomes active the moment it is constructed, so
+each impl's construction logs are captured by its own gatherer; the executor
+re-activates each impl's ``Logs`` around its verify() and post-processing
+handlers. Each record's ``thread`` is stamped at emit time (via the active
+Logs' ``label``) with the per-collection value ``{wire_source}.{collection_id}``,
+so there is no after-the-fact relabel and only one gatherer is ever active
+(siblings cannot cross-capture).
+
+The CLI console output is unaffected — it prints via a separate
+``SodaConsoleHandler`` at emit time, not from these per-result buffers.
+
+These tests drive the executor with a sentinel ``_LoggingImpl`` that mirrors the
+real construct/verify log lifecycle without needing a data source.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from soda_core.check_collections.base import (
+    CheckCollectionImpl,
+    CheckCollectionResult,
+    CheckCollectionYaml,
+)
+from soda_core.check_collections.session import execute_check_collections
+from soda_core.common import logs as logs_module
+from soda_core.common.logging_constants import soda_logger
+from soda_core.common.logs import Logs
+from soda_core.common.soda_cloud import _build_check_collection_results_json_dict
+from soda_core.contracts.contract_verification import (
+    CheckCollectionStatus,
+    Contract,
+    YamlFileContentInfo,
+)
+from soda_core.contracts.impl.contract_verification_impl import (
+    ContractVerificationHandlerRegistry,
+)
+
+_LOGGING_KIND = "logging-isolation-test"
+_RAISING_KIND = "logging-isolation-raise-test"
+_WIRE_SOURCE = "logging-collection"
+
+
+class _FakeYamlObject:
+    """Minimal YamlObject stand-in — the executor reads ``kind`` off it."""
+
+    def __init__(self, kind: Optional[str]):
+        self._kind = kind
+
+    def read_string_opt(self, key: str, env_var=None, default_value=None):
+        return self._kind if key == "kind" else default_value
+
+
+class _LabelledSource:
+    """``CheckCollectionYamlSource`` stand-in carrying a label + kind."""
+
+    def __init__(self, label: str, kind: str = _LOGGING_KIND):
+        self._label = label
+        self._kind = kind
+        self.file_path = f"{label}.yml"
+        self.yaml_str_original = f"# {label}"
+
+    def parse(self):
+        return _FakeYamlObject(kind=self._kind)
+
+
+class _FakeYaml(CheckCollectionYaml):
+    """Inherits the base __init__/parse so ``data_timestamp`` /
+    ``execution_timestamp`` are populated for the executor's post-parse reads."""
+
+
+class _FakeResult(CheckCollectionResult):
+    """Sentinel result subclass — same shape as ``CheckCollectionResult``."""
+
+
+def _make_result(label: str, log_records: list) -> _FakeResult:
+    now = datetime.now(tz=timezone.utc)
+    return _FakeResult(
+        check_collection=Contract(
+            data_source_name="fake_ds",
+            dataset_prefix=[],
+            dataset_name=label,
+            soda_qualified_dataset_name=f"fake_ds/{label}",
+            source=YamlFileContentInfo(
+                source_content_str=f"# {label}",
+                local_file_path=f"/fake/{label}.yml",
+                soda_cloud_file_id=f"file-{label}",
+            ),
+        ),
+        data_source=None,
+        data_timestamp=now,
+        started_timestamp=now,
+        ended_timestamp=now,
+        status=CheckCollectionStatus.PASSED,
+        measurements=[],
+        check_results=[],
+        sending_results_to_soda_cloud_failed=False,
+        log_records=log_records,
+        post_processing_stages=[],
+    )
+
+
+class _LoggingImpl(CheckCollectionImpl):
+    """Sentinel combine-upload subtype that exercises the log lifecycle.
+
+    Mirrors the parts of ``CheckCollectionImpl.__init__`` / ``verify()`` that
+    matter for capture, without a data source: it owns its ``Logs`` (when
+    ``logs=None``), labels that Logs (so records are stamped at emit), emits a
+    construction line, and on verify() emits a line and pops the records.
+    """
+
+    kind = _LOGGING_KIND
+    wire_source = _WIRE_SOURCE
+    display_name = "logging-collection"
+    yaml_class = _FakeYaml
+    result_class = _FakeResult
+    combine_uploads = True
+
+    def __init__(self, yaml, logs=None, **kwargs):
+        # Own a Logs per impl exactly like CheckCollectionImpl.__init__ does
+        # when the caller passes logs=None (the combine-upload path); a freshly
+        # constructed Logs is the active capture target.
+        self.logs = logs if logs is not None else Logs()
+        self.yaml = yaml
+        self._label = yaml.yaml_source._label
+        # Label the capture target so this impl's records are stamped at emit
+        # time (mirrors base.__init__'s ``self.logs.label = self.thread_label``).
+        self.logs.label = self.thread_label
+        soda_logger.info(f"construct-{self._label}")
+
+    @property
+    def collection_id(self) -> Optional[str]:
+        return self._label
+
+    def verify(self) -> _FakeResult:
+        soda_logger.info(f"verify-{self._label}")
+        return _make_result(self._label, self.logs.pop_log_records())
+
+
+class _RaisingConstructImpl(CheckCollectionImpl):
+    """Combine-upload subtype whose __init__ creates its own ``Logs`` and then
+    raises — modelling a per-file construction failure (bad YAML, unparseable
+    dataset, ...). Must not leave the root logger in a degraded state."""
+
+    kind = _RAISING_KIND
+    wire_source = _WIRE_SOURCE
+    display_name = "logging-collection-raising"
+    yaml_class = _FakeYaml
+    result_class = _FakeResult
+    combine_uploads = True
+
+    def __init__(self, yaml, logs=None, **kwargs):
+        self.logs = logs if logs is not None else Logs()
+        raise RuntimeError("construction blew up")
+
+
+@pytest.fixture()
+def _isolate_logging():
+    """Isolate this module's logging side effects from the rest of the suite.
+
+    - Force ``soda_logger`` to DEBUG so the INFO lines the fakes emit are
+      captured (without depending on whatever level prior tests left).
+    - Clear the post-processing handler registry for the duration of the test
+      so phase 3 can't invoke a registered handler against our minimal fakes
+      (which don't model ``data_source_impl`` etc.); restore it afterwards.
+    - Reset the active-capture contextvar before and after so a Logs built here
+      (or by a prior test) doesn't leak as the active target. The single root
+      capturer is process-permanent and intentionally left installed.
+    """
+    prev_level = soda_logger.level
+    soda_logger.setLevel(logging.DEBUG)
+    registry_before = list(ContractVerificationHandlerRegistry.contract_verification_handlers)
+    ContractVerificationHandlerRegistry.contract_verification_handlers[:] = []
+    logs_module._active_logs.set(None)
+    try:
+        yield
+    finally:
+        soda_logger.setLevel(prev_level)
+        ContractVerificationHandlerRegistry.contract_verification_handlers[:] = registry_before
+        logs_module._active_logs.set(None)
+
+
+def _run_three_collections() -> list[_FakeResult]:
+    sources = [_LabelledSource("a"), _LabelledSource("b"), _LabelledSource("c")]
+    session_result = execute_check_collections(yaml_sources=sources, data_source_impl=None)
+    return session_result.results
+
+
+def _messages(result: _FakeResult) -> list[str]:
+    return [r.getMessage() for r in (result.log_records or [])]
+
+
+def test_each_collection_result_only_contains_its_own_log_lines(_isolate_logging):
+    """A collection's result must carry only the log lines it emitted —
+    never lines from sibling collections in the same session."""
+    results = _run_three_collections()
+
+    by_label = {r.check_collection.dataset_name: _messages(r) for r in results}
+    assert by_label["a"] == ["construct-a", "verify-a"]
+    assert by_label["b"] == ["construct-b", "verify-b"]
+    assert by_label["c"] == ["construct-c", "verify-c"]
+
+
+def test_no_log_record_is_shared_across_results(_isolate_logging):
+    """The same ``LogRecord`` object must not appear in more than one result —
+    shared objects are what duplicate into the combined Cloud payload."""
+    results = _run_three_collections()
+
+    seen_ids: set[int] = set()
+    duplicated: list[str] = []
+    for result in results:
+        for record in result.log_records or []:
+            if id(record) in seen_ids:
+                duplicated.append(record.getMessage())
+            seen_ids.add(id(record))
+
+    assert duplicated == []
+
+
+def test_thread_matches_the_emitting_collection(_isolate_logging):
+    """Every record of a collection shares one ``thread`` value, stamped at emit
+    time, that names the collection (``{wire_source}.{collection_id}``)."""
+    results = _run_three_collections()
+
+    for result in results:
+        label = result.check_collection.dataset_name
+        threads = {record.thread for record in (result.log_records or [])}
+        assert threads == {f"{_WIRE_SOURCE}.{label}"}, f"collection {label!r} carried {threads}"
+
+
+def test_combined_payload_has_no_duplicate_log_entries(_isolate_logging):
+    """The combined ``sodaCoreInsertScanResults`` payload must list each emitted
+    log line exactly once, each stamped with its collection's thread."""
+    results = _run_three_collections()
+
+    payload = _build_check_collection_results_json_dict(results, wire_source=_WIRE_SOURCE)
+    entries = [(log["message"], log["thread"]) for log in payload["logs"]]
+
+    assert sorted(entries) == [
+        ("construct-a", f"{_WIRE_SOURCE}.a"),
+        ("construct-b", f"{_WIRE_SOURCE}.b"),
+        ("construct-c", f"{_WIRE_SOURCE}.c"),
+        ("verify-a", f"{_WIRE_SOURCE}.a"),
+        ("verify-b", f"{_WIRE_SOURCE}.b"),
+        ("verify-c", f"{_WIRE_SOURCE}.c"),
+    ]
+
+
+def test_constructing_logs_auto_captures_without_an_explicit_scope(_isolate_logging):
+    """Capture is a side effect of constructing a ``Logs`` — there is no opt-in
+    scope a caller can forget. This guards against regressing to an opt-in model
+    where a missing scope would silently drop records."""
+    logs = Logs()
+    soda_logger.info("ping-unscoped")
+    assert "ping-unscoped" in [r.getMessage() for r in logs.get_log_records()]
+
+
+def test_failed_construction_leaves_capture_intact_for_siblings(_isolate_logging):
+    """A construction that raises must not break capture for the other
+    collections or accumulate handlers on the root logger (there is one
+    process-permanent root capturer; a failed construct adds none)."""
+    handler_count_before = len(logging.root.handlers)
+
+    sources = [
+        _LabelledSource("ok-1"),
+        _LabelledSource("bad", kind=_RAISING_KIND),
+        _LabelledSource("ok-2"),
+    ]
+    session_result = execute_check_collections(yaml_sources=sources, data_source_impl=None)
+
+    # The failed file still yields an ERROR placeholder; siblings still run and
+    # capture their own lines, correctly labelled.
+    assert [r.status for r in session_result.results] == [
+        CheckCollectionStatus.PASSED,
+        CheckCollectionStatus.ERROR,
+        CheckCollectionStatus.PASSED,
+    ]
+    assert _messages(session_result.results[0]) == ["construct-ok-1", "verify-ok-1"]
+    assert _messages(session_result.results[2]) == ["construct-ok-2", "verify-ok-2"]
+    assert {r.thread for r in session_result.results[2].log_records} == {f"{_WIRE_SOURCE}.ok-2"}
+    # No per-construction handler accumulation on the root logger.
+    assert len(logging.root.handlers) == handler_count_before


### PR DESCRIPTION
## Problem

Verifying **multiple collections in one session** produced a correct CLI console log but a corrupted `logs` array in the combined upload payload:

- **Duplicates** — the same log line appeared several times (once per collection that cross-captured it), though only once on the CLI.
- **Wrong grouping label** — most lines were stamped with the *last* collection's label instead of the one that emitted them.

Each `Logs` attached its own root-logger `LogCapturer` filtered **only by OS thread id**; since collections run sequentially on one thread and were all built up front, every capturer captured every sibling's records, and an after-the-fact relabel pass then stamped them with whichever collection popped last.

## Approach

- **One permanent root capturer** routes each record to the **active `Logs`** via a `contextvars.ContextVar`. A `Logs` becomes active **on construction**, so capture is automatic — there is no opt-in scope to forget (a missed re-activation mis-buckets at worst, **never silently drops**).
- The executor re-activates each impl's `Logs` around its `verify()` and post-processing handlers; **only one gatherer is ever active**, so siblings can't cross-capture and a failed construction leaves no handler to leak.
- The per-collection **`thread` is stamped at emit time** (no after-the-fact relabel) as **`{wire_source}.{collection_id}`** (bare `wire_source` when there's no `collection_id`). It's distinct per collection (`collection_id`s are dedup-enforced) — the value Soda Cloud surfaces as a per-scan log filter. The consumer treats `thread` as an opaque string, so no backend change is required.

Replaces the per-`Logs` `LogCapturer` + thread-id filter, the executor's `owns_logs` / attach-detach / orphan-sweep, and the `_apply_thread_label_to_log_records` relabel passes. The public `Logs` surface is now `Logs(gatherer=, label=)`, `activate()`, `close()`, and the read API — `LogCapturer` / `remove_from_root_logger` / `attach_to_root_logger` are gone; callers use `Logs(gatherer=...)` + `close()`.

## Tests

New `soda-tests/tests/unit/test_session_log_isolation.py`: per-result isolation, no shared `LogRecord` across results, per-collection `thread`, a **duplicate-free** combined payload, **auto-capture without an explicit scope** (guards against regressing to opt-in), and **no handler leak on a failed construction**. Full soda-core unit suite + DuckDB integration green; the real two-data-standard combined-upload path (soda-extensions `test_combined_session`) verified green against this branch.

## Downstream

soda-extensions tests are adjusted for the new capture API in [sodadata/soda-extensions#424](https://github.com/sodadata/soda-extensions/pull/424) — forward-compatible (passes on the current and the new soda-core), so it can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)