### PR TITLE
Replace failed rows diagnostics TODO print with a warning

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1292,7 +1292,11 @@ class SodaCloud:
         return self.token
 
     def send_failed_rows_diagnostics(self, scan_id: str, failed_rows_diagnostics: list[FailedRowsDiagnostic]):
-        print(f"TODO sending failed rows diagnostics for scan {scan_id} to Soda Cloud: {failed_rows_diagnostics}")
+        logger.warning(
+            "Skipping failed rows diagnostics upload for scan '%s': feature not implemented yet (%d diagnostic entries).",
+            scan_id,
+            len(failed_rows_diagnostics),
+        )
 
     def migration_create(self, v4_datasource_name: str, v3_dataset_ids: list[str]) -> str:
         logger.info(

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -102,6 +102,28 @@ def test_soda_cloud_from_yaml_source_with_token_auth():
         pytest.fail("An unexpected exception occurred: {exc}")
 
 
+def test_send_failed_rows_diagnostics_logs_warning_without_stdout(capsys):
+    soda_cloud = SodaCloud(
+        host="dev.sodadata.io",
+        api_key_id="some_key_id",
+        api_key_secret="some_key_secret",
+        token=None,
+        port=None,
+        scheme=None,
+    )
+
+    with mock.patch("soda_core.common.soda_cloud.logger.warning") as warning_mock:
+        soda_cloud.send_failed_rows_diagnostics("scan-123", [])
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    warning_mock.assert_called_once_with(
+        "Skipping failed rows diagnostics upload for scan '%s': feature not implemented yet (%d diagnostic entries).",
+        "scan-123",
+        0,
+    )
+
+
 def test_soda_cloud_results(data_source_test_helper: DataSourceTestHelper, env_vars: dict):
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 


### PR DESCRIPTION
## Summary
- replace the TODO `print(...)` in `SodaCloud.send_failed_rows_diagnostics()` with a structured warning
- add a regression test that asserts the method does not write to stdout

## Why
A bare `print()` in production code can leak implementation details into CLI output and make automation harder to reason about. Logging keeps the current placeholder behavior visible without polluting standard output.

## Validation
- `py -m uv run --package soda-tests pytest soda-tests/tests/unit/test_soda_cloud.py -k test_send_failed_rows_diagnostics_logs_warning_without_stdout -q` (`1 passed`, `34 deselected`)
- the remaining tests in that file reached `30 passed`; five integration-backed cases require the optional `soda_postgres` package in the local environment
- `git diff --check`