### PR TITLE
Fix decorator AST visitor dispatch

### DIFF
--- a/soda-core/src/soda_core/telemetry/soda_tracer.py
+++ b/soda-core/src/soda_core/telemetry/soda_tracer.py
@@ -36,7 +36,7 @@ def get_decorators(function):
                 name = n.func.attr if isinstance(n.func, ast.Attribute) else n.func.id
 
                 for a in n.args:
-                    print(ast.dump(a))
+                    logger.debug("Decorator arg AST: %s", ast.dump(a))
             else:
                 group = n.attr if isinstance(n, ast.Attribute) else n.id
                 name = None

--- a/soda-core/src/soda_core/telemetry/soda_tracer.py
+++ b/soda-core/src/soda_core/telemetry/soda_tracer.py
@@ -48,7 +48,7 @@ def get_decorators(function):
                 decorators[node.name][group].append({name})
 
     node_iter = ast.NodeVisitor()
-    node_iter.visit_function_def = visit_function_def
+    node_iter.visit_FunctionDef = visit_function_def
     node_iter.visit(ast.parse(textwrap.dedent(inspect.getsource(function))))
     return decorators
 

--- a/soda-tests/tests/unit/test_soda_tracer.py
+++ b/soda-tests/tests/unit/test_soda_tracer.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+from soda_core.telemetry.soda_tracer import get_decorators
+
+
+def test_get_decorators_does_not_print_ast_arguments(capsys):
+    def decorated_function():
+        return None
+
+    decorated_function = mock.patch("os.getcwd")(decorated_function)
+
+    with mock.patch("soda_core.telemetry.soda_tracer.logger.debug") as debug_mock:
+        decorators = get_decorators(decorated_function)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert decorators["decorated_function"]["mock"] == [{"patch"}]
+    debug_mock.assert_called_once()

--- a/soda-tests/tests/unit/test_soda_tracer.py
+++ b/soda-tests/tests/unit/test_soda_tracer.py
@@ -3,16 +3,25 @@ from unittest import mock
 from soda_core.telemetry.soda_tracer import get_decorators
 
 
+class TestDecorators:
+    @staticmethod
+    def capture(_argument):
+        return lambda function: function
+
+
+decorators = TestDecorators()
+
+
+@decorators.capture("value")
+def decorated_function():
+    return None
+
+
 def test_get_decorators_does_not_print_ast_arguments(capsys):
-    def decorated_function():
-        return None
-
-    decorated_function = mock.patch("os.getcwd")(decorated_function)
-
     with mock.patch("soda_core.telemetry.soda_tracer.logger.debug") as debug_mock:
         decorators = get_decorators(decorated_function)
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert decorators["decorated_function"]["mock"] == [{"patch"}]
+    assert decorators["decorated_function"]["decorators"] == [{"capture"}]
     debug_mock.assert_called_once()


### PR DESCRIPTION
﻿## Summary
- fix the `ast.NodeVisitor` callback registration so `FunctionDef` nodes are actually visited
- route decorator-argument diagnostics through structured debug logging instead of stdout
- add a regression test that exercises a real decorator call with an AST argument

## Why
`NodeVisitor` dispatches function definitions to `visit_FunctionDef`, but the helper registered `visit_function_def`. As a result, `get_decorators()` returned an empty mapping and the intended visitor logic never ran. Correcting the dispatch exposes the existing unconditional `print()`, so the diagnostic is now kept behind the project logger.

## Validation
- `py -m uv run --package soda-tests --group dev pytest soda-tests/tests/unit/test_soda_tracer.py -q` (`1 passed`)
- `py -m uv run black --check soda-tests/tests/unit/test_soda_tracer.py`
- `git diff --check`

## CI note
The GitHub Actions matrix currently stops before test execution in the upstream Get external secrets step because fork runs do not receive the AWS region/Secrets Manager configuration (expected region to be configured for aws.auth#sigv4). The fork-safe pre-commit, lockfile, CLA, Aikido, and SonarCloud checks pass; the targeted unit test above passes locally.
