### PR TITLE
feat(duckdb): Amazon S3 / Object Storage data source (DTL-1808)

### DIFF
--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -12,6 +12,7 @@ from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
 from soda_core.common.sql_ast import *
 from soda_core.common.sql_dialect import SqlDialect
+from soda_core.common.statements.table_types import FullyQualifiedObjectName, TableType
 from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
     DuckDBConnectionProperties,
 )
@@ -422,6 +423,25 @@ class DuckDBDataSourceConnection(DataSourceConnection):
 class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
     def _create_sql_dialect(self) -> SqlDialect:
         return DuckDBSqlDialect()
+
+    def _is_object_storage_source(self) -> bool:
+        """Object-storage datasets are registered as DuckDB VIEWs
+        (see DuckDBDataSourceConnection._create_object_storage_views), not TABLEs."""
+        return isinstance(self.data_source_model.connection_properties, DuckDBObjectStorageConnectionProperties)
+
+    def discover_qualified_objects(
+        self,
+        prefixes: list[str],
+        object_types: Optional[list[TableType]] = None,
+    ) -> list[FullyQualifiedObjectName]:
+        # Object-storage sources expose each configured dataset as a VIEW, but the default
+        # discovery/metadata path enumerates TABLEs only. When the caller does not request
+        # object types explicitly, include VIEWs so those datasets are actually found.
+        # Standard/local-file DuckDB sources materialize TABLEs and keep the TABLE-only default,
+        # so their discovery behavior is unchanged.
+        if object_types is None and self._is_object_storage_source():
+            object_types = [TableType.TABLE, TableType.VIEW]
+        return super().discover_qualified_objects(prefixes=prefixes, object_types=object_types)
 
     def _create_data_source_connection(self) -> DataSourceConnection:
         return DuckDBDataSourceConnection(

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -20,7 +20,11 @@ from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
 )
 from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
     DuckDBExistingConnectionProperties,
+    DuckDBObjectStorageConnectionProperties,
     DuckDBStandardConnectionProperties,
+    ObjectStorageAccessKeyAuth,
+    ObjectStorageAssumeRoleAuth,
+    ObjectStorageProperties,
 )
 
 DuckDBColumn = namedtuple(
@@ -234,6 +238,18 @@ class DuckDBDataSourceConnection(DataSourceConnection):
         ".json": "read_json_auto",
     }
 
