### PR TITLE
fix(docs): replace stale v3 doc links with v4 equivalents

### DIFF
--- a/soda-core/src/soda_core/cli/exit_codes.py
+++ b/soda-core/src/soda_core/cli/exit_codes.py
@@ -5,7 +5,11 @@ from typing import Protocol
 class ExitCode(IntEnum):
     """Possible exit codes and their meaning.
 
-    See https://docs.soda.io/soda-library/programmatic.html#scan-exit-codes
+    0: all checks passed, no errors
+    1: one or more checks failed
+    2: one or more checks warned (no failures)
+    3: errors occurred during execution (e.g. parse or engine errors)
+    4: results could not be sent to Soda Cloud
     """
 
     OK = 0

--- a/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
+++ b/soda-core/src/soda_core/contracts/soda_data_contract_json_schema_1_0_0.json
@@ -680,7 +680,7 @@
                                     {
                                         "type": "object",
                                         "additionalProperties": false,
-                                        "description": "Use a schema check to validate the presence, absence or position of columns in a dataset, or to validate the type of data column contains. See documentation for more details: https://docs.soda.io/soda-cl/schema.html",
+                                        "description": "Use a schema check to validate the presence, absence or position of columns in a dataset, or to validate the type of data column contains. See documentation for more details: https://docs.soda.io/soda-v4/reference/contract-language-reference#schema-check",
                                         "properties": {
                                             "name": {
                                                 "description": "The display name for the check used in Soda Cloud",
@@ -1121,7 +1121,7 @@
         "threshold": {
             "type": "object",
             "additionalProperties": false,
-            "description": "The threshold for the check. See documentation for more details: https://docs.soda.io/#thresholds",
+            "description": "The threshold for the check. See documentation for more details: https://docs.soda.io/soda-v4/reference/contract-language-reference#thresholds",
             "properties": {
                 "metric": {
                     "description": "The type of the metric value to check",
@@ -1131,7 +1131,7 @@
                     ]
                 },
                 "must_be": {
-                    "description": "YY The value the check metric (as specified in the type) must have for the check to pass; The check passes if the metric has the specified value, and fails otherwise; https://docs.soda.io/#thresholds",
+                    "description": "The value the check metric (as specified in the type) must have for the check to pass; The check passes if the metric has the specified value, and fails otherwise; https://docs.soda.io/soda-v4/reference/contract-language-reference#thresholds",
                     "type": [
                         "number",
                         "string"
@@ -1296,7 +1296,7 @@
         "thresholdFreshness": {
             "type": "object",
             "additionalProperties": false,
-            "description": "The threshold for the check. See documentation for more details: https://docs.soda.io/#thresholds",
+            "description": "The threshold for the check. See documentation for more details: https://docs.soda.io/soda-v4/reference/contract-language-reference#thresholds",
             "properties": {
                 "unit": {
                     "description": "The type of the metric value to check",
@@ -1307,7 +1307,7 @@
                     ]
                 },
                 "must_be": {
-                    "description": "YY The value the check metric (as specified in the type) must have for the check to pass; The check passes if the metric has the specified value, and fails otherwise; https://docs.soda.io/#thresholds",
+                    "description": "The value the check metric (as specified in the type) must have for the check to pass; The check passes if the metric has the specified value, and fails otherwise; https://docs.soda.io/soda-v4/reference/contract-language-reference#thresholds",
                     "type": "number"
                 },
                 "must_not_be": {


### PR DESCRIPTION
## Context

A customer cloned the repo and followed a v3 docs link found on the `main` branch, ending up on the wrong (legacy) process. This PR replaces the remaining v3-era doc links with their v4 equivalents.

## Changes

**`soda_data_contract_json_schema_1_0_0.json`** (user-facing via IDE validation/hover while authoring contracts):
- Schema check description: `docs.soda.io/soda-cl/schema.html` (v3 SodaCL) → [`docs.soda.io/soda-v4/reference/contract-language-reference#schema-check`](https://docs.soda.io/soda-v4/reference/contract-language-reference#schema-check)
- 4× threshold descriptions: dead `docs.soda.io/#thresholds` anchor → [`docs.soda.io/soda-v4/reference/contract-language-reference#thresholds`](https://docs.soda.io/soda-v4/reference/contract-language-reference#thresholds)
- Dropped two leftover `"YY "` prefixes in threshold descriptions.

**`exit_codes.py`**:
- The `ExitCode` docstring linked to the v3 Soda Library docs (`docs.soda.io/soda-library/programmatic.html#scan-exit-codes`). No v4 page documents Soda Core's exit codes — the `sodacli` reference documents *different* exit-code semantics (`2` = execution error there, vs. check warnings here) — so the codes are now documented inline in the docstring instead.

Both replacement pages/anchors were verified to exist on docs.soda.io. The v3 links in the README's clearly-labeled "Working with legacy Soda Core v3" section are intentional and left untouched.

## Notes / follow-ups (not in this PR)

- Direct long links are used instead of `go.soda.io` shortlinks: no suitable shortlinks exist yet for these targets, and the closest existing ones (`go.soda.io/schema`, `go.soda.io/contracts`) still redirect to **v3** pages. Once v4-targeted slugs are created (e.g. `contract-schema-check`, `contract-thresholds`), swapping them in is a trivial follow-up.
- Docs gap: Soda Core's CLI exit codes (0–4) aren't documented anywhere in the v4 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)