### PR TITLE
Allow top-level check_attributes in contract JSON schema

### DIFF
--- a/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
+++ b/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
@@ -14,6 +14,9 @@
             "description": "The description of the dataset",
             "type": "string"
         },
+        "check_attributes": {
+            "$ref": "#/$defs/attributes"
+        },
         "filter": {
             "description": "The filter where clause to be applied to the dataset",
             "type": "string"

--- a/soda-tests/tests/unit/contract_yaml/test_data_contract_json_schema.py
+++ b/soda-tests/tests/unit/contract_yaml/test_data_contract_json_schema.py
@@ -1,0 +1,17 @@
+import json
+from importlib import resources
+
+SCHEMA_RESOURCE = "soda_data_contract_json_schema_1_0_0.json"
+
+
+def _load_schema() -> dict:
+    schema_text = resources.files("soda_core.contracts").joinpath(SCHEMA_RESOURCE).read_text(encoding="utf-8")
+    return json.loads(schema_text)
+
+
+def test_dataset_level_check_attributes_reuses_attributes_definition():
+    schema = _load_schema()
+
+    assert schema["additionalProperties"] is False
+    assert "check_attributes" in schema["properties"]
+    assert schema["properties"]["check_attributes"]["$ref"] == "#/$defs/attributes"


### PR DESCRIPTION
## Description
Please provide a description of your changes:

- Add top-level `check_attributes` to the Soda data contract JSON Schema.
- Reuse the existing `#/$defs/attributes` definition used by per-check `attributes`.
- Add a focused unit test that guards the schema property.

The contract language reference documents `check_attributes` as dataset-level default attributes for checks, and the runtime already parses/merges it. However, the root JSON Schema uses `additionalProperties: false` and did not list the property, so schema consumers could reject otherwise valid contracts.

Fixes #2764.

## Checklist
- [x] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml

## Testing

```bash
uv run --package soda-tests pytest soda-tests/tests/unit/contract_yaml/test_data_contract_json_schema.py soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py soda-tests/tests/unit/check_types/yaml_parsing/test_common_check_yaml_features.py -q
```

Result: `54 passed, 1 warning`.