+    # DuckDB table-function per object-storage dataset `format`.
+    OBJECT_STORAGE_FORMAT_READ_FUNCTIONS = {
+        "parquet": "read_parquet",
+        "csv": "read_csv_auto",
+        "json": "read_json_auto",
+    }
+
+    # STS session name used when assuming a role for object-storage credentials.
+    OBJECT_STORAGE_ROLE_SESSION_NAME = "soda-object-storage"
+    # Name of the DuckDB S3 secret created for object-storage access.
+    OBJECT_STORAGE_SECRET_NAME = "soda_object_storage"
+
     def _create_connection(
         self,
         config: DuckDBConnectionProperties,
@@ -243,9 +259,15 @@ class DuckDBDataSourceConnection(DataSourceConnection):
         try:
             if isinstance(config, DuckDBExistingConnectionProperties):
                 return DuckDBDataSourceConnectionWrapper(config.duckdb_connection)
+            # Must precede DuckDBStandardConnectionProperties: object-storage props subclass it.
+            elif isinstance(config, DuckDBObjectStorageConnectionProperties):
+                return self._create_object_storage_connection(config)
             elif isinstance(config, DuckDBStandardConnectionProperties):
                 if (read_function := self.REGISTERED_FORMAT_MAP.get(self.extract_format(config))) is not None:
                     connection = DuckDBDataSourceConnectionWrapper(duckdb.connect(":default:"))
+                    # `:default:` cannot accept a `config=` kwarg, so the configuration dict
+                    # (e.g. httpfs / extension settings) must be applied via SET after connecting.
+                    self._apply_configuration(connection, config.configuration)
                     connection.sql(
                         f"CREATE TABLE {self.extract_dataset_name(config)} AS SELECT * FROM {read_function}('{config.database}')"
                     )
@@ -271,6 +293,116 @@ class DuckDBDataSourceConnection(DataSourceConnection):
 
         except Exception as e:
             raise DataSourceConnectionException(e)
+
+    # ------------------------------------------------------------------ #
+    # Object storage (S3)                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _create_object_storage_connection(
+        self, config: DuckDBObjectStorageConnectionProperties
+    ) -> "DuckDBDataSourceConnectionWrapper":
+        """Open a (typically in-memory) DuckDB connection, wire up S3 access via
+        httpfs + a DuckDB S3 secret, and register one view per configured dataset."""
+        import duckdb
+
+        connection = duckdb.connect(database=config.database, config=config.configuration)
+        self._setup_object_storage(connection, config.object_storage)
+        return DuckDBDataSourceConnectionWrapper(connection)
+
+    def _setup_object_storage(self, connection, object_storage: ObjectStorageProperties) -> None:
+        if object_storage.provider != "s3":
+            # Defensive: the model already restricts provider to "s3" via a Literal.
+            raise DataSourceConnectionException(
+                f"Unsupported object_storage provider '{object_storage.provider}'; only 's3' is supported"
+            )
+        self._install_httpfs(connection)
+        self._create_s3_secret(connection, object_storage)
+        self._create_object_storage_views(connection, object_storage.datasets)
+
+    def _install_httpfs(self, connection) -> None:
+        # httpfs is not statically bundled in the pip DuckDB wheel; INSTALL fetches it
+        # from the DuckDB extension repository (or a local cache) and LOAD activates it.
+        connection.execute("INSTALL httpfs")
+        connection.execute("LOAD httpfs")
+
+    def _create_s3_secret(self, connection, object_storage: ObjectStorageProperties) -> None:
+        access_key_id, secret_access_key, session_token = self._resolve_object_storage_credentials(object_storage)
+        region = object_storage.region
+
+        if self._duckdb_supports_create_secret():
+            secret_parts = [
+                "TYPE S3",
+                f"KEY_ID '{self._escape_sql_literal(access_key_id)}'",
+                f"SECRET '{self._escape_sql_literal(secret_access_key)}'",
+            ]
+            if session_token:
+                secret_parts.append(f"SESSION_TOKEN '{self._escape_sql_literal(session_token)}'")
+            if region:
+                secret_parts.append(f"REGION '{self._escape_sql_literal(region)}'")
+            connection.execute(
+                f"CREATE OR REPLACE SECRET {self.OBJECT_STORAGE_SECRET_NAME} ({', '.join(secret_parts)})"
+            )
+        else:
+            # Fallback for DuckDB versions predating the Secrets API (< 0.10).
+            connection.execute(f"SET s3_access_key_id='{self._escape_sql_literal(access_key_id)}'")
+            connection.execute(f"SET s3_secret_access_key='{self._escape_sql_literal(secret_access_key)}'")
+            if session_token:
+                connection.execute(f"SET s3_session_token='{self._escape_sql_literal(session_token)}'")
+            if region:
+                connection.execute(f"SET s3_region='{self._escape_sql_literal(region)}'")
+
+    def _resolve_object_storage_credentials(self, object_storage: ObjectStorageProperties) -> tuple:
+        """Return (access_key_id, secret_access_key, session_token) for the configured auth."""
+        auth = object_storage.auth
+        if isinstance(auth, ObjectStorageAssumeRoleAuth):
+            return self._assume_role_credentials(auth, object_storage.region)
+        elif isinstance(auth, ObjectStorageAccessKeyAuth):
+            return auth.access_key_id, auth.secret_access_key.get_secret_value(), auth.session_token
+        raise DataSourceConnectionException(f"Unsupported object_storage auth type: {type(auth).__name__}")
+
+    def _assume_role_credentials(self, auth: ObjectStorageAssumeRoleAuth, region: str) -> tuple:
+        import boto3
+
+        sts_client = boto3.client("sts", region_name=region)
+        assume_role_kwargs = {"RoleArn": auth.role_arn, "RoleSessionName": self.OBJECT_STORAGE_ROLE_SESSION_NAME}
+        if auth.external_id:
+            assume_role_kwargs["ExternalId"] = auth.external_id
+        credentials = sts_client.assume_role(**assume_role_kwargs)["Credentials"]
+        return credentials["AccessKeyId"], credentials["SecretAccessKey"], credentials["SessionToken"]
+
+    def _create_object_storage_views(self, connection, datasets) -> None:
+        for dataset in datasets:
+            read_function = self.OBJECT_STORAGE_FORMAT_READ_FUNCTIONS[dataset.format]
+            view_name = self._quote_view_identifier(dataset.name)
+            path_literal = self._escape_sql_literal(dataset.path)
+            # Views are lazy (no in-memory materialization of S3 data) and appear in
+            # information_schema.tables, so the existing discovery/profiling/scan flows pick them up.
+            connection.execute(f"CREATE OR REPLACE VIEW {view_name} AS SELECT * FROM {read_function}('{path_literal}')")
+
+    @staticmethod
+    def _duckdb_supports_create_secret() -> bool:
+        """DuckDB's CREATE SECRET / Secrets API was introduced in 0.10.0."""
+        import duckdb
+
+        try:
+            major, minor = (int(part) for part in duckdb.__version__.split(".")[:2])
+        except (ValueError, AttributeError):
+            return False
+        return (major, minor) >= (0, 10)
+
+    def _apply_configuration(self, connection, configuration: Optional[dict]) -> None:
+        for key, value in (configuration or {}).items():
+            connection.execute(f"SET {key}='{self._escape_sql_literal(str(value))}'")
+
+    @staticmethod
+    def _escape_sql_literal(value: str) -> str:
+        """Escape a value for use inside a single-quoted SQL string literal."""
+        return value.replace("'", "''")
+
+    @staticmethod
+    def _quote_view_identifier(name: str) -> str:
+        """Double-quote a view identifier, escaping embedded double quotes."""
+        return '"' + name.replace('"', '""') + '"'
 
     def _fetch_session_timezone(self) -> tzinfo:
         with self.connection.cursor() as cursor:

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source_connection.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source_connection.py
@@ -1,12 +1,67 @@
 from abc import ABC
