### PR TITLE
docs: align README Python requirement to 3.10+ (matches pyproject)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This repository hosts the open source Soda Core packages which are installable u
 ### Requirements
 To use Soda, you must have installed the following on your system.
 
-* **Python 3.9, 3.10, 3.11, or 3.12** <br>
-To check your existing version, use the CLI command: `python --version` or `python3 --version`. If you have not already installed Python, consider using `pyenv` to manage multiple versions of Python in your environment.  **Note:** While Python 3.12 is the highest officially supported version, there are no known issues preventing use of Python 3.13+.
+* **Python 3.10+ (3.10, 3.11, or 3.12)** <br>
+To check your existing version, use the CLI command: `python --version` or `python3 --version`. If you have not already installed Python, consider using `pyenv` to manage multiple versions of Python in your environment.  **Note:** While Python 3.12 is the highest officially validated version, there are no known issues preventing use of Python 3.13+.
 
 * **UV (recommended) or Pip 21.0 or greater** <br>
 We recommend using [UV](https://docs.astral.sh/uv/) for faster and more reliable package management. To install UV, see the [UV installation guide](https://docs.astral.sh/uv/getting-started/installation/). Alternatively, you can use pip (version 21.0+). To check your pip version: `pip --version` 


### PR DESCRIPTION
## Description

- Aligns the README Python version requirement with pyproject.toml.
- Updates the Requirements section to state Python 3.10+ (3.10, 3.11, or 3.12) instead of including Python 3.9.
- Clarifies that Python 3.12 is the highest officially validated version, with no known issues for 3.13+.

### Problem being solved
- README.md stated “Python 3.9, 3.10, 3.11, or 3.12” while pyproject.toml requires >=3.10.
- This inconsistency could mislead users about supported versions.

## Changes

- In README.md under Requirements:
  - Changed “Python 3.9, 3.10, 3.11, or 3.12” to “Python 3.10+ (3.10, 3.11, or 3.12)”.
  - Updated the note to say “officially validated” instead of “officially supported” for 3.12.

## How I verified

- Compared README.md with pyproject.toml to ensure consistency.
- Confirmed pyproject.toml specifies requires-python = ">=3.10".

## Affected areas

- README.md documentation only.

## Backward compatibility and risks

- No compatibility impact. This is a documentation update.
- No risk to code or runtime behavior.

## Files changed

- README.md

## Checklist

- [x] I verified the change aligns with pyproject.toml.
- [ ] I verified this PR does not break [soda-extensions](https://github.com/sodadata/soda-extensions) (not applicable; docs-only change).

## Release notes

- Docs: Updated README to reflect Python 3.10+ requirement (previously listed 3.9).