### PR TITLE
ci(publish): fix Soda PyPI --skip-existing + single approval gate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 ---
 name: Publish to PyPI
 
-# Publishes an ALREADY-TAGGED release to public PyPI.
+# Publishes an ALREADY-TAGGED release to Soda PyPI and public PyPI.
 #
 # Why this exists, separate from release.yaml:
 #   release.yaml ("one-button release") resolves a version, tags it, builds,
@@ -28,8 +28,13 @@ name: Publish to PyPI
 #                           (e.g. v4.14.0, or the 4.8.0-4.13.0 backlog); a tag
 #                           pushed before this workflow existed won't re-fire.
 #
-# twine runs with --skip-existing, so re-runs and backfills are safe and the
-# automatic tag path does not fail when public PyPI already has the version.
+# Idempotency (re-runs / backfills must not fail on an already-published
+# version) is handled per-registry, because the two indexes differ:
+#   public PyPI        -> supports `twine upload --skip-existing`.
+#   pypi.cloud.soda.io -> devpi index; does NOT support --skip-existing
+#                         (`UnsupportedConfiguration: ... --skip-existing`).
+#                         So we upload plain and treat an "already exists"
+#                         rejection as success.
 #
 # Approval: only the `approve` job references the production-release
 # environment, so reviewers get ONE approval request per run rather than one
@@ -122,6 +127,17 @@ jobs:
       - name: Set up UV
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
 
+      - name: Get external secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802  # v2.0.10
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BUILD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BUILD_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_BUILD_DEFAULT_REGION }}
+        with:
+          secret-ids: |
+            PYPI_USERNAME,/soda/github/common/SODA_PYPI_CLOUD_WRITE_USERNAME
+            PYPI_PASSWORD,/soda/github/common/SODA_PYPI_CLOUD_WRITE_PASSWORD
+
       - name: Build ${{ matrix.module }}
         run: |
           uv venv .venv
@@ -152,6 +168,39 @@ jobs:
           echo "Staggering upload by ${DELAY}s..."
           sleep "$DELAY"
 
+      - name: Publish to Soda PyPI
+        id: soda_pypi
+        if: ${{ !inputs.dry_run }}
+        env:
+          TWINE_REPOSITORY_URL: ${{ vars.CLOUD_PYPI_REPOSITORY }}
+          TWINE_USERNAME: ${{ env.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ env.PYPI_PASSWORD }}
+        run: |
+          source .venv/bin/activate
+          # pypi.cloud.soda.io (devpi) does NOT support --skip-existing, so we
+          # upload plain and treat an "already exists" rejection as success to
+          # keep re-runs / backfills idempotent.
+          RESULT="failure"
+          for attempt in 1 2 3; do
+            OUT="$(twine upload "${{ matrix.module }}"/dist/* 2>&1)" && {
+              echo "$OUT"; RESULT="success"
+              echo "Soda PyPI upload succeeded on attempt $attempt"; break
+            }
+            echo "$OUT"
+            if echo "$OUT" | grep -qiE "already (exists|been uploaded)|this filename has already been used|409 (conflict|client error)"; then
+              RESULT="success"
+              echo "Soda PyPI already has this version — treating as success."; break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              DELAY=$((attempt * 15))
+              echo "::warning::Soda PyPI upload failed (attempt $attempt/3), retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            else
+              echo "::error::Soda PyPI upload failed after 3 attempts"
+            fi
+          done
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
       - name: Publish to public PyPI
         id: public_pypi
         if: ${{ !inputs.dry_run }}
@@ -179,8 +228,9 @@ jobs:
         if: ${{ always() && !inputs.dry_run }}
         run: |
           echo "### ${{ matrix.module }} @ ${{ needs.resolve.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Soda PyPI: ${{ steps.soda_pypi.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Public PyPI: ${{ steps.public_pypi.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.public_pypi.outputs.result }}" != "success" ]; then
-            echo "::error::${{ matrix.module }} did not publish to public PyPI — see logs."
+          if [ "${{ steps.soda_pypi.outputs.result }}" != "success" ] || [ "${{ steps.public_pypi.outputs.result }}" != "success" ]; then
+            echo "::error::${{ matrix.module }} did not publish cleanly to both registries — see logs."
             exit 1
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 ---
 name: Publish to PyPI
 
-# Publishes an ALREADY-TAGGED release to Soda PyPI and public PyPI.
+# Publishes an ALREADY-TAGGED release to public PyPI.
 #
 # Why this exists, separate from release.yaml:
 #   release.yaml ("one-button release") resolves a version, tags it, builds,
@@ -28,8 +28,12 @@ name: Publish to PyPI
 #                           (e.g. v4.14.0, or the 4.8.0-4.13.0 backlog); a tag
 #                           pushed before this workflow existed won't re-fire.
 #
-# twine runs with --skip-existing, so re-runs are safe and the automatic path
-# does not fail when a registry already has the version (e.g. Soda PyPI).
+# twine runs with --skip-existing, so re-runs and backfills are safe and the
+# automatic tag path does not fail when public PyPI already has the version.
+#
+# Approval: only the `approve` job references the production-release
+# environment, so reviewers get ONE approval request per run rather than one
+# per matrix leg.
 
 on:
   push:
@@ -85,11 +89,22 @@ jobs:
         id: modules
         run: echo "modules=$(bash scripts/release_matrix.sh)" >> "$GITHUB_OUTPUT"
 
