### PR TITLE
r-600 DWH memory management follow-up: honest fetch naming & encapsulated driver settings (core)

### DIFF
--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -17,45 +17,24 @@ logger: logging.Logger = soda_logger
 
 from tabulate import tabulate
 
-# General toggle for the memory-optimized fetch driver across ALL data source
-# connections. Env-gated and disabled by default.
-MEMORY_OPTIMIZED_DRIVER_ENABLED_ENV: str = "MEMORY_OPTIMIZED_DRIVER_ENABLED"
+class MemoryOptimizedDriverSettings:
+    """Process-level enablement for the bounded-memory streaming fetch driver.
 
-# Process-level override set from the Soda Cloud diagnostics-warehouse config
-# (the `use_memory_optimized` feature flag, plumbed in by soda-extensions). ORed
-# with the env toggle: either source can turn the driver on.
-_memory_optimized_override: bool = False
+    Enabled when EITHER the Soda Cloud override (``configure``, plumbed in by
+    soda-extensions from the ``useMemoryOptimized`` feature flag) OR the env var
+    ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` is on; DISABLED by default.
 
-# One-off guard so the "driver active" line is logged once per process, not per query.
-_memory_optimized_logged: bool = False
+    When disabled, every connection's ``execute_query_one_by_one_prefer_streaming``
+    uses the buffered base fetch. When enabled, connections that advertise a
+    low-memory fetch (``supports_streaming_fetch``, e.g. postgres' server-side
+    streaming cursor) use it. Disabled by default because the streaming path trades
+    throughput for bounded peak memory and regresses DWH runtime on fast /
+    low-latency sources.
 
-
-def set_memory_optimized_override(enabled: Optional[bool]) -> None:
-    """Enable the memory-optimized fetch driver from outside the env toggle.
-
-    Called by soda-extensions when Soda Cloud sends ``use_memory_optimized`` with
-    the diagnostics-warehouse configuration. ORed with
-    ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` in ``is_memory_optimized_driver_enabled``,
-    so the backend flag can turn the driver on regardless of the env var. A falsy
-    value leaves the env var as the sole control.
-    """
-    global _memory_optimized_override
-    _memory_optimized_override = bool(enabled)
-
-
-def is_memory_optimized_driver_enabled() -> bool:
-    """Whether the memory-optimized fetch driver is enabled for data source
-    connections. Enabled when EITHER the Soda Cloud override
-    (``set_memory_optimized_override``) OR the env var
-    (``MEMORY_OPTIMIZED_DRIVER_ENABLED``) is on; DISABLED by default.
-
-    When disabled, every connection's ``execute_query_one_by_one_memory_optimized``
-    uses the buffered base fetch. When enabled, connections that implement a
-    low-memory fetch (e.g. postgres' server-side streaming cursor, via
-    ``_execute_query_one_by_one_memory_optimized_impl``) use it. Disabled by
-    default because the memory-optimized path trades throughput for bounded peak
-    memory and regresses DWH runtime on fast / low-latency sources. Read at call
-    time so it can be toggled per-process (or per-test via monkeypatch.setenv).
+    Process-scoped (a single module instance) because the Soda Cloud flag is
+    resolved during diagnostics-config parse, before any DWH/source connection
+    exists, and connections are reused across scans. The env var is read at call
+    time so it can be toggled per-process (or per-test via ``monkeypatch.setenv``).
 
     Operator guidance: enable this (set ``MEMORY_OPTIMIZED_DRIVER_ENABLED=true``)
     when reads of very wide source rows run out of memory — without it the source
@@ -63,9 +42,42 @@ def is_memory_optimized_driver_enabled() -> bool:
     (other adapters fall back to the buffered read regardless). Expect a throughput
     cost (~14% slower @100k rows) in exchange for bounded peak memory.
     """
-    if _memory_optimized_override:
-        return True
-    return os.getenv(MEMORY_OPTIMIZED_DRIVER_ENABLED_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+    ENV_VAR: str = "MEMORY_OPTIMIZED_DRIVER_ENABLED"
+    _TRUTHY: tuple[str, ...] = ("1", "true", "yes", "on")
+
+    def __init__(self) -> None:
+        # Override set from the Soda Cloud diagnostics-warehouse config; ORed with
+        # the env toggle so either source can turn the driver on.
+        self._override: bool = False
+        # One-off guard so the "driver active" line is logged once per process,
+        # not once per query.
+        self._active_logged: bool = False
+
+    def configure(self, enabled: Optional[bool]) -> None:
+        """Set the Soda Cloud override. A falsy value leaves the env var as the
+        sole control."""
+        self._override = bool(enabled)
+
+    def is_enabled(self) -> bool:
+        if self._override:
+            return True
+        return os.getenv(self.ENV_VAR, "").strip().lower() in self._TRUTHY
+
+    def log_active_once(self, adapter_name: str) -> None:
+        if not self._active_logged:
+            self._active_logged = True
+            logger.info("Memory-optimized fetch driver active (%s)", adapter_name)
+
+    def reset(self) -> None:
+        """Restore defaults — for test isolation between cases."""
+        self._override = False
+        self._active_logged = False
+
+
+# Single process-level instance. State lives here rather than in module globals so
+# it is encapsulated and unit-testable (see MemoryOptimizedDriverSettings.reset).
+memory_optimized_driver_settings = MemoryOptimizedDriverSettings()
 
 
 # IANA names that mean "UTC, no DST, no historical offsets". When ZoneInfo returns one
@@ -409,53 +421,63 @@ class DataSourceConnection(ABC):
             cursor.close()
         return description
 
-    def execute_query_one_by_one_memory_optimized(
+    def supports_streaming_fetch(self) -> bool:
+        """Whether this adapter implements a real bounded-memory streaming fetch
+        (i.e. overrides ``_execute_query_one_by_one_streaming``). Base: ``False``;
+        postgres returns ``True``. Used by
+        ``execute_query_one_by_one_prefer_streaming`` to decide whether the
+        streaming impl is worth dispatching to."""
+        return False
+
+    def execute_query_one_by_one_prefer_streaming(
         self,
         sql: str,
         row_callback: Callable[[tuple, tuple[tuple]], None],
         log_query: bool = True,
         row_limit: Optional[int] = None,
     ) -> tuple[tuple]:
-        """Memory-optimized variant of ``execute_query_one_by_one``.
+        """Execute ``sql`` and deliver rows one-by-one to ``row_callback``,
+        *preferring* a bounded-memory streaming fetch when it is both enabled and
+        available — otherwise the plain buffered fetch (same external contract).
 
-        Callers that stream potentially large result sets through Python with a
-        bounded buffer — the diagnostics-warehouse failed-rows flows — call this
-        instead of the base method.
-
-        Gated by the general ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` env toggle
-        (disabled by default). When disabled, every connection uses the buffered
-        base fetch. When enabled, the call is dispatched to
-        ``_execute_query_one_by_one_memory_optimized_impl``, which data sources
-        with a low-memory fetch strategy override (e.g. postgres opens a
-        server-side named cursor and fetches byte-budgeted batches, bounding peak
-        memory to ~one batch plus the largest single row). Adapters without an
-        override keep the proven buffered behavior even when enabled.
+        Callers that stream potentially large result sets through Python — the
+        diagnostics-warehouse failed-rows flows — use this instead of the base
+        ``execute_query_one_by_one``. The name says *preferring*, not
+        *guaranteeing*: streaming engages only when the driver is enabled
+        (``MEMORY_OPTIMIZED_DRIVER_ENABLED`` env var or the Soda Cloud override)
+        AND this adapter advertises a streaming impl (``supports_streaming_fetch``).
+        Today only postgres does (server-side named cursor, byte-budgeted batches,
+        bounding peak memory to ~one batch plus the largest single row); every other
+        adapter — and every adapter when the driver is disabled — keeps the proven
+        buffered behavior.
         """
-        if is_memory_optimized_driver_enabled():
-            global _memory_optimized_logged
-            if not _memory_optimized_logged:
-                _memory_optimized_logged = True
-                logger.info("Memory-optimized fetch driver active (%s)", type(self).__name__)
-            return self._execute_query_one_by_one_memory_optimized_impl(
+        # Two terms, one feature: the "memory-optimized driver" is the operator-facing
+        # toggle (the MEMORY_OPTIMIZED_DRIVER_ENABLED env var / Soda Cloud flag);
+        # "streaming" is the fetch mechanism it prefers. So: driver enabled AND this
+        # adapter can stream → stream, otherwise buffer. The "driver active" log lives
+        # in the streaming impl (it fires only when streaming actually engages, not when
+        # an adapter accepts the call but then falls back, e.g. postgres in autocommit).
+        if memory_optimized_driver_settings.is_enabled() and self.supports_streaming_fetch():
+            return self._execute_query_one_by_one_streaming(
                 sql=sql, row_callback=row_callback, log_query=log_query, row_limit=row_limit
             )
         return self.execute_query_one_by_one(
             sql=sql, row_callback=row_callback, log_query=log_query, row_limit=row_limit
         )
 
-    def _execute_query_one_by_one_memory_optimized_impl(
+    def _execute_query_one_by_one_streaming(
         self,
         sql: str,
         row_callback: Callable[[tuple, tuple[tuple]], None],
         log_query: bool = True,
         row_limit: Optional[int] = None,
     ) -> tuple[tuple]:
-        """Memory-optimized fetch implementation, invoked only when the
-        ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` toggle is on. The base default is the
-        buffered fetch; adapters with a real low-memory fetch (e.g. postgres'
-        server-side streaming cursor) override this."""
-        return self.execute_query_one_by_one(
-            sql=sql, row_callback=row_callback, log_query=log_query, row_limit=row_limit
+        """Bounded-memory streaming fetch. Only reached when this adapter advertises
+        the capability via ``supports_streaming_fetch`` returning ``True``, so the
+        base raises — advertise *and* implement (e.g. postgres' server-side cursor)."""
+        raise NotImplementedError(
+            f"{type(self).__name__} advertises supports_streaming_fetch() but does not implement "
+            "_execute_query_one_by_one_streaming()"
         )
 
     @contextlib.contextmanager

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -17,6 +17,7 @@ logger: logging.Logger = soda_logger
 
 from tabulate import tabulate
 
+
 class MemoryOptimizedDriverSettings:
     """Process-level enablement for the bounded-memory streaming fetch driver.
 

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -160,17 +160,17 @@ class DataSourceImpl(ABC):
             sql=sql, row_callback=row_callback, log_query=log_query, row_limit=row_limit
         )
 
-    def execute_query_one_by_one_memory_optimized(
+    def execute_query_one_by_one_prefer_streaming(
         self,
         sql: str,
         row_callback: Callable[[tuple, tuple[tuple]], None],
         log_query: bool = True,
         row_limit: Optional[int] = None,
     ) -> tuple[tuple]:
-        # Memory-optimized streaming fetch — see
-        # DataSourceConnection.execute_query_one_by_one_memory_optimized.
+        # One-by-one fetch preferring a bounded-memory streaming read when enabled
+        # and supported — see DataSourceConnection.execute_query_one_by_one_prefer_streaming.
         # Returns the description of the query.
-        return self.data_source_connection.execute_query_one_by_one_memory_optimized(
+        return self.data_source_connection.execute_query_one_by_one_prefer_streaming(
             sql=sql, row_callback=row_callback, log_query=log_query, row_limit=row_limit
         )
 

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -11,6 +11,7 @@ import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr, field_validator
 from soda_core.common.data_source_connection import (
     DataSourceConnection,
+    memory_optimized_driver_settings,
     parse_session_timezone,
 )
 from soda_core.common.data_source_results import QueryResult
@@ -147,7 +148,7 @@ class PostgresDataSourceConnection(DataSourceConnection):
         # Pre-memory-work behavior, restored: the buffered base
         # implementation with postgres's rollback-on-error wrapper. Callers
         # that stream large result sets use
-        # execute_query_one_by_one_memory_optimized instead.
+        # execute_query_one_by_one_prefer_streaming instead.
         try:
             return super().execute_query_one_by_one(sql, row_callback, log_query=log_query, row_limit=row_limit)
         except psycopg.errors.Error as e:  # Catch the error and roll back the transaction
@@ -156,7 +157,12 @@ class PostgresDataSourceConnection(DataSourceConnection):
             self.rollback()
             raise e
 
-    def _execute_query_one_by_one_memory_optimized_impl(
+    def supports_streaming_fetch(self) -> bool:
+        # Postgres has a real bounded-memory streaming fetch (server-side cursor),
+        # so it advertises the capability and implements _execute_query_one_by_one_streaming.
+        return True
+
+    def _execute_query_one_by_one_streaming(
         self,
         sql: str,
         row_callback: Callable[[tuple, tuple[tuple]], None],
@@ -167,7 +173,7 @@ class PostgresDataSourceConnection(DataSourceConnection):
         in byte-budgeted batches instead of buffering the whole result.
 
         Invoked only when the general MEMORY_OPTIMIZED_DRIVER_ENABLED toggle is
-        on (the base ``execute_query_one_by_one_memory_optimized`` gates and
+        on (the base ``execute_query_one_by_one_prefer_streaming`` gates and
         dispatches here). Disabled by default.
 
         The base ``DataSourceConnection.execute_query_one_by_one`` uses
@@ -228,10 +234,16 @@ class PostgresDataSourceConnection(DataSourceConnection):
             # self.execute_query_one_by_one is the restored postgres wrapper,
             # so the rollback-on-error semantics are preserved.
             logger.debug(
-                "execute_query_one_by_one_memory_optimized: connection is in autocommit mode, "
+                "_execute_query_one_by_one_streaming: connection is in autocommit mode, "
                 "falling back to buffered client-side cursor"
             )
             return self.execute_query_one_by_one(sql, row_callback, log_query=log_query, row_limit=row_limit)
+
+        # Streaming actually engages from here on — log it once per process. Logged
+        # here (not in the router) so the "driver active" line reflects the path
+        # really taken: the autocommit fallback above keeps the line from firing
+        # when we silently downgrade to the buffered fetch.
+        memory_optimized_driver_settings.log_active_once(type(self).__name__)
 
         cursor_name = f"soda_stream_{uuid.uuid4().hex[:12]}"
         if log_query:

--- a/soda-postgres/tests/features/test_postgres_streaming_reads.py
+++ b/soda-postgres/tests/features/test_postgres_streaming_reads.py
@@ -1,4 +1,4 @@
-"""Real-postgres coverage for ``execute_query_one_by_one_memory_optimized``.
+"""Real-postgres coverage for ``execute_query_one_by_one_prefer_streaming``.
 
 The unit tests (soda-tests/tests/unit/test_memory_optimized_query.py) drive
 this path with mocks — they pin the call shape (server-side named cursor,
@@ -62,7 +62,7 @@ def test_streaming_returns_every_row_in_order_for_thin_fat_mix(data_source_test_
     sql = _select_sql(data_source_test_helper, test_table)
 
     seen: list[tuple] = []
-    description = data_source_test_helper.data_source_impl.execute_query_one_by_one_memory_optimized(
+    description = data_source_test_helper.data_source_impl.execute_query_one_by_one_prefer_streaming(
         sql=sql, row_callback=lambda row, desc: seen.append(row)
     )
 
@@ -87,7 +87,7 @@ def test_withhold_cursor_survives_commit_mid_iteration(data_source_test_helper: 
         if len(seen) == 1:
             raw_connection.commit()  # would kill a non-withhold cursor
 
-    data_source_test_helper.data_source_impl.execute_query_one_by_one_memory_optimized(
+    data_source_test_helper.data_source_impl.execute_query_one_by_one_prefer_streaming(
         sql=sql, row_callback=commit_after_first_row
     )
 
@@ -105,7 +105,7 @@ def test_autocommit_connection_falls_back_to_buffered(data_source_test_helper: D
     raw_connection.autocommit = True
     try:
         seen: list[tuple] = []
-        data_source_test_helper.data_source_impl.execute_query_one_by_one_memory_optimized(
+        data_source_test_helper.data_source_impl.execute_query_one_by_one_prefer_streaming(
             sql=sql, row_callback=lambda row, desc: seen.append(row)
         )
         assert {row[0] for row in seen} == set(range(_N_ROWS))
@@ -130,6 +130,6 @@ def test_rollback_before_cursor_held_breaks_the_stream(data_source_test_helper: 
             raw_connection.rollback()  # destroys the not-yet-held cursor
 
     with pytest.raises(psycopg.errors.Error):
-        data_source_test_helper.data_source_impl.execute_query_one_by_one_memory_optimized(
+        data_source_test_helper.data_source_impl.execute_query_one_by_one_prefer_streaming(
             sql=sql, row_callback=rollback_after_first_row
         )

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -1193,14 +1193,14 @@ class SnapshotDataSourceConnection(DataSourceConnection):
             row_callback(row, description)
         return description
 
-    def execute_query_one_by_one_memory_optimized(
+    def execute_query_one_by_one_prefer_streaming(
         self,
         sql: str,
         row_callback: Callable[[tuple, tuple[tuple]], None],
         log_query: bool = True,
         row_limit: Optional[int] = None,
     ) -> Optional[tuple[tuple]]:
-        # The memory-optimized routing is a real-connection concern; the
+        # The streaming-preference routing is a real-connection concern; the
         # record/replay semantics are identical to the base one-by-one.
         # Without this explicit wrapper, __getattr__ would forward the call
         # straight to the real connection and bypass snapshot capture.

--- a/soda-tests/tests/unit/test_memory_optimized_override.py
+++ b/soda-tests/tests/unit/test_memory_optimized_override.py
@@ -1,54 +1,74 @@
 """Unit tests for the memory-optimized driver toggle's two sources.
 
 The driver is enabled when EITHER soda-extensions' Soda Cloud override
-(``set_memory_optimized_override``, from the ``useMemoryOptimized`` feature flag)
-OR the ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` env var is on — ORed, so neither can
-force the other off.
+(``memory_optimized_driver_settings.configure``, from the ``useMemoryOptimized``
+feature flag) OR the ``MEMORY_OPTIMIZED_DRIVER_ENABLED`` env var is on — ORed, so
+neither can force the other off.
 """
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
-from soda_core.common.data_source_connection import (
-    is_memory_optimized_driver_enabled,
-    set_memory_optimized_override,
-)
+from soda_core.common.data_source_connection import memory_optimized_driver_settings
 
 ENV = "MEMORY_OPTIMIZED_DRIVER_ENABLED"
 
 
 @pytest.fixture(autouse=True)
-def _reset_override():
-    # The override is process-level state; reset around every test so order can't leak it.
-    set_memory_optimized_override(False)
+def _reset_settings():
+    # The settings object is process-level state; reset around every test so order can't leak it.
+    memory_optimized_driver_settings.reset()
     yield
-    set_memory_optimized_override(False)
+    memory_optimized_driver_settings.reset()
 
 
 def test_disabled_when_neither_env_nor_override(monkeypatch):
     monkeypatch.delenv(ENV, raising=False)
-    assert is_memory_optimized_driver_enabled() is False
+    assert memory_optimized_driver_settings.is_enabled() is False
 
 
 def test_override_enables_without_env(monkeypatch):
     monkeypatch.delenv(ENV, raising=False)
-    set_memory_optimized_override(True)
-    assert is_memory_optimized_driver_enabled() is True
+    memory_optimized_driver_settings.configure(True)
+    assert memory_optimized_driver_settings.is_enabled() is True
 
 
 def test_env_enables_without_override(monkeypatch):
     monkeypatch.setenv(ENV, "true")
-    assert is_memory_optimized_driver_enabled() is True
+    assert memory_optimized_driver_settings.is_enabled() is True
 
 
 def test_either_source_enables_or_semantics(monkeypatch):
     # Env explicitly off, override on → still enabled (override can't be forced off).
     monkeypatch.setenv(ENV, "false")
-    set_memory_optimized_override(True)
-    assert is_memory_optimized_driver_enabled() is True
+    memory_optimized_driver_settings.configure(True)
+    assert memory_optimized_driver_settings.is_enabled() is True
 
 
 def test_falsy_override_leaves_env_as_sole_control(monkeypatch):
     monkeypatch.delenv(ENV, raising=False)
-    set_memory_optimized_override(None)
-    assert is_memory_optimized_driver_enabled() is False
+    memory_optimized_driver_settings.configure(None)
+    assert memory_optimized_driver_settings.is_enabled() is False
+
+
+def test_reset_clears_a_previously_set_override(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    memory_optimized_driver_settings.configure(True)
+    assert memory_optimized_driver_settings.is_enabled() is True
+    memory_optimized_driver_settings.reset()
+    assert memory_optimized_driver_settings.is_enabled() is False
+
+
+def test_log_active_once_logs_only_once_until_reset():
+    # The "driver active" line must be emitted at most once per process so it does
+    # not spam per query; reset() re-arms it.
+    with patch("soda_core.common.data_source_connection.logger") as mock_logger:
+        memory_optimized_driver_settings.log_active_once("postgres")
+        memory_optimized_driver_settings.log_active_once("postgres")
+        assert mock_logger.info.call_count == 1
+
+        memory_optimized_driver_settings.reset()
+        memory_optimized_driver_settings.log_active_once("postgres")
+        assert mock_logger.info.call_count == 2

--- a/soda-tests/tests/unit/test_memory_optimized_query.py
+++ b/soda-tests/tests/unit/test_memory_optimized_query.py
@@ -1,11 +1,13 @@
-"""Unit tests for the execute_query_one_by_one / _memory_optimized split.
+"""Unit tests for the execute_query_one_by_one / preferring-streaming split.
 
 Contract: the base ``execute_query_one_by_one`` is the proven buffered
-implementation; ``execute_query_one_by_one_memory_optimized`` is what the
-DWH failed-rows flows call, and it DEFAULTS to the base implementation for
-adapters without (or not needing) a low-memory fetch. Postgres overrides
-the optimized variant with the server-side named cursor and keeps its
-pre-existing rollback-on-error wrapper as the base.
+implementation; ``execute_query_one_by_one_prefer_streaming`` is what the
+DWH failed-rows flows call. It dispatches to the streaming impl only when the
+driver is enabled AND the adapter advertises ``supports_streaming_fetch()``;
+otherwise it DEFAULTS to the base buffered fetch (adapters without a low-memory
+fetch). Postgres advertises the capability and overrides
+``_execute_query_one_by_one_streaming`` with the server-side named cursor, keeping
+its pre-existing rollback-on-error wrapper as the base.
 """
 
 from __future__ import annotations