-from typing import Dict, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 from duckdb import DuckDBPyConnection
-from pydantic import Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
 )
+
+
+class ObjectStorageAssumeRoleAuth(BaseModel):
+    """AWS credentials obtained by assuming an IAM role via STS AssumeRole."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["assume_role"] = Field("assume_role")
+    role_arn: str = Field(..., description="ARN of the IAM role to assume", min_length=1)
+    external_id: Optional[str] = Field(None, description="Optional STS ExternalId to pass to AssumeRole")
+
+
+class ObjectStorageAccessKeyAuth(BaseModel):
+    """Static AWS access-key credentials."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["access_key"] = Field("access_key")
+    access_key_id: str = Field(..., description="AWS access key ID", min_length=1)
+    secret_access_key: SecretStr = Field(..., description="AWS secret access key")
+    session_token: Optional[str] = Field(None, description="Optional AWS session token")
+
+
+# Polymorphic credential block, discriminated on the ``type`` key. Mirrors the
+# Redshift AwsCredentials idioms (assume-role vs. static keys).
+ObjectStorageAuth = Union[ObjectStorageAssumeRoleAuth, ObjectStorageAccessKeyAuth]
+
+
+class ObjectStorageDataset(BaseModel):
+    """A single object-storage dataset: one prefix+glob exposed as one view."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(..., description="Dataset name; becomes the queryable view name", min_length=1)
+    path: str = Field(
+        ...,
+        description="Object storage path/glob, e.g. s3://bucket/prefix/*.parquet (supports * and **)",
+        min_length=1,
+    )
+    format: Literal["parquet", "csv", "json"] = Field(..., description="File format of the dataset")
+
+
+class ObjectStorageProperties(BaseModel):
+    """The ``object_storage`` connection block. Its presence marks a DuckDB data
+    source as an object-storage (S3) source: each dataset is exposed as a view
+    over files read via DuckDB ``httpfs``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: Literal["s3"] = Field("s3", description="Object storage provider. Only 's3' is implemented.")
+    region: str = Field(..., description="AWS region of the bucket(s)", min_length=1)
+    auth: ObjectStorageAuth = Field(..., discriminator="type", description="AWS credentials")
+    datasets: List[ObjectStorageDataset] = Field(
+        ..., description="Datasets to expose as views (each = one prefix+glob)", min_length=1
+    )
 
 
 class DuckDBConnectionProperties(DataSourceConnectionProperties, ABC):
@@ -21,6 +76,16 @@ class DuckDBStandardConnectionProperties(DuckDBConnectionProperties):
     )
     read_only: bool = Field(False, description="If True, the database is opened in read-only mode")
     configuration: Dict[str, str] = Field({}, description="Optional configuration dictionary for DuckDB")
+
+
+class DuckDBObjectStorageConnectionProperties(DuckDBStandardConnectionProperties):
+    """A DuckDB connection backed by object storage (S3). The ``database`` is
+    typically ``:memory:``; each configured dataset is registered as an
+    in-connection view over ``read_parquet`` / ``read_csv_auto`` / ``read_json_auto``."""
+
+    object_storage: ObjectStorageProperties = Field(
+        ..., description="Object storage (S3) configuration; its presence marks this an S3 source"
+    )
 
 
 class DuckDBExistingConnectionProperties(DuckDBConnectionProperties, arbitrary_types_allowed=True):
@@ -41,7 +106,11 @@ class DuckDBDataSource(DataSourceBase, ABC):
         if isinstance(value, DuckDBConnectionProperties):
             return value
 
-        if "database" in value:
+        # object_storage must be checked before database: the object-storage YAML
+        # carries both keys (database ':memory:' + object_storage block).
+        if "object_storage" in value:
+            return DuckDBObjectStorageConnectionProperties(**value)
+        elif "database" in value:
             return DuckDBStandardConnectionProperties(**value)
         elif "duckdb_connection" in value:
             return DuckDBExistingConnectionProperties(**value)