-  publish:
-    name: Publish ${{ matrix.module }}
+  # Single approval gate for the whole run. Only this job carries the
+  # production-release environment, so reviewers approve ONCE per run instead
+  # of once per matrix leg (one email, not 14). Secrets are repo-level, so the
+  # publish matrix below still has access without referencing the environment.
+  approve:
+    name: Approve publish
     needs: [resolve]
     runs-on: ubuntu-24.04
     environment: production-release
+    steps:
+      - run: echo "Publishing ${{ needs.resolve.outputs.tag }} approved."
+
+  publish:
+    name: Publish ${{ matrix.module }}
+    needs: [resolve, approve]
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -106,17 +121,6 @@ jobs:
 
       - name: Set up UV
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
-
-      - name: Get external secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802  # v2.0.10
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BUILD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BUILD_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_BUILD_DEFAULT_REGION }}
-        with:
-          secret-ids: |
-            PYPI_USERNAME,/soda/github/common/SODA_PYPI_CLOUD_WRITE_USERNAME
-            PYPI_PASSWORD,/soda/github/common/SODA_PYPI_CLOUD_WRITE_PASSWORD
 
       - name: Build ${{ matrix.module }}
         run: |
@@ -148,30 +152,6 @@ jobs:
           echo "Staggering upload by ${DELAY}s..."
           sleep "$DELAY"
 
-      - name: Publish to Soda PyPI
-        id: soda_pypi
-        if: ${{ !inputs.dry_run }}
-        env:
-          TWINE_REPOSITORY_URL: ${{ vars.CLOUD_PYPI_REPOSITORY }}
-          TWINE_USERNAME: ${{ env.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ env.PYPI_PASSWORD }}
-        run: |
-          source .venv/bin/activate
-          RESULT="failure"
-          for attempt in 1 2 3; do
-            if twine upload --skip-existing "${{ matrix.module }}"/dist/*; then
-              RESULT="success"; echo "Soda PyPI upload succeeded on attempt $attempt"; break
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              DELAY=$((attempt * 15))
-              echo "::warning::Soda PyPI upload failed (attempt $attempt/3), retrying in ${DELAY}s..."
-              sleep "$DELAY"
-            else
-              echo "::error::Soda PyPI upload failed after 3 attempts"
-            fi
-          done
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
-
       - name: Publish to public PyPI
         id: public_pypi
         if: ${{ !inputs.dry_run }}
@@ -199,9 +179,8 @@ jobs:
         if: ${{ always() && !inputs.dry_run }}
         run: |
           echo "### ${{ matrix.module }} @ ${{ needs.resolve.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Soda PyPI: ${{ steps.soda_pypi.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Public PyPI: ${{ steps.public_pypi.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.soda_pypi.outputs.result }}" != "success" ] || [ "${{ steps.public_pypi.outputs.result }}" != "success" ]; then
-            echo "::error::${{ matrix.module }} did not publish cleanly to both registries — see logs."
+          if [ "${{ steps.public_pypi.outputs.result }}" != "success" ]; then
+            echo "::error::${{ matrix.module }} did not publish to public PyPI — see logs."
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #2758 — two fixes surfaced by the first v4.14.0 publish run.

## 1. Fix the Soda PyPI (`pypi.cloud.soda.io`) upload — don't drop it

The run failed on the Soda leg:
```
UnsupportedConfiguration: The configured repository 'https://pypi.cloud.soda.io'
does not have support for the following features: --skip-existing
```

The registry wasn't the problem — the **flag** was. #2758 added `--skip-existing`
to *every* upload leg, but `pypi.cloud.soda.io` is a devpi index that rejects it.
The old `release.yaml` always uploaded to Soda PyPI *plain* (no `--skip-existing`),
which is why it worked.

soda-core clean releases are still needed on Soda PyPI, so we keep the leg and fix
idempotency **per-registry**:
- **public PyPI** → keeps `twine upload --skip-existing` (supported).
- **pypi.cloud.soda.io** → uploads plain; captures twine output and treats an
  "already exists" / 409 rejection as success, so re-runs and backfills stay safe.

> ⚠️ Note for registry owners: soda-core 4.x packages (`soda-postgres`,
> `soda-snowflake`, …) share names with soda-library 1.x on this same index.
> Publishing soda-core's 4.x there can shadow soda-library's identically-named
> 1.x packages for any consumer resolving from cloud PyPI. This restores the
> pre-#2758 behaviour intentionally; worth confirming a consumer actually needs
> soda-core clean releases from cloud before relying on it.

## 2. Collapse 14 approval emails into one

The matrix `publish` job referenced `environment: production-release` directly, so
each of the 14 matrix legs raised its own deployment approval → 14 emails per
release. A tiny `approve` gate job now carries the environment; the matrix
`needs:` it and no longer references the environment itself. Safe because
`PYPI_API_TOKEN` is a **repo-level** secret, so the matrix keeps secret access.

```
resolve → approve (production-release, ONE approval) → publish [matrix ×14]
```

## Verification
- YAML parses; job graph: `resolve` → `approve` (env) → `publish` (matrix, no env).
- Soda PyPI leg uploads without `--skip-existing` (devpi-compatible) and tolerates
  duplicate-version rejections.
- Public PyPI leg unchanged from #2758.
- `--skip-existing` on public PyPI + the duplicate-tolerant Soda leg make re-running
  on an already-published tag (e.g. `v4.14.0`) a safe no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)