### PR TITLE
feat: add failed_rows keys_query check form (r-601)

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -78,12 +78,19 @@ class FailedRowsCheckImpl(CheckImpl):
                 RowCountMetricImpl(contract_impl=contract_impl, check_impl=self)
             )
 
-        elif self.is_query_check():
+        elif self.is_query_check() or self.is_keys_query_check():
+            # The `query` and `keys_query` forms both count failing rows from a user query. They differ
+            # only downstream: the `query` form's failures land in a per-check table, while the
+            # `keys_query` form's keys are hashed and routed into the shared diagnostics-warehouse
+            # fk_/fr_ tables (handled in soda-extensions). Counting is identical here.
+            active_query: str = self.failed_rows_check_yaml.query or self.failed_rows_check_yaml.keys_query
             self.failed_rows_count_metric_impl = self._resolve_metric(
-                FailedRowsQueryMetricImpl(contract_impl=contract_impl, column_impl=column_impl, check_impl=self)
+                FailedRowsQueryMetricImpl(
+                    contract_impl=contract_impl, column_impl=column_impl, check_impl=self, query=active_query
+                )
             )
 
-            sql = self.failed_rows_check_yaml.query
+            sql = active_query
 
             if contract_impl.should_apply_sampling:
                 sql = contract_impl.data_source_impl.sql_dialect.apply_sampling(
@@ -203,6 +210,9 @@ class FailedRowsCheckImpl(CheckImpl):
     def is_query_check(self) -> bool:
         return self.failed_rows_check_yaml.query
 
+    def is_keys_query_check(self) -> bool:
+        return self.failed_rows_check_yaml.keys_query
+
 
 class FailedRowsExpressionMetricImpl(AggregationMetricImpl):
     def __init__(
@@ -281,8 +291,11 @@ class FailedRowsQueryMetricImpl(MetricImpl):
         check_impl: FailedRowsCheckImpl,
         data_source_impl: Optional[DataSourceImpl] = None,
         dataset_identifier: Optional[DatasetIdentifier] = None,
+        query: Optional[str] = None,
     ):
-        self.query: str = check_impl.check_yaml.query
+        # Carries either the `query` form's SQL or the `keys_query` form's SQL — both count failing
+        # rows the same way. The SQL is part of the metric identity, so the two forms never collide.
+        self.query: str = query if query is not None else check_impl.check_yaml.query
         super().__init__(
             contract_impl=contract_impl,
             column_impl=column_impl,

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check_yaml.py
@@ -35,23 +35,64 @@ class FailedRowsCheckYaml(ThresholdCheckYaml):
         self.query: Optional[str] = check_yaml_object.read_string_opt("query")
         if self.query:
             self.query = dedent(self.query).strip()
+        # Third form: a custom SQL query whose output keys are routed into the shared diagnostics-warehouse
+        # fk_/fr_ tables (instead of a per-check frq_ table). The keys are hashed by Soda; see the
+        # failed-rows extractor in soda-extensions.
+        self.keys_query: Optional[str] = check_yaml_object.read_string_opt("keys_query")
+        if self.keys_query:
+            self.keys_query = dedent(self.keys_query).strip()
         self.rows_tested_query: Optional[str] = check_yaml_object.read_string_opt("rows_tested_query")
         if self.rows_tested_query:
             self.rows_tested_query = dedent(self.rows_tested_query).strip()
-        if not self.expression and not self.query:
+        # Maps each DWH key column name to the query output column that supplies it. Identity when omitted
+        # (the query output column has the same name as the DWH key column). The set of DWH key columns is
+        # not known at contract-parse time (it ships via the diagnostics-warehouse config), so completeness
+        # of this mapping against the actual key columns is validated in soda-extensions, not here.
+        self.key_column_mapping: Optional[dict[str, str]] = None
+        key_column_mapping_object = check_yaml_object.read_object_opt("key_column_mapping")
+        if key_column_mapping_object is not None:
+            self.key_column_mapping = {}
+            for mapping_key, mapping_value in key_column_mapping_object.yaml_dict.items():
+                if not isinstance(mapping_value, str):
+                    logger.error(
+                        msg="In a 'failed_rows' check, 'key_column_mapping' must map each key column name "
+                        "to a query output column name (a string)",
+                        extra={ExtraKeys.LOCATION: key_column_mapping_object.location},
+                    )
+                else:
+                    self.key_column_mapping[str(mapping_key)] = mapping_value
+
+        forms_set: list[str] = [
+            name
+            for name, value in (("expression", self.expression), ("query", self.query), ("keys_query", self.keys_query))
+            if value
+        ]
+        if len(forms_set) == 0:
             logger.error(
-                msg="In a 'failed_rows' check, either 'expression' or 'query' is required",
+                msg="In a 'failed_rows' check, one of 'expression', 'query' or 'keys_query' is required",
                 extra={ExtraKeys.LOCATION: check_yaml_object.location},
             )
-        if self.metric == "percent" and self.query and not self.rows_tested_query:
+        elif len(forms_set) > 1:
             logger.error(
-                msg="In a 'failed_rows' check with metric 'percent' and 'query', 'rows_tested_query' is required",
+                msg=f"In a 'failed_rows' check, 'expression', 'query' and 'keys_query' are mutually exclusive, "
+                f"but found: {', '.join(forms_set)}",
                 extra={ExtraKeys.LOCATION: check_yaml_object.location},
             )
-        if self.rows_tested_query and not self.query:
+        if self.metric == "percent" and (self.query or self.keys_query) and not self.rows_tested_query:
+            logger.error(
+                msg="In a 'failed_rows' check with metric 'percent' and 'query'/'keys_query', "
+                "'rows_tested_query' is required",
+                extra={ExtraKeys.LOCATION: check_yaml_object.location},
+            )
+        if self.rows_tested_query and not (self.query or self.keys_query):
             logger.warning(
-                msg="In a 'failed_rows' check, 'rows_tested_query' is only used with 'query' mode; "
+                msg="In a 'failed_rows' check, 'rows_tested_query' is only used with 'query' or 'keys_query' mode; "
                 "expression mode already computes check_rows_tested automatically",
+                extra={ExtraKeys.LOCATION: check_yaml_object.location},
+            )
+        if self.key_column_mapping is not None and not self.keys_query:
+            logger.warning(
+                msg="In a 'failed_rows' check, 'key_column_mapping' is only used with 'keys_query' mode",
                 extra={ExtraKeys.LOCATION: check_yaml_object.location},
             )
 

--- a/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
+++ b/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
@@ -475,6 +475,17 @@
                                                                     "description": "A SQL query returning the number of rows evaluated. Used with query mode to enable checkRowsTested and percent thresholds.",
                                                                     "type": "string"
                                                                 },
+                                                                "keys_query": {
+                                                                    "description": "A custom SQL query whose output key columns are routed into the shared diagnostics-warehouse failed-keys tables (instead of a per-check table). Soda hashes the mapped key columns.",
+                                                                    "type": "string"
+                                                                },
+                                                                "key_column_mapping": {
+                                                                    "description": "Maps each DWH key column name to the query output column that supplies it. Identity (same names) when omitted. Only used with keys_query.",
+                                                                    "type": "object",
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
                                                                 "qualifier": {
                                                                     "description": "The qualifier for the check used in Soda Cloud",
                                                                     "type": "string"
@@ -489,8 +500,17 @@
                                                                         "expression"
                                                                     ],
                                                                     "not": {
-                                                                        "required": [
-                                                                            "query"
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "required": [
+                                                                                    "query"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "required": [
+                                                                                    "keys_query"
+                                                                                ]
+                                                                            }
                                                                         ]
                                                                     }
                                                                 },
@@ -499,12 +519,50 @@
                                                                         "query"
                                                                     ],
                                                                     "not": {
-                                                                        "required": [
-                                                                            "expression"
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "required": [
+                                                                                    "expression"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "required": [
+                                                                                    "keys_query"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "keys_query"
+                                                                    ],
+                                                                    "not": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "required": [
+                                                                                    "expression"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "required": [
+                                                                                    "query"
+                                                                                ]
+                                                                            }
                                                                         ]
                                                                     }
                                                                 }
