### PR TITLE
feat(databricks): OAuth (M2M + Azure service principal) auth [PLATL-820]

### DIFF
--- a/soda-databricks/pyproject.toml
+++ b/soda-databricks/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 dependencies = [
     "soda-core==4.16.0",
     "databricks-sql-connector",
+    "databricks-sdk>=0.19",
 ]
 
 [project.entry-points."soda.plugins.data_source.databricks"]

--- a/soda-databricks/pyproject.toml
+++ b/soda-databricks/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "soda-core==4.16.0",
     "databricks-sql-connector",
-    "databricks-sdk>=0.19",
+    "databricks-sdk>=0.19,<1",
 ]
 
 [project.entry-points."soda.plugins.data_source.databricks"]

--- a/soda-databricks/pyproject.toml
+++ b/soda-databricks/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "soda-core==4.16.0",
     "databricks-sql-connector",
-    "databricks-sdk>=0.117,<1",
+    "databricks-sdk>=0.19,<1",
 ]
 
 [project.entry-points."soda.plugins.data_source.databricks"]

--- a/soda-databricks/pyproject.toml
+++ b/soda-databricks/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "soda-core==4.16.0",
     "databricks-sql-connector",
-    "databricks-sdk>=0.19,<1",
+    "databricks-sdk>=0.117,<1",
 ]
 
 [project.entry-points."soda.plugins.data_source.databricks"]

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -13,7 +13,9 @@ from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
 )
 from soda_databricks.model.data_source.databricks_connection_properties import (
+    DatabricksAzureServicePrincipal,
     DatabricksConnectionProperties,
+    DatabricksOAuthM2M,
 )
 
 logger: logging.Logger = soda_logger
@@ -27,10 +29,60 @@ class DatabricksDataSourceConnection(DataSourceConnection):
         self,
         config: DatabricksConnectionProperties,
     ):
+        connection_kwargs = config.to_connection_kwargs()
+
+        # OAuth modes: the SDK builds a credentials_provider callable (handling token
+        # acquisition + refresh). The credential fields are stripped from connection_kwargs
+        # by the properties class, so they never reach sql.connect as plain kwargs.
+        credentials_provider = self._build_credentials_provider(config, connection_kwargs)
+        if credentials_provider is not None:
+            return sql.connect(
+                user_agent_entry="Soda Core",
+                credentials_provider=credentials_provider,
+                **connection_kwargs,
+            )
+
+        # Token (PAT) auth: access_token flows through connection_kwargs unchanged.
         return sql.connect(
             user_agent_entry="Soda Core",
-            **config.to_connection_kwargs(),
+            **connection_kwargs,
         )
+
+    @staticmethod
+    def _build_credentials_provider(config: DatabricksConnectionProperties, connection_kwargs: dict):
+        """Return an SDK credentials_provider callable for OAuth modes, else None.
+
+        The Databricks SDK derives the token endpoint from the workspace host and handles
+        refresh. ``connection_kwargs['server_hostname']`` has had any scheme stripped by the
+        properties layer, so re-add ``https://`` for the SDK ``Config``.
+        """
+        if not isinstance(config, (DatabricksOAuthM2M, DatabricksAzureServicePrincipal)):
+            return None
+
+        from databricks.sdk.core import Config
+        from databricks.sdk.credentials_provider import (
+            azure_service_principal,
+            oauth_service_principal,
+        )
+
+        host = f"https://{connection_kwargs['server_hostname']}"
+
+        if isinstance(config, DatabricksOAuthM2M):
+            sdk_config = Config(
+                host=host,
+                client_id=config.client_id,
+                client_secret=config.client_secret.get_secret_value(),
+            )
+            return oauth_service_principal(sdk_config)
+
+        # DatabricksAzureServicePrincipal — Entra ID (Azure AD) service principal.
+        sdk_config = Config(
+            host=host,
+            azure_client_id=config.azure_client_id,
+            azure_client_secret=config.azure_client_secret.get_secret_value(),
+            azure_tenant_id=config.azure_tenant_id,
+        )
+        return azure_service_principal(sdk_config)
 
     def _fetch_session_timezone(self) -> tzinfo:
         with self.connection.cursor() as cursor:

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -73,16 +73,32 @@ class DatabricksDataSourceConnection(DataSourceConnection):
                 client_id=config.client_id,
                 client_secret=config.client_secret.get_secret_value(),
             )