--- a/soda-duckdb/tests/data_sources/test_duckdb_object_storage.py
+++ b/soda-duckdb/tests/data_sources/test_duckdb_object_storage.py
@@ -1,0 +1,474 @@
+"""Tests for the DuckDB object-storage (S3) data source (DTL-1808).
+
+The tests are split into:
+  * pure config-parsing round-trips + validation error cases (hermetic);
+  * view creation / glob / format machinery, proved against LOCAL temp files
+    (no S3, no network) by calling the view-creation helper directly;
+  * credential resolution: static access keys and STS AssumeRole (boto3 mocked),
+    asserting the temp credentials flow into the DuckDB S3 secret;
+  * the config-dict-ignored bug fix in the file-extension branch;
+  * one end-to-end integration test through the full DataSourceImpl (requires the
+    httpfs extension, skipped when it cannot be installed offline).
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import duckdb
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+from soda_core.common.data_source_impl import DataSourceImpl
+from soda_core.common.statements.table_types import TableType
+from soda_core.common.yaml import DataSourceYamlSource
+from soda_duckdb.common.data_sources.duckdb_data_source import (
+    DuckDBDataSourceConnection,
+    DuckDBDataSourceImpl,
+)
+from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
+    DuckDBDataSource as DuckDBDataSourceModel,
+)
+from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
+    DuckDBObjectStorageConnectionProperties,
+    DuckDBStandardConnectionProperties,
+    ObjectStorageAccessKeyAuth,
+    ObjectStorageAssumeRoleAuth,
+    ObjectStorageDataset,
+    ObjectStorageProperties,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+class _RecordingConnection:
+    """Minimal stand-in that records the SQL executed against it."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def execute(self, sql: str):
+        self.executed.append(sql)
+        return self
+
+
+def _bare_connection_helper() -> DuckDBDataSourceConnection:
+    """A DuckDBDataSourceConnection instance without opening a real connection.
+
+    The object-storage helper methods only use class constants / other helpers,
+    never per-instance connection state, so bypassing __init__ is safe here."""
+    return DuckDBDataSourceConnection.__new__(DuckDBDataSourceConnection)
+
+
+def _access_key_object_storage(datasets: list[ObjectStorageDataset]) -> ObjectStorageProperties:
+    return ObjectStorageProperties(
+        provider="s3",
+        region="eu-west-1",
+        auth=ObjectStorageAccessKeyAuth(access_key_id="AKIAEXAMPLE", secret_access_key="secretvalue"),
+        datasets=datasets,
+    )
+
+
+def _httpfs_available() -> bool:
+    try:
+        connection = duckdb.connect(":memory:")
+        connection.execute("INSTALL httpfs")
+        connection.execute("LOAD httpfs")
+        return True
+    except Exception:
+        return False
+
+
+HTTPFS_AVAILABLE = _httpfs_available()
+
+
+# --------------------------------------------------------------------------- #
+# 1. Config parse round-trip                                                   #
+# --------------------------------------------------------------------------- #
+def _object_storage_dict(auth: dict) -> dict:
+    return {
+        "database": ":memory:",
+        "object_storage": {
+            "provider": "s3",
+            "region": "eu-west-1",
+            "auth": auth,
+            "datasets": [
+                {"name": "remittances", "path": "s3://highradius-landing/remittances/*.parquet", "format": "parquet"}
+            ],
+        },
+    }
+
+
+def test_parse_access_key_auth_round_trip():
+    props = DuckDBObjectStorageConnectionProperties(
+        **_object_storage_dict(
+            {
+                "type": "access_key",
+                "access_key_id": "AKIAEXAMPLE",
+                "secret_access_key": "topsecret",
+                "session_token": "sometoken",
+            }
+        )
+    )
+    assert props.database == ":memory:"
+    assert props.object_storage.provider == "s3"
+    assert props.object_storage.region == "eu-west-1"
+    assert isinstance(props.object_storage.auth, ObjectStorageAccessKeyAuth)
+    assert props.object_storage.auth.access_key_id == "AKIAEXAMPLE"
+    # Secret is wrapped in SecretStr and not exposed via repr.
+    assert props.object_storage.auth.secret_access_key.get_secret_value() == "topsecret"
+    assert "topsecret" not in repr(props.object_storage.auth)
+    assert props.object_storage.auth.session_token == "sometoken"
+    assert props.object_storage.datasets[0].name == "remittances"
+    assert props.object_storage.datasets[0].format == "parquet"
+
+
+def test_parse_assume_role_auth_round_trip():
+    props = DuckDBObjectStorageConnectionProperties(
+        **_object_storage_dict(
+            {
+                "type": "assume_role",
+                "role_arn": "arn:aws:iam::123456789012:role/soda-reader",
+                "external_id": "soda-highradius",
+            }
+        )
+    )
+    assert isinstance(props.object_storage.auth, ObjectStorageAssumeRoleAuth)
+    assert props.object_storage.auth.role_arn == "arn:aws:iam::123456789012:role/soda-reader"
+    assert props.object_storage.auth.external_id == "soda-highradius"
+
+
+def test_assume_role_external_id_optional():
+    props = DuckDBObjectStorageConnectionProperties(
+        **_object_storage_dict({"type": "assume_role", "role_arn": "arn:aws:iam::123456789012:role/soda-reader"})
+    )
+    assert props.object_storage.auth.external_id is None
+
+
+def test_object_storage_marks_connection_type_via_yaml():
+    """Presence of the object_storage block routes to the object-storage props subclass."""
+    model = DuckDBDataSourceModel(
+        name="highradius_landing",
+        connection={
+            "database": ":memory:",
+            "object_storage": {
+                "provider": "s3",
+                "region": "eu-west-1",
+                "auth": {"type": "access_key", "access_key_id": "AK", "secret_access_key": "SK"},
+                "datasets": [{"name": "r", "path": "s3://b/p/*.parquet", "format": "parquet"}],
+            },
+        },
+    )
+    assert isinstance(model.connection_properties, DuckDBObjectStorageConnectionProperties)
+
+
+def test_standard_connection_still_infers_without_object_storage():
+    model = DuckDBDataSourceModel(name="plain", connection={"database": ":memory:"})
+    assert isinstance(model.connection_properties, DuckDBStandardConnectionProperties)
+    assert not isinstance(model.connection_properties, DuckDBObjectStorageConnectionProperties)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Validation error cases                                                    #
+# --------------------------------------------------------------------------- #
+def test_unsupported_provider_rejected():
+    with pytest.raises(ValidationError) as exc_info:
+        DuckDBObjectStorageConnectionProperties(
+            database=":memory:",
+            object_storage={
+                "provider": "gcs",
+                "region": "eu-west-1",
+                "auth": {"type": "access_key", "access_key_id": "AK", "secret_access_key": "SK"},
+                "datasets": [{"name": "r", "path": "gs://b/p/*.parquet", "format": "parquet"}],
+            },
+        )
+    assert "provider" in str(exc_info.value)
+
+
+def test_bad_format_rejected():
+    with pytest.raises(ValidationError) as exc_info:
+        ObjectStorageDataset(name="r", path="s3://b/p/*.avro", format="avro")
+    assert "format" in str(exc_info.value)
+
+
+def test_missing_access_key_fields_rejected():
+    with pytest.raises(ValidationError):
+        ObjectStorageAccessKeyAuth(access_key_id="AK")  # secret_access_key missing
+
+
+def test_missing_role_arn_rejected():
+    with pytest.raises(ValidationError):
+        ObjectStorageAssumeRoleAuth(external_id="x")  # role_arn missing
+
+
+def test_missing_region_rejected():
+    with pytest.raises(ValidationError):
+        ObjectStorageProperties(
+            provider="s3",
+            auth=ObjectStorageAccessKeyAuth(access_key_id="AK", secret_access_key="SK"),
+            datasets=[ObjectStorageDataset(name="r", path="s3://b/p/*.parquet", format="parquet")],
+        )
+
+
+def test_empty_datasets_rejected():
+    with pytest.raises(ValidationError):
+        ObjectStorageProperties(
+            provider="s3",
+            region="eu-west-1",
+            auth=ObjectStorageAccessKeyAuth(access_key_id="AK", secret_access_key="SK"),
+            datasets=[],
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 3. View creation / glob / format (local temp files, no network)             #
+# --------------------------------------------------------------------------- #
+def test_create_views_parquet_glob(tmp_path):
+    pd.DataFrame({"id": [1, 2]}).to_parquet(tmp_path / "part-0.parquet")
+    pd.DataFrame({"id": [3]}).to_parquet(tmp_path / "part-1.parquet")
+    datasets = [ObjectStorageDataset(name="remittances", path=str(tmp_path / "*.parquet"), format="parquet")]
+
+    connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._create_object_storage_views(connection, datasets)
+
+    # glob spans both files -> 3 rows
+    assert connection.execute('SELECT count(*) FROM "remittances"').fetchone() == (3,)
+
+
+def test_create_views_csv(tmp_path):
+    (tmp_path / "data.csv").write_text("id,name\n1,a\n2,b\n")
+    datasets = [ObjectStorageDataset(name="invoices", path=str(tmp_path / "data.csv"), format="csv")]
+
+    connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._create_object_storage_views(connection, datasets)
+
+    assert connection.execute('SELECT count(*) FROM "invoices"').fetchone() == (2,)
+
+
+def test_create_views_json(tmp_path):
+    (tmp_path / "data.json").write_text('[{"id": 1}, {"id": 2}, {"id": 3}]')
+    datasets = [ObjectStorageDataset(name="events", path=str(tmp_path / "data.json"), format="json")]
+
+    connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._create_object_storage_views(connection, datasets)
+
+    assert connection.execute('SELECT count(*) FROM "events"').fetchone() == (3,)
+
+
+def test_create_views_uses_correct_read_function():
+    recording = _RecordingConnection()
+    datasets = [
+        ObjectStorageDataset(name="p", path="s3://b/p/*.parquet", format="parquet"),
+        ObjectStorageDataset(name="c", path="s3://b/c/*.csv", format="csv"),
+        ObjectStorageDataset(name="j", path="s3://b/j/*.json", format="json"),
+    ]
+    _bare_connection_helper()._create_object_storage_views(recording, datasets)
+    sql = "\n".join(recording.executed)
+    assert "read_parquet('s3://b/p/*.parquet')" in sql
+    assert "read_csv_auto('s3://b/c/*.csv')" in sql
+    assert "read_json_auto('s3://b/j/*.json')" in sql
+    # view names are double-quoted identifiers
+    assert 'CREATE OR REPLACE VIEW "p" AS' in sql
+
+
+def test_view_identifier_and_path_are_escaped():
+    helper = _bare_connection_helper()
+    assert helper._quote_view_identifier('weird"name') == '"weird""name"'
+    assert helper._escape_sql_literal("s3://b/o'brien/*.parquet") == "s3://b/o''brien/*.parquet"
+
+
+# --------------------------------------------------------------------------- #
+# 4. Discovery lists the created views (hermetic, no httpfs)                   #
+# --------------------------------------------------------------------------- #
+def test_discovery_lists_object_storage_views(tmp_path):
+    pd.DataFrame({"id": [1, 2, 3]}).to_parquet(tmp_path / "r.parquet")
+    (tmp_path / "c.csv").write_text("id\n1\n2\n")
+    datasets = [
+        ObjectStorageDataset(name="remittances", path=str(tmp_path / "r.parquet"), format="parquet"),
+        ObjectStorageDataset(name="invoices", path=str(tmp_path / "c.csv"), format="csv"),
+    ]
+
+    raw_connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._create_object_storage_views(raw_connection, datasets)
+
+    data_source_impl = DuckDBDataSourceImpl.from_existing_cursor(raw_connection, "os_discovery")
+    data_source_impl.open_connection()
+    discovered = data_source_impl.discover_qualified_objects(
+        prefixes=["main"], object_types=[TableType.TABLE, TableType.VIEW]
+    )
+    discovered_names = sorted(obj.get_object_name() for obj in discovered)
+    assert discovered_names == ["invoices", "remittances"]
+    data_source_impl.close_connection()
+
+
+# --------------------------------------------------------------------------- #
+# 5. Credential resolution -> DuckDB S3 secret                                 #
+# --------------------------------------------------------------------------- #
+def test_access_key_credentials_flow_into_secret():
+    """Static access-key credentials populate a real DuckDB S3 secret."""
+    object_storage = _access_key_object_storage(
+        [ObjectStorageDataset(name="r", path="s3://b/p/*.parquet", format="parquet")]
+    )
+    connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._create_s3_secret(connection, object_storage)
+
+    secrets = connection.execute("SELECT name, type FROM duckdb_secrets()").fetchall()
+    assert (DuckDBDataSourceConnection.OBJECT_STORAGE_SECRET_NAME, "s3") in secrets
+
+
+def test_assume_role_credentials_flow_into_secret():
+    """STS AssumeRole temp credentials (mocked) flow into the CREATE SECRET statement,
+    and ExternalId is passed through to STS."""
+    object_storage = ObjectStorageProperties(
+        provider="s3",
+        region="eu-west-1",
+        auth=ObjectStorageAssumeRoleAuth(
+            role_arn="arn:aws:iam::123456789012:role/soda-reader", external_id="soda-highradius"
+        ),
+        datasets=[ObjectStorageDataset(name="r", path="s3://b/p/*.parquet", format="parquet")],
+    )
+
+    fake_sts = mock.Mock()
+    fake_sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ASIATEMPKEY",
+            "SecretAccessKey": "tempsecretvalue",
+            "SessionToken": "tempsessiontoken",
+        }
+    }
+    recording = _RecordingConnection()
+
+    with mock.patch("boto3.client", return_value=fake_sts) as client_mock:
+        _bare_connection_helper()._create_s3_secret(recording, object_storage)
+
+    client_mock.assert_called_once_with("sts", region_name="eu-west-1")
+    fake_sts.assume_role.assert_called_once_with(
+        RoleArn="arn:aws:iam::123456789012:role/soda-reader",
+        RoleSessionName=DuckDBDataSourceConnection.OBJECT_STORAGE_ROLE_SESSION_NAME,
+        ExternalId="soda-highradius",
+    )
+    secret_sql = "\n".join(recording.executed)
+    assert "CREATE OR REPLACE SECRET" in secret_sql
+    assert "ASIATEMPKEY" in secret_sql
+    assert "tempsecretvalue" in secret_sql
+    assert "tempsessiontoken" in secret_sql
+    assert "REGION 'eu-west-1'" in secret_sql
+
+
+def test_assume_role_without_external_id_omits_it():
+    object_storage = ObjectStorageProperties(
+        provider="s3",
+        region="us-east-1",
+        auth=ObjectStorageAssumeRoleAuth(role_arn="arn:aws:iam::123456789012:role/soda-reader"),
+        datasets=[ObjectStorageDataset(name="r", path="s3://b/p/*.parquet", format="parquet")],
+    )
+    fake_sts = mock.Mock()
+    fake_sts.assume_role.return_value = {
+        "Credentials": {"AccessKeyId": "K", "SecretAccessKey": "S", "SessionToken": "T"}
+    }
+    with mock.patch("boto3.client", return_value=fake_sts):
+        _bare_connection_helper()._create_s3_secret(_RecordingConnection(), object_storage)
+
+    _, called_kwargs = fake_sts.assume_role.call_args
+    assert "ExternalId" not in called_kwargs
+
+
+def test_resolve_credentials_access_key_returns_secret_value():
+    object_storage = ObjectStorageProperties(
+        provider="s3",
+        region="eu-west-1",
+        auth=ObjectStorageAccessKeyAuth(access_key_id="AK", secret_access_key="SK", session_token="ST"),
+        datasets=[ObjectStorageDataset(name="r", path="s3://b/p/*.parquet", format="parquet")],
+    )
+    key_id, secret, token = _bare_connection_helper()._resolve_object_storage_credentials(object_storage)
+    assert (key_id, secret, token) == ("AK", "SK", "ST")
+
+
+def test_duckdb_supports_create_secret_true_on_current_version():
+    # Installed DuckDB is >= 1.x, well past the 0.10 Secrets API introduction.
+    assert DuckDBDataSourceConnection._duckdb_supports_create_secret() is True
+
+
+# --------------------------------------------------------------------------- #
+# 6. Config-dict-ignored bug fix (file-extension branch)                       #
+# --------------------------------------------------------------------------- #
+def test_apply_configuration_sets_options():
+    connection = duckdb.connect(":memory:")
+    _bare_connection_helper()._apply_configuration(connection, {"memory_limit": "512MB"})
+    # DuckDB normalizes the reported value; assert it was applied (not the default).
+    applied = connection.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+    assert "MiB" in applied or "GiB" in applied
+
+
+def test_apply_configuration_handles_empty():
+    connection = duckdb.connect(":memory:")
+    # Should be a no-op and not raise.
+    _bare_connection_helper()._apply_configuration(connection, {})
+    _bare_connection_helper()._apply_configuration(connection, None)
+
+
+def test_file_extension_branch_applies_configuration(tmp_path):
+    """The file-extension branch used to ignore the configuration dict; it must
+    now feed it through _apply_configuration."""
+    parquet_path = tmp_path / "landing_probe.parquet"
+    pd.DataFrame({"id": [1, 2, 3]}).to_parquet(parquet_path)
+    yaml_str = f"""
+        type: duckdb
+        name: DUCKDB_CFG_PROBE
+        connection:
+            database: "{parquet_path}"
+            configuration:
+                memory_limit: "512MB"
+    """
+    with mock.patch.object(DuckDBDataSourceConnection, "_apply_configuration", autospec=True) as apply_mock:
+        data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(yaml_str=yaml_str))
+        data_source_impl.open_connection()
+        data_source_impl.close_connection()
+
+    assert apply_mock.called
+    # autospec => (self, connection, configuration)
+    passed_configuration = apply_mock.call_args.args[-1]
+    assert passed_configuration == {"memory_limit": "512MB"}
+
+
+# --------------------------------------------------------------------------- #
+# 7. End-to-end through DataSourceImpl (requires httpfs)                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not HTTPFS_AVAILABLE, reason="httpfs extension not available offline")
+def test_object_storage_end_to_end_local_files(tmp_path):
+    pd.DataFrame({"id": [1, 2]}).to_parquet(tmp_path / "a.parquet")
+    pd.DataFrame({"id": [3]}).to_parquet(tmp_path / "b.parquet")
+    (tmp_path / "c.csv").write_text("id\n10\n20\n30\n")
+
+    yaml_str = f"""
+        type: duckdb
+        name: highradius_landing
+        connection:
+            database: ":memory:"
+            object_storage:
+                provider: s3
+                region: eu-west-1
+                auth:
+                    type: access_key
+                    access_key_id: "AKIAEXAMPLE"
+                    secret_access_key: "secretexample"
+                datasets:
+                    - name: remittances
+                      path: "{tmp_path / '*.parquet'}"
+                      format: parquet
+                    - name: invoices
+                      path: "{tmp_path / 'c.csv'}"
+                      format: csv
+    """
+    data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(yaml_str=yaml_str))
+    data_source_impl.open_connection()
+    try:
+        assert data_source_impl.execute_query("SELECT count(*) FROM remittances").rows == [(3,)]
+        assert data_source_impl.execute_query("SELECT count(*) FROM invoices").rows == [(3,)]
+        discovered = data_source_impl.discover_qualified_objects(
+            prefixes=["main"], object_types=[TableType.TABLE, TableType.VIEW]
+        )
+        assert sorted(obj.get_object_name() for obj in discovered) == ["invoices", "remittances"]
+    finally:
+        data_source_impl.close_connection()

