### PR TITLE
fix: apply check-level filter to failed_rows expression checks

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -229,10 +229,21 @@ class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
         return id_properties
 
     def sql_expression(self) -> SqlExpression:
-        return COUNT(CASE_WHEN(SqlExpressionStr(self.expression), LITERAL(1)))
+        # Route the count through sql_condition_expression() so the numerator and the failing-rows
+        # condition always carry the same check_filter (they cannot drift). Mirrors
+        # MissingCountMetricImpl / InvalidCountMetricImpl.
+        return COUNT(CASE_WHEN(self.sql_condition_expression(), LITERAL(1)))
 
     def sql_condition_expression(self) -> SqlExpression:
-        return SqlExpressionStr(self.expression)
+        # Apply the check-level filter, like missing/invalid do. When check_filter is None this
+        # collapses to the bare expression (byte-identical to the previous behaviour), so it is a
+        # no-op for filterless checks and only scopes checks that actually set `filter:`.
+        return AND.optional(
+            [
+                SqlExpressionStr.optional(self.check_filter),
+                SqlExpressionStr(self.expression),
+            ]
+        )
 
     def convert_db_value(self, value) -> any:
         return int(value) if value is not None else 0

--- a/soda-tests/tests/integration/test_udf_failed_rows_check.py
+++ b/soda-tests/tests/integration/test_udf_failed_rows_check.py
@@ -19,6 +19,26 @@ test_table_specification = (
     .build()
 )
 
+# (end - start) > 5 fails for (0,10), (10,20), (10,17) -> 3 failures unfiltered. With `filter: start = 0`
+# only (0,4) [passes] and (0,10) [fails] are in scope, so a correctly-scoped check finds 1 failure of 2
+# tested -> 50%. This narrowed-but-non-zero shape is what distinguishes "filter scopes the numerator"
+# from "filter only scopes the denominator" (the 200% bug) or "filter zeroes everything".
+narrowing_test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("failed_rows_narrowing")
+    .column_integer("start")
+    .column_integer("end")
+    .rows(
+        rows=[
+            (0, 4),
+            (0, 10),
+            (10, 20),
+            (10, 17),
+        ]
+    )
+    .build()
+)
+
 
 def test_failed_rows_expression(data_source_test_helper: DataSourceTestHelper):
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
@@ -51,6 +71,75 @@ def test_failed_rows_expression(data_source_test_helper: DataSourceTestHelper):
         "failedRowsPercent": 2 * 100 / 3,
         "datasetRowsTested": 3,
         "checkRowsTested": 3,
+    }
+
+
+def test_failed_rows_expression_applies_check_filter(data_source_test_helper: DataSourceTestHelper):
+    """A check-level `filter:` on a failed_rows expression must scope BOTH the failing-rows count
+    (numerator) and the rows-tested denominator. With `filter: start = 0`, only the row (0, 4) is in
+    scope and it does NOT satisfy (end - start) > 5, so the check PASSES with failed_rows_count 0.
+
+    Regression guard: before the fix, FailedRowsExpressionMetricImpl ignored check_filter, so the
+    numerator counted the two out-of-scope failing rows (10,20) and (10,17) -> failed_rows_count = 2
+    over a filtered denominator of 1 -> a 200% failed_rows_percent and a FAILED outcome."""
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_pass(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  expression: |
+                    ({end_quoted} - {start_quoted}) > 5
+                  filter: |
+                    {start_quoted} = 0
+        """,
+        publish_results=False,
+    )
+
+    check_result = contract_verification_result.check_results[0]
+    assert check_result.diagnostic_metric_values == {
+        "failed_rows_count": 0,
+        "failed_rows_percent": 0,
+        "dataset_rows_tested": 3,
+        "check_rows_tested": 1,
+    }
+
+
+def test_failed_rows_expression_filter_narrows_count(data_source_test_helper: DataSourceTestHelper):
+    """The check-level `filter:` must scope the failing-rows COUNT (numerator), not just the
+    rows-tested denominator. With `filter: start = 0`, the in-scope rows are (0,4) [passes] and
+    (0,10) [fails], so failed_rows_count = 1 of 2 tested -> 50%. Unfiltered the expression fails for 3
+    rows, so this asserts the filter narrows to a NON-ZERO count that differs from the unfiltered one,
+    and that failed_rows_percent stays <= 100 with a real numerator (the headline regression was a
+    200% percent from an unscoped numerator over a scoped denominator)."""
+    test_table = data_source_test_helper.ensure_test_table(narrowing_test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  expression: |
+                    ({end_quoted} - {start_quoted}) > 5
+                  filter: |
+                    {start_quoted} = 0
+        """,
+        publish_results=False,
+    )
+
+    check_result = contract_verification_result.check_results[0]
+    assert check_result.diagnostic_metric_values == {
+        "failed_rows_count": 1,
+        "failed_rows_percent": 50,
+        "dataset_rows_tested": 4,
+        "check_rows_tested": 2,
     }
 
 


### PR DESCRIPTION
## What & why

`failed_rows: expression:` checks accept a check-level `filter:`, but `FailedRowsExpressionMetricImpl` stored it and never used it — so the filter was silently ignored. Other check types (`missing`, `invalid`) apply `check_filter` consistently.

This was worse than a plain no-op: the percent denominator (`RowCountMetricImpl`) **already** honours the filter, so a filtered check computed an *unfiltered numerator over a filtered denominator* — `failed_rows_percent` could exceed 100%.

## The fix

Mirror `MissingCountMetricImpl` / `InvalidCountMetricImpl`:

- `sql_condition_expression()` now ANDs `check_filter` via `AND.optional`.
- `sql_expression()` (the COUNT) routes through `sql_condition_expression()` so the numerator and the failing-rows condition always carry the same filter and cannot drift.

When no `filter:` is set, `AND.optional` collapses to the bare expression, so the generated SQL is **byte-identical** for filterless checks — only checks that actually set `filter:` change behaviour (and those were previously broken). The verbatim `failed_rows: query:` flavour is untouched (it stays opaque user SQL).

## Tests

- `test_failed_rows_expression_applies_check_filter` — a filtered check now PASSES with `failed_rows_count` 0 when the only in-scope row passes (pre-fix it reported count 2 / 200% percent / FAILED).
- `test_failed_rows_expression_filter_narrows_count` — asserts a non-zero scoped count (1 of 2 = 50%) that differs from the unfiltered count of 3, guarding that the filter scopes the numerator (not just the denominator).

## Related

Required by soda-extensions PR sodadata/soda-extensions#439 — the `soda-failed-rows-query` package's failing/passing extraction queries inherit this filter (the failing query via `sql_condition_expression()`, the passing query updated in lockstep there). That PR pins this branch via `SODA_CORE_BRANCH=fix/failed_rows_expression_filter`, so its CI builds against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