-                                                            ]
+                                                            ],
+                                                            "if": {
+                                                                "required": [
+                                                                    "key_column_mapping"
+                                                                ]
+                                                            },
+                                                            "then": {
+                                                                "required": [
+                                                                    "keys_query"
+                                                                ]
+                                                            }
                                                         }
                                                     ]
                                                 },
@@ -774,6 +832,17 @@
                                                 "description": "A SQL query returning the number of rows evaluated. Used with query mode to enable checkRowsTested and percent thresholds.",
                                                 "type": "string"
                                             },
+                                            "keys_query": {
+                                                "description": "A custom SQL query whose output key columns are routed into the shared diagnostics-warehouse failed-keys tables (instead of a per-check table). Soda hashes the mapped key columns.",
+                                                "type": "string"
+                                            },
+                                            "key_column_mapping": {
+                                                "description": "Maps each DWH key column name to the query output column that supplies it. Identity (same names) when omitted. Only used with keys_query.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
                                             "qualifier": {
                                                 "description": "The qualifier for the check used in Soda Cloud",
                                                 "type": "string"
@@ -788,8 +857,17 @@
                                                     "expression"
                                                 ],
                                                 "not": {
-                                                    "required": [
-                                                        "query"
+                                                    "anyOf": [
+                                                        {
+                                                            "required": [
+                                                                "query"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "required": [
+                                                                "keys_query"
+                                                            ]
+                                                        }
                                                     ]
                                                 }
                                             },
@@ -798,12 +876,50 @@
                                                     "query"
                                                 ],
                                                 "not": {
-                                                    "required": [
-                                                        "expression"
+                                                    "anyOf": [
+                                                        {
+                                                            "required": [
+                                                                "expression"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "required": [
+                                                                "keys_query"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "required": [
+                                                    "keys_query"
+                                                ],
+                                                "not": {
+                                                    "anyOf": [
+                                                        {
+                                                            "required": [
+                                                                "expression"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "required": [
+                                                                "query"
+                                                            ]
+                                                        }
                                                     ]
                                                 }
                                             }
-                                        ]
+                                        ],
+                                        "if": {
+                                            "required": [
+                                                "key_column_mapping"
+                                            ]
+                                        },
+                                        "then": {
+                                            "required": [
+                                                "keys_query"
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/soda-tests/tests/integration/test_failed_keys_check.py
+++ b/soda-tests/tests/integration/test_failed_keys_check.py
@@ -1,0 +1,139 @@
+"""
+Integration tests for the `failed_rows` `keys_query` form (soda-core side).
+
+The keys_query form counts failing rows exactly like the `query` form, keeps `datasetRowsTested`
+(dataset metadata count), and supports the optional `rows_tested_query` for `checkRowsTested`.
+soda-core also validates — independent of any DWH config — that an explicit `key_column_mapping`
+references columns the keys_query actually outputs.
+
+Routing the keys into the shared diagnostics-warehouse fk_/fr_ tables is exercised on the
+soda-extensions side; here we only assert the soda-core behaviour, which must work with no DWH config.
+"""
+
+from helpers.data_source_test_helper import DataSourceTestHelper
+from helpers.mock_soda_cloud import MockResponse
+from helpers.test_table import TestTableSpecification
+
+test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("failed_keys")
+    .column_integer("id")
+    .column_integer("start")
+    .column_integer("end")
+    .rows(
+        rows=[
+            (1, 0, 4),
+            (2, 10, 20),
+            (3, 10, 17),
+        ]
+    )
+    .build()
+)
+
+
+def test_failed_keys_query_counts_failures_and_keeps_dataset_rows_tested(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """keys_query counts failing rows like the query form and keeps datasetRowsTested (no suppression)."""
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+    id_quoted = data_source_test_helper.quote_column("id")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  keys_query: |
+                    SELECT {id_quoted}
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    check_json: dict = soda_core_insert_scan_results_command["checks"][0]
+
+    assert check_json["diagnostics"]["v4"] == {"type": "failed_rows", "failedRowsCount": 2, "datasetRowsTested": 3}
+
+
+def test_failed_keys_query_with_rows_tested_query(data_source_test_helper: DataSourceTestHelper):
+    """An optional rows_tested_query flows checkRowsTested into v4 diagnostics, like the query form."""
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+    id_quoted = data_source_test_helper.quote_column("id")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  keys_query: |
+                    SELECT {id_quoted}
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    SELECT COUNT(*) FROM {test_table.qualified_name}
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    check_json: dict = soda_core_insert_scan_results_command["checks"][0]
+
+    assert check_json["diagnostics"]["v4"] == {
+        "type": "failed_rows",
+        "failedRowsCount": 2,
+        "failedRowsPercent": 2 * 100 / 3,
+        "datasetRowsTested": 3,
+        "checkRowsTested": 3,
+    }
+
+
+def test_failed_keys_query_with_mapping_is_accepted_and_counts(data_source_test_helper: DataSourceTestHelper):
+    """soda-core accepts a key_column_mapping and still counts like the query form. The mapping is
+    inert without DWH config (key routing/column-existence checking happens in soda-extensions), so
+    here we only assert the form runs and counts with a mapping present."""
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+    id_quoted = data_source_test_helper.quote_column("id")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  keys_query: |
+                    SELECT {id_quoted}
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  key_column_mapping:
+                    customer_id: id
+        """,
+    )
+
+    check_json: dict = data_source_test_helper.soda_cloud.requests[1].json["checks"][0]
+    assert check_json["diagnostics"]["v4"]["failedRowsCount"] == 2

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -141,7 +141,10 @@ def test_failed_rows_percent_without_rows_tested_query_emits_error(data_source_t
         """,
     )
 
-    assert "In a 'failed_rows' check with metric 'percent' and 'query', 'rows_tested_query' is required" in errors_str
+    assert (
+        "In a 'failed_rows' check with metric 'percent' and 'query'/'keys_query', 'rows_tested_query' is required"
+        in errors_str
+    )
 
 
 def test_failed_rows_query_without_rows_tested_query_backward_compat(data_source_test_helper: DataSourceTestHelper):
@@ -479,7 +482,7 @@ def test_failed_rows_rows_tested_query_with_expression_emits_warning(data_source
 
     warnings_str = contract_verification_result.get_warnings_str()
     assert (
-        "In a 'failed_rows' check, 'rows_tested_query' is only used with 'query' mode; expression mode already computes check_rows_tested automatically"
+        "In a 'failed_rows' check, 'rows_tested_query' is only used with 'query' or 'keys_query' mode; expression mode already computes check_rows_tested automatically"
         in warnings_str
     )
 

--- a/soda-tests/tests/unit/check_types/yaml_parsing/test_failed_rows_check_yaml_parsing.py
+++ b/soda-tests/tests/unit/check_types/yaml_parsing/test_failed_rows_check_yaml_parsing.py
@@ -50,3 +50,145 @@ class TestFailedRowsCheckYamlParsing:
         assert "status NOT IN" in check.query
         assert "FROM my_dataset" in check.query
         assert check.expression is None
+
+    def test_failed_rows_with_keys_query(self):
+        """Failed keys form parses keys_query; expression/query None; mapping defaults to identity (None)."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  keys_query: |
+                    SELECT customer_id, order_date
+                    FROM orders
+                    WHERE total < 0
+        """
+        check = parse_check_from_contract(yaml_str)
+        assert check.keys_query is not None
+        assert "SELECT customer_id, order_date" in check.keys_query
+        assert check.expression is None
+        assert check.query is None
+        assert check.key_column_mapping is None
+
+    def test_failed_rows_keys_query_with_mapping(self):
+        """Explicit key_column_mapping parses as a dwh-key -> query-output-column dict."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  keys_query: "SELECT cust_id, order_dt FROM orders WHERE total < 0"
+                  key_column_mapping:
+                    customer_id: cust_id
+                    order_date: order_dt
+        """
+        check = parse_check_from_contract(yaml_str)
+        assert check.key_column_mapping == {"customer_id": "cust_id", "order_date": "order_dt"}
+
+    def test_failed_rows_keys_query_allows_rows_tested_query(self, caplog):
+        """rows_tested_query is valid with keys_query (no warning/error)."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  keys_query: "SELECT customer_id FROM orders WHERE total < 0"
+                  rows_tested_query: "SELECT count(*) FROM orders"
+        """
+        with caplog.at_level("WARNING"):
+            check = parse_check_from_contract(yaml_str)
+        assert check.keys_query is not None
+        assert check.rows_tested_query is not None
+        assert "only used with" not in caplog.text
+
+    def test_failed_rows_rejects_multiple_forms(self, caplog):
+        """query and keys_query together is a mutually-exclusive error."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  query: "SELECT * FROM orders WHERE total < 0"
+                  keys_query: "SELECT customer_id FROM orders WHERE total < 0"
+        """
+        with caplog.at_level("ERROR"):
+            parse_check_from_contract(yaml_str)
+        assert "mutually exclusive" in caplog.text
+
+    def test_failed_rows_requires_a_form(self, caplog):
+        """None of expression/query/keys_query is an error."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  name: missing a form
+        """
+        with caplog.at_level("ERROR"):
+            parse_check_from_contract(yaml_str)
+        assert "is required" in caplog.text
+
+    def test_failed_rows_keys_query_mapping_non_string_value_errors(self, caplog):
+        """A key_column_mapping whose value is not a string (here an int) is a parse-time error."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  keys_query: "SELECT customer_id FROM orders WHERE total < 0"
+                  key_column_mapping:
+                    customer_id: 123
+        """
+        with caplog.at_level("ERROR"):
+            parse_check_from_contract(yaml_str)
+        assert "must map each key column name" in caplog.text
+
+    def test_failed_rows_keys_query_mapping_nested_value_errors(self, caplog):
+        """A key_column_mapping value that is itself an object (not a column-name string) is an error."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  keys_query: "SELECT customer_id FROM orders WHERE total < 0"
+                  key_column_mapping:
+                    customer_id:
+                      nested: cust_id
+        """
+        with caplog.at_level("ERROR"):
+            parse_check_from_contract(yaml_str)
+        assert "must map each key column name" in caplog.text
+
+    def test_failed_rows_key_column_mapping_without_keys_query_warns(self, caplog):
+        """key_column_mapping on a non-keys_query form (here query) warns it is ignored, but still parses."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  query: "SELECT * FROM orders WHERE total < 0"
+                  key_column_mapping:
+                    customer_id: cust_id
+        """
+        with caplog.at_level("WARNING"):
+            check = parse_check_from_contract(yaml_str)
+        assert check.query is not None
+        assert "only used with 'keys_query' mode" in caplog.text
+
+    def test_failed_rows_rejects_all_three_forms(self, caplog):
+        """expression, query and keys_query together is a mutually-exclusive error listing all three."""
+        yaml_str = """
+            dataset: schema/table
+            columns: []
+            checks:
+              - failed_rows:
+                  expression: "total < 0"
+                  query: "SELECT * FROM orders WHERE total < 0"
+                  keys_query: "SELECT customer_id FROM orders WHERE total < 0"
+        """
+        with caplog.at_level("ERROR"):
+            parse_check_from_contract(yaml_str)
+        assert "mutually exclusive" in caplog.text
+        assert "expression" in caplog.text
+        assert "query" in caplog.text
+        assert "keys_query" in caplog.text


### PR DESCRIPTION
## Description

Adds a third `failed_rows` check form — `keys_query` (+ optional `key_column_mapping`) — alongside the existing `expression` and `query` forms.

- **What problem:** custom-SQL failed-rows checks each get their own per-check diagnostics table (`frq_`), which sprawls (the majority of checks are custom SQL). The new `keys_query` form returns the dataset's diagnostics-warehouse key columns, which Soda hashes and routes into the shared per-dataset failed-keys/rows tables so custom-SQL failures consolidate and become scoreable. This PR is the soda-core half: parsing, validation, and running the form as a complete failed-rows check.
- Parse + validate the new form (the three forms are mutually exclusive); `keys_query` runs with no diagnostics-warehouse config required.
- JSON schema declares `keys_query` / `key_column_mapping` and forbids `key_column_mapping` unless `keys_query` is set.
- **Downstream impact:** key routing into the shared diagnostics-warehouse tables is implemented in soda-extensions on the matching `r-601-implement-failed-keys-check` branch. No behavior change to existing `expression` / `query` checks.

Ticket: r-601.

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