--- a/soda-duckdb/tests/data_sources/test_duckdb_object_storage.py
+++ b/soda-duckdb/tests/data_sources/test_duckdb_object_storage.py
@@ -302,6 +302,79 @@ def test_discovery_lists_object_storage_views(tmp_path):
     data_source_impl.close_connection()
 
 
+def test_default_discovery_includes_object_storage_views(tmp_path):
+    """The DEFAULT discovery path (no explicit object_types) must enumerate the
+    object-storage VIEW datasets — that is the path the real product profiling /
+    discovery flow uses. This goes through the full DataSourceImpl built from YAML,
+    so the source is genuinely an object-storage source (connection_properties is
+    DuckDBObjectStorageConnectionProperties). httpfs install + S3 secret creation
+    are stubbed so the VIEWs are built over local files (no network, no httpfs)."""
+    pd.DataFrame({"id": [1, 2, 3]}).to_parquet(tmp_path / "r.parquet")
+    (tmp_path / "c.csv").write_text("id\n1\n2\n")
+
+    yaml_str = f"""
+        type: duckdb
+        name: highradius_landing
+        connection:
+            database: ":memory:"
+            object_storage:
+                provider: s3
+                region: eu-west-1
+                auth:
+                    type: access_key
+                    access_key_id: "AK"
+                    secret_access_key: "SK"
+                datasets:
+                    - name: remittances
+                      path: "{tmp_path / 'r.parquet'}"
+                      format: parquet
+                    - name: invoices
+                      path: "{tmp_path / 'c.csv'}"
+                      format: csv
+    """
+    with mock.patch.object(DuckDBDataSourceConnection, "_install_httpfs"), mock.patch.object(
+        DuckDBDataSourceConnection, "_create_s3_secret"
+    ):
+        data_source_impl = DataSourceImpl.from_yaml_source(DataSourceYamlSource.from_str(yaml_str=yaml_str))
+        data_source_impl.open_connection()
+        try:
+            # NB: object_types is intentionally NOT passed -> the default path, which
+            # used to default to TABLE-only and therefore miss the object-storage VIEWs.
+            discovered = data_source_impl.discover_qualified_objects(prefixes=["main"])
+            discovered_names = sorted(obj.get_object_name() for obj in discovered)
+            assert discovered_names == ["invoices", "remittances"]
+        finally:
+            data_source_impl.close_connection()
+
+
+def test_default_discovery_excludes_views_for_non_object_storage():
+    """Scope guard: a standard (non-object-storage) DuckDB source keeps the TABLE-only
+    default. A VIEW present in such a source is NOT returned by the default path; it is
+    only surfaced when object_types explicitly asks for it. This proves the VIEW-inclusion
+    is scoped to object-storage sources and does not regress local-file / standard DuckDB."""
+    raw_connection = duckdb.connect(":memory:")
+    raw_connection.execute("CREATE TABLE t AS SELECT 1 AS id")
+    raw_connection.execute("CREATE VIEW v AS SELECT 1 AS id")
+
+    data_source_impl = DuckDBDataSourceImpl.from_existing_cursor(raw_connection, "std_source")
+    data_source_impl.open_connection()
+    try:
+        default_names = sorted(
+            obj.get_object_name() for obj in data_source_impl.discover_qualified_objects(prefixes=["main"])
+        )
+        assert default_names == ["t"]  # view "v" excluded by the TABLE-only default
+
+        with_views = sorted(
+            obj.get_object_name()
+            for obj in data_source_impl.discover_qualified_objects(
+                prefixes=["main"], object_types=[TableType.TABLE, TableType.VIEW]
+            )
+        )
+        assert with_views == ["t", "v"]  # mechanism still works when explicitly requested
+    finally:
+        data_source_impl.close_connection()
+
+
 # --------------------------------------------------------------------------- #
 # 5. Credential resolution -> DuckDB S3 secret                                 #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Amazon S3 / Object Storage data source (DTL-1808)

Adds S3 / object-storage support to the DuckDB engine plugin so files in S3 (Parquet/CSV/JSON) can be scanned directly, **before** ingestion into a warehouse.

### What's in it
- New `connection.object_storage` block on the DuckDB data source: `provider: s3`, `region`, polymorphic `auth` (assume-role or access-key), and `datasets` (each a name + S3 path/glob + format).
- On connect: `INSTALL/LOAD httpfs`, build S3 credentials (STS AssumeRole via boto3, or static access-key), `CREATE SECRET`, and one `CREATE VIEW` per dataset over `read_parquet` / `read_csv_auto` / `read_json_auto` (globs supported).
- Discovery includes VIEWs for object-storage sources (scoped so local-file DuckDB behaviour is unchanged).
- Fixes the file-mode `configuration`-dict-ignored gap.

### Tests
41 passing in `soda-duckdb` — config parse (both auth modes), view creation over local files, assume-role (STS mocked), discovery, error cases.

### Runtime note
The runner image must have the DuckDB `httpfs` extension available (egress at connect time, or pre-bundled offline).

Part of the cross-repo object-storage feature (`soda`, `soda-contract-launcher`, `docs`). Ticket: DTL-1808.