-            return oauth_service_principal(sdk_config)
+            header_factory = oauth_service_principal(sdk_config)
+            auth_desc = "OAuth (M2M)"
+        else:
+            # DatabricksAzureServicePrincipal — Entra ID (Azure AD) service principal.
+            sdk_config = Config(
+                host=host,
+                azure_client_id=config.azure_client_id,
+                azure_client_secret=config.azure_client_secret.get_secret_value(),
+                azure_tenant_id=config.azure_tenant_id,
+            )
+            header_factory = azure_service_principal(sdk_config)
+            auth_desc = "Azure service principal"
 
-        # DatabricksAzureServicePrincipal — Entra ID (Azure AD) service principal.
-        sdk_config = Config(
-            host=host,
-            azure_client_id=config.azure_client_id,
-            azure_client_secret=config.azure_client_secret.get_secret_value(),
-            azure_tenant_id=config.azure_tenant_id,
-        )
-        return azure_service_principal(sdk_config)
+        # The SDK returns None when OIDC discovery yields no token endpoint. Fail loudly here
+        # instead of returning None — otherwise the caller would silently degrade to a
+        # credential-less PAT connect for a config the user explicitly marked OAuth.
+        if header_factory is None:
+            raise ValueError(
+                f"Databricks {auth_desc} authentication setup failed: the SDK could not resolve "
+                f"an OIDC token endpoint for host '{host}'. Verify the workspace host and credentials."
+            )
+
+        # databricks-sql-connector's ExternalAuthProvider calls credentials_provider() once to
+        # obtain the header factory, then invokes that per request. So credentials_provider must
+        # be a zero-arg callable that RETURNS the SDK header factory, not the factory itself.
+        return lambda: header_factory
 
     def _fetch_session_timezone(self) -> tzinfo:
         with self.connection.cursor() as cursor:

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -39,3 +39,47 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
 class DatabricksTokenAuth(DatabricksSharedConnectionProperties):
     access_token: SecretStr = Field(..., description="Personal access token")
+
+
+class DatabricksOAuthM2M(DatabricksSharedConnectionProperties):
+    """Databricks-managed OAuth machine-to-machine (service principal) auth.
+
+    The token endpoint is derived from ``host`` by the Databricks SDK, so no
+    ``token_url`` is required. The connection layer builds a ``credentials_provider``
+    from these fields via ``oauth_service_principal`` — they must NOT be emitted as
+    plain ``sql.connect`` kwargs, hence the ``to_connection_kwargs`` override below.
+    """
+
+    client_id: str = Field(..., description="Databricks OAuth service-principal client ID")
+    client_secret: SecretStr = Field(..., description="Databricks OAuth service-principal client secret")
+
+    # Consumed by the connection layer to build the credentials_provider, never passed to sql.connect.
+    _credential_fields: ClassVar[tuple] = ("client_id", "client_secret")
+
+    def to_connection_kwargs(self) -> dict:
+        connection_kwargs = super().to_connection_kwargs()
+        for field_name in self._credential_fields:
+            connection_kwargs.pop(field_name, None)
+        return connection_kwargs
+
+
+class DatabricksAzureServicePrincipal(DatabricksSharedConnectionProperties):
+    """Microsoft Entra ID (Azure AD) service-principal auth for Azure Databricks.
+
+    Distinct from Databricks-managed OAuth M2M: the SP lives in an Entra app
+    registration and the token comes from ``login.microsoftonline.com``, so a tenant
+    ID is required. The connection layer builds a ``credentials_provider`` from these
+    fields; they must NOT be emitted as plain ``sql.connect`` kwargs.
+    """
+
+    azure_client_id: str = Field(..., description="Entra ID (Azure AD) service-principal application/client ID")
+    azure_client_secret: SecretStr = Field(..., description="Entra ID (Azure AD) service-principal client secret")
+    azure_tenant_id: str = Field(..., description="Entra ID (Azure AD) directory/tenant ID")
+
+    _credential_fields: ClassVar[tuple] = ("azure_client_id", "azure_client_secret", "azure_tenant_id")
+
+    def to_connection_kwargs(self) -> dict:
+        connection_kwargs = super().to_connection_kwargs()
+        for field_name in self._credential_fields:
+            connection_kwargs.pop(field_name, None)
+        return connection_kwargs

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -10,9 +10,8 @@ from soda_databricks.model.data_source.databricks_connection_properties import (
     DatabricksTokenAuth,
 )
 
-# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style).
-# NOTE (provisional): these literals must match what the Backend emits in the generated
-# YAML — confirm with BE before merge. See implementation-plan.md.
+# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
+# are the cross-repo contract: they match soda-library#759 and the Cloud connection form.
 AUTH_TYPE_TOKEN = "personal-access-token"
 AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
 AUTH_TYPE_AZURE_SP = "azure-service-principal"

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -4,9 +4,24 @@ from typing import Literal
 from pydantic import Field, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_databricks.model.data_source.databricks_connection_properties import (
+    DatabricksAzureServicePrincipal,
     DatabricksConnectionProperties,
+    DatabricksOAuthM2M,
     DatabricksTokenAuth,
 )
+
+# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style).
+# NOTE (provisional): these literals must match what the Backend emits in the generated
+# YAML — confirm with BE before merge. See implementation-plan.md.
+AUTH_TYPE_TOKEN = "personal-access-token"
+AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
+AUTH_TYPE_AZURE_SP = "azure-service-principal"
+
+_AUTH_TYPE_TO_PROPERTIES = {
+    AUTH_TYPE_TOKEN: DatabricksTokenAuth,
+    AUTH_TYPE_OAUTH_M2M: DatabricksOAuthM2M,
+    AUTH_TYPE_AZURE_SP: DatabricksAzureServicePrincipal,
+}
 
 
 class DatabricksDataSource(DataSourceBase, abc.ABC):
@@ -18,6 +33,28 @@ class DatabricksDataSource(DataSourceBase, abc.ABC):
     @field_validator("connection_properties", mode="before")
     @classmethod
     def infer_connection_type(cls, value):
+        # Already a resolved properties object (e.g. constructed in code) — pass through.
+        if isinstance(value, DatabricksConnectionProperties):
+            return value
+        if not isinstance(value, dict):
+            raise ValueError("Could not infer Databricks connection type from input")
+
+        # Copy so the discriminator can be stripped without mutating caller input; also
+        # prevents auth_type leaking into sql.connect kwargs (base model has extra='allow').
+        value = dict(value)
+        auth_type = value.pop("auth_type", None)
+
+        if auth_type is not None:
+            properties_class = _AUTH_TYPE_TO_PROPERTIES.get(auth_type)
+            if properties_class is None:
+                supported = ", ".join(sorted(_AUTH_TYPE_TO_PROPERTIES))
+                raise ValueError(f"Unknown Databricks auth_type '{auth_type}'. Supported: {supported}")
+            return properties_class(**value)
+
+        # Backward compatibility: no explicit auth_type → infer PAT from field presence.
         if "access_token" in value:
             return DatabricksTokenAuth(**value)
-        raise ValueError("Could not infer Databricks connection type from input")
+        raise ValueError(
+            "Could not infer Databricks connection type: provide 'auth_type' "
+            f"(one of {', '.join(sorted(_AUTH_TYPE_TO_PROPERTIES))}) or 'access_token'."
+        )

--- a/soda-databricks/tests/data_sources/test_databricks.py
+++ b/soda-databricks/tests/data_sources/test_databricks.py
@@ -29,7 +29,7 @@ DATABRICKS_AZURE_TENANT_ID = os.getenv("DATABRICKS_AZURE_TENANT_ID")
 
 
 def _with_https(host: str | None) -> str | None:
-    if host and not (host.startswith("https://") or host.startswith("http://")):
+    if host and "://" not in host:
         return f"https://{host}"
     return host
 

--- a/soda-databricks/tests/data_sources/test_databricks.py
+++ b/soda-databricks/tests/data_sources/test_databricks.py
@@ -19,54 +19,165 @@ DATABRICKS_HOST = os.getenv("DATABRICKS_HOST")
 DATABRICKS_HTTP_PATH = os.getenv("DATABRICKS_HTTP_PATH")
 DATABRICKS_TOKEN = os.getenv("DATABRICKS_TOKEN")
 DATABRICKS_CATALOG = os.getenv("DATABRICKS_CATALOG", "unity_catalog")