@@ -13,7 +15,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import (
+    DataSourceConnection,
+    memory_optimized_driver_settings,
+)
 from soda_postgres.common.data_sources.postgres_data_source_connection import (
     PostgresDataSourceConnection,
 )
@@ -41,17 +46,66 @@ class _StubConnection(DataSourceConnection):
         return (("col",),)
 
 
-class TestDefaultDelegation:
-    def test_memory_optimized_defaults_to_base_implementation(self):
+class _CapableButUnimplemented(DataSourceConnection):
+    """Advertises the streaming capability but never overrides the impl — the
+    exact misconfiguration the base ``NotImplementedError`` guards against."""
+
+    def __init__(self):
+        # Bypass DataSourceConnection.__init__ — only the dispatch matters.
+        pass
+
+    def _create_connection(self, config):  # pragma: no cover - never called
+        return MagicMock()
+
+    def supports_streaming_fetch(self):
+        return True
+
+
+class TestDispatchGating:
+    def test_unsupported_adapter_buffers_even_when_driver_enabled(self):
+        # Driver ON (autouse fixture) but the adapter advertises no streaming
+        # capability, so the call must fall through to the buffered base fetch —
+        # and the streaming impl (which would raise) is never reached.
         connection = _StubConnection()
         callback = lambda row, description: None
 