-DATABRICKS_HOSTNAME_WITH_HTTPS = (
-    f"https://{DATABRICKS_HOST}"
-    if not (DATABRICKS_HOST.startswith("https://") or DATABRICKS_HOST.startswith("http://"))
-    else DATABRICKS_HOST
+# OAuth service-principal creds (client-credentials M2M)
+DATABRICKS_CLIENT_ID = os.getenv("DATABRICKS_CLIENT_ID")
+DATABRICKS_CLIENT_SECRET = os.getenv("DATABRICKS_CLIENT_SECRET")
+# Azure Entra ID service-principal creds
+DATABRICKS_AZURE_CLIENT_ID = os.getenv("DATABRICKS_AZURE_CLIENT_ID")
+DATABRICKS_AZURE_CLIENT_SECRET = os.getenv("DATABRICKS_AZURE_CLIENT_SECRET")
+DATABRICKS_AZURE_TENANT_ID = os.getenv("DATABRICKS_AZURE_TENANT_ID")
+
+
+def _with_https(host: str | None) -> str | None:
+    if host and not (host.startswith("https://") or host.startswith("http://")):
+        return f"https://{host}"
+    return host
+
+
+DATABRICKS_HOSTNAME_WITH_HTTPS = _with_https(DATABRICKS_HOST)
+
+# Which live-credential sets are available. Live cases are only added when their creds are
+# present, so the module imports and the no-credential (config-validation) cases below still
+# run in any environment.
+_has_pat = all([DATABRICKS_HOST, DATABRICKS_HTTP_PATH, DATABRICKS_TOKEN])
+_has_oauth_m2m = all([DATABRICKS_HOST, DATABRICKS_HTTP_PATH, DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET])
+_has_azure_sp = all(
+    [
+        DATABRICKS_HOST,
+        DATABRICKS_HTTP_PATH,
+        DATABRICKS_AZURE_CLIENT_ID,
+        DATABRICKS_AZURE_CLIENT_SECRET,
+        DATABRICKS_AZURE_TENANT_ID,
+    ]
 )
 
 # define test cases and expected behavior (passing unless otherwise specified)
+# Config-validation cases run everywhere (no creds/live connection): they confirm auth_type
+# dispatch and required-field validation through the full YAML -> DataSourceImpl path.
 test_connections: list[TestConnection] = [
-    TestConnection(  # correct connection, should work
-        test_name="correct_connection",
-        connection_yaml_str=f"""
+    TestConnection(  # unknown discriminator must be rejected at parse time
+        test_name="unknown_auth_type_rejected",
+        connection_yaml_str="""
                 type: databricks
                 name: DATABRICKS_TEST
                 connection:
-                    host: {DATABRICKS_HOST}
-                    http_path: {DATABRICKS_HTTP_PATH}
-                    access_token: {DATABRICKS_TOKEN}
-                    catalog: {DATABRICKS_CATALOG}
+                    host: abc.cloud.databricks.com
+                    http_path: /sql/1.0/endpoints/abc
+                    auth_type: not-a-real-mode
             """,
+        valid_yaml=False,
+        expected_yaml_error="Unknown Databricks auth_type",
     ),
-    TestConnection(  # confirm session configuration is applied
-        test_name="applies_session_configuration",
-        connection_yaml_str=f"""
+    TestConnection(  # OAuth M2M without its required secret must be rejected at parse time
+        test_name="oauth_m2m_missing_client_secret_rejected",
+        connection_yaml_str="""
                 type: databricks
                 name: DATABRICKS_TEST
                 connection:
-                    host: {DATABRICKS_HOST}
-                    http_path: {DATABRICKS_HTTP_PATH}
-                    access_token: {DATABRICKS_TOKEN}
-                    catalog: {DATABRICKS_CATALOG}
-                    session_configuration: {{"foo":"bar"}}
+                    host: abc.cloud.databricks.com
+                    http_path: /sql/1.0/endpoints/abc
+                    auth_type: databricks-oauth-m2m
+                    client_id: some-client-id
             """,
-        query_should_succeed=False,
-        expected_query_error="Configuration foo is not available.",
+        valid_yaml=False,
+        expected_yaml_error="client_secret",
     ),
-    TestConnection(  # correct connection, should work
-        test_name="connection_with_https_prefix",
-        connection_yaml_str=f"""
+    TestConnection(  # Azure service principal without its tenant id must be rejected at parse time
+        test_name="azure_service_principal_missing_tenant_rejected",
+        connection_yaml_str="""
                 type: databricks
                 name: DATABRICKS_TEST
                 connection:
-                    host: {DATABRICKS_HOSTNAME_WITH_HTTPS}
-                    http_path: {DATABRICKS_HTTP_PATH}
-                    access_token: {DATABRICKS_TOKEN}
-                    catalog: {DATABRICKS_CATALOG}
+                    host: adb-123.azuredatabricks.net
+                    http_path: /sql/1.0/endpoints/abc
+                    auth_type: azure-service-principal
+                    azure_client_id: some-client-id
+                    azure_client_secret: some-secret
             """,
+        valid_yaml=False,
+        expected_yaml_error="azure_tenant_id",
     ),
 ]
+
+if _has_pat:
+    test_connections += [
+        TestConnection(  # correct connection, should work
+            test_name="correct_connection",
+            connection_yaml_str=f"""
+                    type: databricks
+                    name: DATABRICKS_TEST
+                    connection:
+                        host: {DATABRICKS_HOST}
+                        http_path: {DATABRICKS_HTTP_PATH}
+                        access_token: {DATABRICKS_TOKEN}
+                        catalog: {DATABRICKS_CATALOG}
+                """,
+        ),
+        TestConnection(  # confirm session configuration is applied
+            test_name="applies_session_configuration",
+            connection_yaml_str=f"""
+                    type: databricks
+                    name: DATABRICKS_TEST
+                    connection:
+                        host: {DATABRICKS_HOST}
+                        http_path: {DATABRICKS_HTTP_PATH}
+                        access_token: {DATABRICKS_TOKEN}
+                        catalog: {DATABRICKS_CATALOG}
+                        session_configuration: {{"foo":"bar"}}
+                """,
+            query_should_succeed=False,
+            expected_query_error="Configuration foo is not available.",
+        ),
+        TestConnection(  # correct connection, should work
+            test_name="connection_with_https_prefix",
+            connection_yaml_str=f"""
+                    type: databricks
+                    name: DATABRICKS_TEST
+                    connection:
+                        host: {DATABRICKS_HOSTNAME_WITH_HTTPS}
+                        http_path: {DATABRICKS_HTTP_PATH}
+                        access_token: {DATABRICKS_TOKEN}
+                        catalog: {DATABRICKS_CATALOG}
+                """,
+        ),
+    ]
+
+if _has_oauth_m2m:
+    test_connections.append(
+        TestConnection(  # live Databricks-managed OAuth M2M (service principal)
+            test_name="oauth_m2m_connection",
+            connection_yaml_str=f"""
+                    type: databricks
+                    name: DATABRICKS_TEST
+                    connection:
+                        host: {DATABRICKS_HOST}
+                        http_path: {DATABRICKS_HTTP_PATH}
+                        auth_type: databricks-oauth-m2m
+                        client_id: {DATABRICKS_CLIENT_ID}
+                        client_secret: {DATABRICKS_CLIENT_SECRET}
+                        catalog: {DATABRICKS_CATALOG}
+                """,
+        )
+    )
+
+if _has_azure_sp:
+    test_connections.append(
+        TestConnection(  # live Azure Entra ID service principal
+            test_name="azure_service_principal_connection",
+            connection_yaml_str=f"""
+                    type: databricks
+                    name: DATABRICKS_TEST
+                    connection:
+                        host: {DATABRICKS_HOST}
+                        http_path: {DATABRICKS_HTTP_PATH}
+                        auth_type: azure-service-principal
+                        azure_client_id: {DATABRICKS_AZURE_CLIENT_ID}
+                        azure_client_secret: {DATABRICKS_AZURE_CLIENT_SECRET}
+                        azure_tenant_id: {DATABRICKS_AZURE_TENANT_ID}
+                        catalog: {DATABRICKS_CATALOG}
+                """,
+        )
+    )
 
 
 # run tests.  parameterization means each test case will show up as an individual test

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -145,13 +145,21 @@ def test_m2m_connection_passes_credentials_provider():
             "client_secret": "sec",
         }
     )
-    with patch("databricks.sdk.credentials_provider.oauth_service_principal", return_value="M2M") as osp, patch(
-        "databricks.sdk.core.Config"
-    ) as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
+    headers = {"Authorization": "Bearer tok"}
+    with patch(
+        "databricks.sdk.credentials_provider.oauth_service_principal", return_value=lambda: headers
+    ) as osp, patch("databricks.sdk.core.Config") as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
         _make_connection()._create_connection(props)
 
     called_kwargs = mock_connect.call_args.kwargs
-    assert called_kwargs["credentials_provider"] == "M2M"
+    # ExternalAuthProvider calls credentials_provider() once to get the header factory, then
+    # calls that factory per request. Verify both levels resolve to a headers dict — the old
+    # one-level shape would make provider() return the dict and provider()() raise TypeError.
+    provider = called_kwargs["credentials_provider"]
+    assert callable(provider)
+    header_factory = provider()
+    assert callable(header_factory)
+    assert header_factory() == headers
     assert "client_id" not in called_kwargs and "client_secret" not in called_kwargs
     # SDK Config got a scheme-prefixed host built from the stripped server_hostname.
     assert cfg.call_args.kwargs["host"] == "https://abc.cloud.databricks.com"
@@ -171,16 +179,39 @@ def test_azure_connection_passes_credentials_provider():
             "azure_tenant_id": "tid",
         }
     )
-    with patch("databricks.sdk.credentials_provider.azure_service_principal", return_value="AZ") as asp, patch(
-        "databricks.sdk.core.Config"
-    ) as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
+    headers = {"Authorization": "Bearer az"}
+    with patch(
+        "databricks.sdk.credentials_provider.azure_service_principal", return_value=lambda: headers
+    ) as asp, patch("databricks.sdk.core.Config") as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
         _make_connection()._create_connection(props)
 
     called_kwargs = mock_connect.call_args.kwargs
-    assert called_kwargs["credentials_provider"] == "AZ"
+    provider = called_kwargs["credentials_provider"]
+    assert callable(provider)
+    assert provider()() == headers
     assert cfg.call_args.kwargs["azure_tenant_id"] == "tid"
     assert cfg.call_args.kwargs["azure_client_secret"] == "asec"
     asp.assert_called_once()
+
+
+def test_m2m_provider_none_raises_clear_error():
+    """If the SDK yields no header factory (OIDC discovery failure), fail loudly rather than
+    silently falling through to a credential-less PAT connect."""
+    props = infer(
+        {
+            "auth_type": "databricks-oauth-m2m",
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "client_id": "cid",
+            "client_secret": "sec",
+        }
+    )
+    with patch("databricks.sdk.credentials_provider.oauth_service_principal", return_value=None), patch(
+        "databricks.sdk.core.Config"
+    ), patch.object(conn_mod.sql, "connect") as mock_connect:
+        with pytest.raises(ValueError, match="OAuth .M2M. authentication setup failed"):
+            _make_connection()._create_connection(props)
+    mock_connect.assert_not_called()
 
 
 def test_token_connection_has_no_credentials_provider():

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -1,0 +1,216 @@
+"""Unit tests for Databricks OAuth (M2M + Azure service principal) auth.
+
+No live database. The SDK credentials-provider factories are mocked because building a
+real provider performs OIDC endpoint discovery over the network.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from soda_databricks.common.data_sources import databricks_data_source_connection as conn_mod
+from soda_databricks.common.data_sources.databricks_data_source_connection import (
+    DatabricksDataSourceConnection,
+)
+from soda_databricks.model.data_source.databricks_connection_properties import (
+    DatabricksAzureServicePrincipal,
+    DatabricksOAuthM2M,
+    DatabricksTokenAuth,
+)
+from soda_databricks.model.data_source.databricks_data_source import DatabricksDataSource
+
+infer = DatabricksDataSource.infer_connection_type
+
+
+# --------------------------------------------------------------------------- dispatch
+
+
+def test_token_auth_inferred_without_auth_type():
+    """Backward compatibility: existing PAT YAML has no auth_type."""
+    props = infer(
+        {
+            "host": "https://abc.cloud.databricks.com",
+            "http_path": "/sql/1.0/endpoints/abc",
+            "access_token": "dapi123",
+        }
+    )
+    assert isinstance(props, DatabricksTokenAuth)
+
+
+def test_explicit_token_auth_type():
+    props = infer(
+        {
+            "auth_type": "personal-access-token",
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "access_token": "dapi123",
+        }
+    )
+    assert isinstance(props, DatabricksTokenAuth)
+
+
+def test_oauth_m2m_dispatch():
+    props = infer(
+        {
+            "auth_type": "databricks-oauth-m2m",
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "client_id": "cid",
+            "client_secret": "sec",
+        }
+    )
+    assert isinstance(props, DatabricksOAuthM2M)
+
+
+def test_azure_service_principal_dispatch():
+    props = infer(
+        {
+            "auth_type": "azure-service-principal",
+            "host": "adb-123.azuredatabricks.net",
+            "http_path": "/x",
+            "azure_client_id": "aid",
+            "azure_client_secret": "asec",
+            "azure_tenant_id": "tid",
+        }
+    )
+    assert isinstance(props, DatabricksAzureServicePrincipal)
+
+
+def test_unknown_auth_type_raises():
+    with pytest.raises(ValueError, match="Unknown Databricks auth_type"):
+        infer({"auth_type": "nope", "host": "h", "http_path": "/x"})
+
+
+def test_no_auth_type_no_access_token_raises():
+    with pytest.raises(ValueError, match="Could not infer"):
+        infer({"host": "h", "http_path": "/x"})
+
+
+def test_m2m_missing_client_id_raises():
+    with pytest.raises(ValueError):
+        infer({"auth_type": "databricks-oauth-m2m", "host": "h", "http_path": "/x", "client_secret": "sec"})
+
+
+# ------------------------------------------------------------- credential-field stripping
+
+
+def test_m2m_credentials_not_in_connection_kwargs():
+    props = infer(
+        {
+            "auth_type": "databricks-oauth-m2m",
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "client_id": "cid",
+            "client_secret": "sec",
+        }
+    )
+    kwargs = props.to_connection_kwargs()
+    assert "client_id" not in kwargs
+    assert "client_secret" not in kwargs
+    assert kwargs["server_hostname"] == "abc.cloud.databricks.com"
+
+
+def test_azure_credentials_not_in_connection_kwargs():
+    props = infer(
+        {
+            "auth_type": "azure-service-principal",
+            "host": "adb-123.azuredatabricks.net",
+            "http_path": "/x",
+            "azure_client_id": "aid",
+            "azure_client_secret": "asec",
+            "azure_tenant_id": "tid",
+        }
+    )
+    kwargs = props.to_connection_kwargs()
+    assert not any(k.startswith("azure_") for k in kwargs)
+
+
+# --------------------------------------------------- connection layer builds the provider
+
+
+def _make_connection():
+    return DatabricksDataSourceConnection.__new__(DatabricksDataSourceConnection)
+
+
+def test_m2m_connection_passes_credentials_provider():
+    props = infer(
+        {
+            "auth_type": "databricks-oauth-m2m",
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "client_id": "cid",
+            "client_secret": "sec",
+        }
+    )
+    with patch("databricks.sdk.credentials_provider.oauth_service_principal", return_value="M2M") as osp, patch(
+        "databricks.sdk.core.Config"
+    ) as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
+        _make_connection()._create_connection(props)
+
+    called_kwargs = mock_connect.call_args.kwargs
+    assert called_kwargs["credentials_provider"] == "M2M"
+    assert "client_id" not in called_kwargs and "client_secret" not in called_kwargs
+    # SDK Config got a scheme-prefixed host built from the stripped server_hostname.
+    assert cfg.call_args.kwargs["host"] == "https://abc.cloud.databricks.com"
+    assert cfg.call_args.kwargs["client_id"] == "cid"
+    assert cfg.call_args.kwargs["client_secret"] == "sec"
+    osp.assert_called_once()
+
+
+def test_azure_connection_passes_credentials_provider():
+    props = infer(
+        {
+            "auth_type": "azure-service-principal",
+            "host": "adb-123.azuredatabricks.net",
+            "http_path": "/x",
+            "azure_client_id": "aid",
+            "azure_client_secret": "asec",
+            "azure_tenant_id": "tid",
+        }
+    )
+    with patch("databricks.sdk.credentials_provider.azure_service_principal", return_value="AZ") as asp, patch(
+        "databricks.sdk.core.Config"
+    ) as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
+        _make_connection()._create_connection(props)
+
+    called_kwargs = mock_connect.call_args.kwargs
+    assert called_kwargs["credentials_provider"] == "AZ"
+    assert cfg.call_args.kwargs["azure_tenant_id"] == "tid"
+    assert cfg.call_args.kwargs["azure_client_secret"] == "asec"
+    asp.assert_called_once()
+
+
+def test_token_connection_has_no_credentials_provider():
+    props = infer(
+        {
+            "host": "abc.cloud.databricks.com",
+            "http_path": "/x",
+            "access_token": "dapi123",
+        }
+    )
+    with patch.object(conn_mod.sql, "connect") as mock_connect:
+        _make_connection()._create_connection(props)
+
+    called_kwargs = mock_connect.call_args.kwargs
+    assert "credentials_provider" not in called_kwargs
+    assert called_kwargs["access_token"] == "dapi123"
+
+
+def test_m2m_connection_strips_host_scheme():
+    """A pasted https:// host must reach sql.connect scheme-less and the SDK Config with a
+    single scheme — never a doubled https://https://."""
+    props = infer(
+        {
+            "auth_type": "databricks-oauth-m2m",
+            "host": "https://abc.cloud.databricks.com",
+            "http_path": "/x",
+            "client_id": "cid",
+            "client_secret": "sec",
+        }
+    )
+    with patch("databricks.sdk.credentials_provider.oauth_service_principal", return_value="M2M"), patch(
+        "databricks.sdk.core.Config"
+    ) as cfg, patch.object(conn_mod.sql, "connect") as mock_connect:
+        _make_connection()._create_connection(props)
+
+    assert mock_connect.call_args.kwargs["server_hostname"] == "abc.cloud.databricks.com"
+    assert cfg.call_args.kwargs["host"] == "https://abc.cloud.databricks.com"

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -4,10 +4,12 @@ No live database. The SDK credentials-provider factories are mocked because buil
 real provider performs OIDC endpoint discovery over the network.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-from soda_databricks.common.data_sources import databricks_data_source_connection as conn_mod
+from soda_databricks.common.data_sources import (
+    databricks_data_source_connection as conn_mod,
+)
 from soda_databricks.common.data_sources.databricks_data_source_connection import (
     DatabricksDataSourceConnection,
 )
@@ -16,7 +18,9 @@ from soda_databricks.model.data_source.databricks_connection_properties import (
     DatabricksOAuthM2M,
     DatabricksTokenAuth,
 )
-from soda_databricks.model.data_source.databricks_data_source import DatabricksDataSource
+from soda_databricks.model.data_source.databricks_data_source import (
+    DatabricksDataSource,
+)
 
 infer = DatabricksDataSource.infer_connection_type
 

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,21 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.119.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/12/f9f912d8be2786c9aa2dbfa2a2da0af97c5548432a94b65a2c2af807da71/databricks_sdk-0.119.0.tar.gz", hash = "sha256:40e56ad56a8afb8150d4152c9fc7bf474ba1d44b6315ac4d9a5b18d57fd29900", size = 1001754, upload-time = "2026-06-24T15:37:01.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/aa/65c33c372960c4c786def1b01346767e880a4d85fdf310aecf817789fa82/databricks_sdk-0.119.0-py3-none-any.whl", hash = "sha256:17d9fe9add06668da57250454e4e91a18f7a288ba5fe80cd73be3e66cded48ef", size = 948381, upload-time = "2026-06-24T15:36:59.986Z" },
+]
+
+[[package]]
 name = "databricks-sql-connector"
 version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2237,12 +2252,14 @@ name = "soda-databricks"
 version = "4.16.0"
 source = { editable = "soda-databricks" }
 dependencies = [
+    { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
     { name = "soda-core" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "databricks-sdk", specifier = ">=0.19" },
     { name = "databricks-sql-connector" },
     { name = "soda-core", editable = "soda-core" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "databricks-sdk", specifier = ">=0.117,<1" },
+    { name = "databricks-sdk", specifier = ">=0.19,<1" },
     { name = "databricks-sql-connector" },
     { name = "soda-core", editable = "soda-core" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "databricks-sdk", specifier = ">=0.19" },
+    { name = "databricks-sdk", specifier = ">=0.19,<1" },
     { name = "databricks-sql-connector" },
     { name = "soda-core", editable = "soda-core" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "databricks-sdk", specifier = ">=0.19,<1" },
+    { name = "databricks-sdk", specifier = ">=0.117,<1" },
     { name = "databricks-sql-connector" },
     { name = "soda-core", editable = "soda-core" },
 ]


### PR DESCRIPTION
## Summary

Adds OAuth authentication to the `soda-databricks` (v4) connector alongside the
existing personal-access-token auth.

- New `auth_type` discriminator on the Databricks connection: `personal-access-token`
  (default / backward-compatible when absent), `databricks-oauth-m2m` (Databricks-managed
  service principal), `azure-service-principal` (Entra ID).
- OAuth modes build a Databricks SDK `credentials_provider` (`oauth_service_principal` /
  `azure_service_principal`); credential fields are stripped from `sql.connect` kwargs and
  the workspace host is normalized (scheme re-added for the SDK `Config`).
- `databricks-sdk>=0.19` added as a dependency.

## Tests

- `tests/unit/test_databricks_oauth.py` (new) — auth dispatch, credential-field stripping,
  credentials-provider construction, host-scheme handling, PAT regression. **13 pass.**
- `tests/data_sources/test_databricks.py` — added `TestConnection` config-validation cases
  (unknown `auth_type`, missing credentials) that run without live creds, plus live OAuth
  M2M / Azure-SP cases (env-guarded). The module is now import-safe without creds.

## Cross-repo

Part of PLATL-820. Pairs with the backend passthrough in `sodadata/soda` and the spark
bridge in `sodadata/soda-library`. The `auth_type` literals match across all three.