-        description = connection.execute_query_one_by_one_memory_optimized(
+        description = connection.execute_query_one_by_one_prefer_streaming(
             "SELECT 1", callback, log_query=False, row_limit=7
         )
 
         assert connection.calls == [("SELECT 1", callback, False, 7)]
         assert description == (("col",),)
+
+    def test_disabled_driver_buffers_even_for_capable_adapter(self, monkeypatch):
+        # Driver OFF → even postgres (a capable adapter) takes the buffered path
+        # (a plain client-side cursor, no server-side named cursor).
+        monkeypatch.delenv("MEMORY_OPTIMIZED_DRIVER_ENABLED", raising=False)
+        memory_optimized_driver_settings.reset()
+        pg = _make_postgres_connection(autocommit=False)
+        plain_cursor = _make_plain_cursor()
+        pg.connection.cursor.return_value = plain_cursor
+
+        pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
+
+        assert pg.connection.cursor.call_args.kwargs == {}  # no name → buffered
+
+    def test_base_supports_streaming_fetch_is_false(self):
+        assert _StubConnection().supports_streaming_fetch() is False
+
+    def test_postgres_supports_streaming_fetch_is_true(self):
+        assert _make_postgres_connection(autocommit=False).supports_streaming_fetch() is True
+
+    def test_base_streaming_impl_raises_not_implemented(self):
+        # The base impl must fail loudly rather than silently buffer — the buffered
+        # fallback now lives in the router gate, not here.
+        with pytest.raises(NotImplementedError):
+            _StubConnection()._execute_query_one_by_one_streaming("SELECT 1", lambda r, d: None)
+
+    def test_capable_adapter_without_impl_raises(self):
+        # Advertises supports_streaming_fetch() == True but never overrides the impl:
+        # the dispatch must surface the misconfiguration, not quietly buffer.
+        with pytest.raises(NotImplementedError):
+            _CapableButUnimplemented().execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
 
 
 def _make_postgres_connection(autocommit: bool) -> PostgresDataSourceConnection:
@@ -83,7 +137,7 @@ class TestPostgresMemoryOptimized:
         named_cursor = _make_plain_cursor()
         pg.connection.cursor.return_value.__enter__.return_value = named_cursor
 
-        description = pg.execute_query_one_by_one_memory_optimized("SELECT 1", lambda r, d: None)
+        description = pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
 
         cursor_kwargs = pg.connection.cursor.call_args.kwargs
         assert cursor_kwargs.get("name", "").startswith("soda_stream_")
@@ -95,7 +149,7 @@ class TestPostgresMemoryOptimized:
         plain_cursor = _make_plain_cursor()
         pg.connection.cursor.return_value = plain_cursor
 
-        description = pg.execute_query_one_by_one_memory_optimized("SELECT 1", lambda r, d: None)
+        description = pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
 
         # Base path: a plain client-side cursor — no name, no withhold.
         assert pg.connection.cursor.call_args.kwargs == {}
@@ -147,7 +201,7 @@ def _stream_rows(rows, row_limit=None):
     pg.connection.cursor.return_value.__enter__.return_value = fake_cursor
 
     seen = []
-    pg.execute_query_one_by_one_memory_optimized(
+    pg.execute_query_one_by_one_prefer_streaming(
         "SELECT 1", lambda row, description: seen.append(row), row_limit=row_limit
     )
     return fake_cursor.fetch_sizes, seen
@@ -232,7 +286,7 @@ class TestHeldCursorCloseAfterRollback:
         pg.connection.cursor.side_effect = cursor_factory
 
         try:
-            pg.execute_query_one_by_one_memory_optimized("SELECT 1", lambda r, d: None)
+            pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
             raise AssertionError("expected the stream error to propagate")
         except psycopg.errors.QueryCanceled:
             pass


### PR DESCRIPTION
## Context

Follow-up to #2757 (r-594), addressing the only unprocessed (non-blocking) review feedback from @paulteehan on the memory-optimized fetch path:

- `execute_query_one_by_one_memory_optimized` was a **misleadingly-named runtime router** — it ran the buffered fetch when a driver toggle was off, so the name over-promised.
- Enablement lived in **module-level mutable globals** mutated via bare `global` statements.

This is a **pure internal refactor — no behavior change** except one benign logging adjustment.

## What changed

- **Honest naming**: `execute_query_one_by_one_memory_optimized` → `execute_query_one_by_one_prefer_streaming` (it *prefers* streaming, falls back to buffered). The per-adapter impl `_execute_query_one_by_one_memory_optimized_impl` → `_execute_query_one_by_one_streaming`.
- **Explicit capability dispatch**: new `supports_streaming_fetch()` (base `False`, postgres `True`). The router streams only when the driver is enabled **and** the adapter advertises the capability; the base streaming impl now raises `NotImplementedError` so a misconfigured adapter fails loudly instead of silently buffering.
- **Encapsulated state**: the three module globals + `set_/is_memory_optimized_driver_enabled()` are replaced by a single `MemoryOptimizedDriverSettings` instance (`configure` / `is_enabled` / `log_active_once` / `reset`). "memory-optimized driver" stays the operator-facing term (anchored by the `MEMORY_OPTIMIZED_DRIVER_ENABLED` env var); "streaming" is the mechanism it prefers.
- **Accurate logging**: the "driver active" line moved into the postgres streaming impl, *after* the autocommit guard, so it no longer fires when postgres downgrades to buffered.
- **Tests**: added coverage for the capability hook, the `NotImplementedError` invariant, the disabled and enabled-but-unsupported buffered cells, and `log_active_once` once-semantics.

## Notes

- **Hard rename, no deprecated shims** (deliberate). `soda_core_version.txt` is intentionally **not** bumped (versioning handled separately). Pairs with the matching soda-extensions branch `r-600-dwh-memory-management-follow-up`.
- Verified by 5 independent review passes (correctness / naming / code-quality / tests / cross-repo): no blockers, behavior preserved, postgres is the sole streaming adapter.

## Testing

22 core unit tests + 4 postgres live-DB streaming feature tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)