### PR TITLE
feat(dialect): all-datasource groundwork — time/interval, percentile, typed timestamp literal, NaN filter

### DIFF
--- a/docs/superpowers/specs/2026-07-24-sqlserver-version-guard-design.md
+++ b/docs/superpowers/specs/2026-07-24-sqlserver-version-guard-design.md
@@ -1,0 +1,145 @@
+# SQL Server version-based capability derivation — design
+
+**Date:** 2026-07-24
+**Branch:** `obsl-1036-dialect-groundwork-all-datasources` (PR #2787)
+**Status:** approved
+
+## Problem
+
+The current `APPROX_PERCENTILE_DISC` version guard (commit `055176ce`) inverts the
+desired responsibility split: `SqlServerDataSourceImpl` probes the engine
+(`SERVERPROPERTY('ProductMajorVersion')` / `EngineEdition`), derives a capability
+boolean in `_engine_supports_approx_percentile_disc`, and injects that pre-chewed
+boolean into the dialect via `set_approx_percentile_disc_supported()`. The dialect
+never sees the version, so every future version-dependent capability needs its own
+probe/setter pair in the connector.
+
+## Goal
+
+Mirror the Oracle pattern from soda-extensions #2795: the connection detects raw
+server facts, the data source syncs them onto the dialect, and the dialect derives
+capabilities itself. The connector computes no capabilities; the dialect touches no
+connection.
+
+## Decisions (with rationale)
+
+1. **The dialect receives two raw facts** — `server_major_version` and
+   `engine_edition` — not a derived boolean and not a normalized version. A version
+   number alone cannot decide this capability: Azure SQL Database (EngineEdition 5)
+   and Managed Instance (EngineEdition 8) report legacy `ProductMajorVersion` 12 but
+   support `APPROX_PERCENTILE_DISC`; on-prem needs 2022+ (major ≥ 16).
+2. **Detection is eager, at connection open, in the connection class.**
+   `server_major_version` comes free from the pyodbc login handshake
+   (`connection.getinfo(pyodbc.SQL_DBMS_VER)`); `engine_edition` costs one
+   `SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT)` query. Lazy detection was
+   rejected: reading the connection during SQL generation breaks snapshot replay
+   (see the explicit warning in `oracle_data_source.py`).
+3. **Facts are synced onto the dialect after creation (Oracle-style setter/sync).**
+   Constructor injection was explored and rejected: the base `DataSourceImpl.__init__`
+   creates the dialect before any connection exists, and contract parsing /
+   `only_validate_without_execute` read `sql_dialect` without ever opening a
+   connection — so constructor injection would force replacing the dialect instance
+   at connection open, which we don't want. A lazy `server_info_provider` callable
+   was also explored and rejected as over-engineered.
+4. **SQL-Server-local pattern.** No generalization into the `SqlDialect` base in
+   soda-core. Oracle and SQL Server are two local precedents; unify in core when a
+   third dialect needs it (rule of three).
+
+## Design
+
+### 1. Detection — `SqlServerDataSourceConnection`
+
+After the pyodbc connection is created in `_create_connection`:
+
+- `self.server_major_version: Optional[int]` — parsed from
+  `connection.getinfo(pyodbc.SQL_DBMS_VER)` (e.g. `"15.00.4123"` → `15`) via a
+  static `_parse_server_major_version` helper (same shape as Oracle's).
+- `self.engine_edition: Optional[int]` — one `SERVERPROPERTY('EngineEdition')` query.
+
+Any detection failure logs a warning and leaves the attribute `None`; detection never
+fails an otherwise healthy connect. Fabric/Synapse connections inherit this; the one
+extra query at their connect is harmless (their dialects pin the capability, so a
+`None` there is inert).
+
+### 2. Sync — `SqlServerDataSourceImpl`
+
+The current `open_connection` override (probe + boolean push) is replaced by
+`_sync_dialect_server_info()`, called from:
+
+- `open_connection()`, after `super().open_connection()`, and
+- `__init__` when a live connection is passed in (the
+  `create_copy_with_different_connection` path — Oracle has the same two call sites).
+
+It copies both attributes onto the dialect when
+`isinstance(conn, SqlServerDataSourceConnection)` and
+`isinstance(self.sql_dialect, SqlServerSqlDialect)`. The current
+`type(...) is SqlServerSqlDialect` exact-type guard disappears: syncing facts onto
+Fabric/Synapse dialects is inert because they override the capability method.
+
+### 3. Derivation — `SqlServerSqlDialect`
+
+`__init__` sets `self.server_major_version: Optional[int] = None` and
+`self.engine_edition: Optional[int] = None`. The old seam
+(`_approx_percentile_disc_supported`, `set_approx_percentile_disc_supported`,
+`_probe_approx_percentile_disc_support`, `_engine_supports_approx_percentile_disc`)
+is deleted. The decision matrix moves into the dialect:
+
+```python
+def supports_percentile_within_group(self) -> bool:
+    if self.server_major_version is None and self.engine_edition is None:
+        return True  # no live server facts (offline rendering, unit tests,
+                     # snapshot replay): assume newest engine, like Oracle
+    return (
+        self.server_major_version is not None
+        and self.server_major_version >= SQLSERVER_2022_MAJOR_VERSION
+    ) or self.engine_edition in (
+        AZURE_SQL_DATABASE_ENGINE_EDITION,      # 5
+        AZURE_SQL_MANAGED_INSTANCE_ENGINE_EDITION,  # 8
+    )
+```
+
+Named module constants replace the magic numbers (`SQLSERVER_2022_MAJOR_VERSION = 16`,
+editions 5 and 8).
+
+One deliberate semantic change: the old code distinguished a *failed probe*
+(→ assume support) from a *live server reporting NULL for both properties*
+(→ `False`, per the old matrix test `f(None, None) is False`). With facts stored as
+attributes, "offline" and "live but unknown" are indistinguishable, so `(None, None)`
+uniformly means assume support. The NULL/NULL-from-a-live-server case is not known to
+occur in practice; assume-support merely restores pre-guard v3 behavior for it (the
+real query surfaces any error).
+
+### 4. Fabric / Synapse
+
+Pins unchanged: Fabric overrides `supports_percentile_within_group()` → `True`,
+Synapse → `False`. The Fabric test that currently calls
+`set_approx_percentile_disc_supported(False)` changes to setting the version
+attributes to a non-supporting combination and asserting the pin still wins.
+
+## Error handling
+
+- Detection failures: warning + `None`, never a failed connect (matches Oracle and
+  the current probe's fallback).
+- `None` facts at capability time: assume support — the real query surfaces any
+  engine error, which is the pre-guard v3 behavior.
+
+## Testing
+
+- **Dialect unit tests** (port of the existing matrix test, moved from the data
+  source to the dialect): set the two attributes, assert
+  `supports_percentile_within_group()` — covering 2022+ (16/17), 2019 (15),
+  Azure SQL DB (12/5), Managed Instance (12/8), Express (15/4), and the
+  unknown-engine default — note the flip: `(None, None)` now asserts `True`
+  (assume support), where the old matrix asserted `False` (see the semantic-change
+  note above).
+- **Connection unit test**: `_parse_server_major_version` on `"15.00.4123"`,
+  `"12.00.2000"`, garbage, `None`.
+- **Fabric/Synapse pin tests**: pins win regardless of synced facts.
+- No integration-test changes expected: live behavior is identical.
+
+## Out of scope
+
+- Generalizing a version seam into `SqlDialect` (soda-core base).
+- Migrating Oracle onto any shared mechanism.
+- Any change to when connections open, or to dialect creation order in
+  `DataSourceImpl`.

--- a/docs/superpowers/specs/2026-07-24-sqlserver-version-guard-design.md
+++ b/docs/superpowers/specs/2026-07-24-sqlserver-version-guard-design.md
@@ -70,9 +70,19 @@ The current `open_connection` override (probe + boolean push) is replaced by
 - `__init__` when a live connection is passed in (the
   `create_copy_with_different_connection` path — Oracle has the same two call sites).
 
-It copies both attributes onto the dialect when
-`isinstance(conn, SqlServerDataSourceConnection)` and
-`isinstance(self.sql_dialect, SqlServerSqlDialect)`. The current
+It copies both attributes onto the dialect, guarded by
+`isinstance(conn, SqlServerDataSourceConnection)`. This guard is load-bearing, not
+defensive: in snapshot replay the connection is a `SnapshotDataSourceConnection`
+lazy wrapper (`soda-tests/src/helpers/snapshot_connection.py`) whose `__getattr__`
+opens a real connection on attribute access — duck-typing the attributes would break
+replay (same rationale as documented on Oracle's `_sync_dialect_server_version`).
+Skipping the sync there is also correct: replay has no live server facts, and the
+dialect's `None` default is what recorded snapshots expect.
+
+The dialect side needs no runtime guard — every `_create_sql_dialect` in the
+hierarchy returns a `SqlServerSqlDialect` subclass — but the sync uses
+`assert isinstance(self.sql_dialect, SqlServerSqlDialect)` purely to narrow the
+declared `SqlDialect` type for the attribute assignment. The current
 `type(...) is SqlServerSqlDialect` exact-type guard disappears: syncing facts onto
 Fabric/Synapse dialects is inert because they override the capability method.
 

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -325,9 +325,8 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
     def sql_expr_timestamp_add_day(self, timestamp_literal: str) -> str:
         return f"{timestamp_literal} + interval '1' day"
 
-    # Lowercase singular unit names for date_add (v3 athena_data_source.py:233-242;
-    # Athena engine v3 functions are Trino's,
-    # https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html).
+    # Lowercase singular unit names for date_add (Athena engine v3 functions are
+    # Trino's, https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html).
     _TIME_BUCKET_UNIT_NAMES: dict = {
         "weeks": "week",
         "days": "day",
@@ -336,29 +335,23 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
     }
 
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
-        """Athena date_diff('second', ...) divided by the float seconds-per-
-        interval (v3 athena_data_source.py:269-273), plus the int cast of the
-        v3 TRINO form (trino_data_source.py:269-271) that v3 athena lacked:
-        floor() returns double on the Trino engine and date_add's value
-        argument must be integer-typed."""
+        """Seconds date_diff divided by the float seconds-per-interval, cast to
+        int. The cast matters: floor() returns double on the Trino engine and
+        date_add's value argument must be integer-typed."""
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         secs_per_interval: float = seconds_per_time_bucket(time_delta.unit, time_delta.count) / 1.0
         return f"cast(floor(date_diff('second', {start_sql}, {end_sql}) / {secs_per_interval}) as int)"
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
-        """Trino date_add form (v3 trino_data_source.py:280-281; v3 athena
-        inherited the base interval-multiply form, but Athena engine v3 is
-        Trino-based and date_add is the documented rendering)."""
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
         return f"date_add('{unit_name}', {count_sql}, {timestamp_sql})"
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
-        """The base WITHIN GROUP form is not accepted by the Trino-based
-        Athena engine; v3 rendered approx_percentile(expr, p)
-        (v3 athena_data_source.py:256-259)."""
+        """The Trino-based Athena engine does not accept the base WITHIN GROUP
+        form; approx_percentile is its percentile aggregate."""
         expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
         return f"approx_percentile({expression_sql}, {percentile_within_group.percentile})"
 

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -16,13 +16,17 @@ from soda_core.common.data_source_impl import DataSourceImpl, FullyQualifiedTabl
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
+    ADD_INTERVAL,
     ALTER_TABLE_ADD_COLUMN,
     COLUMN,
     CREATE_TABLE,
     CREATE_TABLE_COLUMN,
     CREATE_TABLE_IF_NOT_EXISTS,
     INSERT_INTO_VIA_SELECT,
+    PERCENTILE_WITHIN_GROUP,
     STRING_HASH,
+    TIME_DELTA,
+    seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
 
@@ -320,6 +324,43 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
 
     def sql_expr_timestamp_add_day(self, timestamp_literal: str) -> str:
         return f"{timestamp_literal} + interval '1' day"
+
+    # Lowercase singular unit names for date_add (v3 athena_data_source.py:233-242;
+    # Athena engine v3 functions are Trino's,
+    # https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html).
+    _TIME_BUCKET_UNIT_NAMES: dict = {
+        "weeks": "week",
+        "days": "day",
+        "hours": "hour",
+        "seconds": "second",
+    }
+
+    def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
+        """Athena date_diff('second', ...) divided by the float seconds-per-
+        interval (v3 athena_data_source.py:269-273), plus the int cast of the
+        v3 TRINO form (trino_data_source.py:269-271) that v3 athena lacked:
+        floor() returns double on the Trino engine and date_add's value
+        argument must be integer-typed."""
+        start_sql: str = self.build_expression_sql(time_delta.start)
+        end_sql: str = self.build_expression_sql(time_delta.end)
+        secs_per_interval: float = seconds_per_time_bucket(time_delta.unit, time_delta.count) / 1.0
+        return f"cast(floor(date_diff('second', {start_sql}, {end_sql}) / {secs_per_interval}) as int)"
+
+    def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
+        """Trino date_add form (v3 trino_data_source.py:280-281; v3 athena
+        inherited the base interval-multiply form, but Athena engine v3 is
+        Trino-based and date_add is the documented rendering)."""
+        timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
+        count_sql: str = self.build_expression_sql(add_interval.count_expression)
+        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
+        return f"date_add('{unit_name}', {count_sql}, {timestamp_sql})"
+
+    def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
+        """The base WITHIN GROUP form is not accepted by the Trino-based
+        Athena engine; v3 rendered approx_percentile(expr, p)
+        (v3 athena_data_source.py:256-259)."""
+        expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
+        return f"approx_percentile({expression_sql}, {percentile_within_group.percentile})"
 
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -89,3 +89,54 @@ class TestCollapseAthenaPrefixes:
             "s3tablescatalog/a/b",
             "my_schema",
         )
+
+
+# ---------------------------------------------------------------------------
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036). Athena engine
+# v3 is Trino-based (https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html):
+# seconds date_diff divided by the float seconds-per-interval (v3
+# athena_data_source.py:269-273) with the v3-trino int cast added (date_add's
+# value argument must be integer-typed); date_add with lowercase unit names.
+# ---------------------------------------------------------------------------
+
+
+def test_time_delta_renders_date_diff_seconds_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = AthenaSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr('"ts"'), "days", 1)
+    )
+    assert sql == (
+        "cast(floor(date_diff('second', From_iso8601_timestamp('2020-06-20T00:00:00'), (\"ts\")) / 86400.0) as int)"
+    )
+
+
+def test_add_interval_renders_date_add_lowercase_unit():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = AthenaSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "date_add('day', ((soda_partition__ + 1) * 1), From_iso8601_timestamp('2020-06-20T00:00:00'))"
+
+
+# ---------------------------------------------------------------------------
+# PERCENTILE_WITHIN_GROUP — the base WITHIN GROUP form is not accepted by the
+# Trino-based Athena engine; v3 rendered approx_percentile(expr, p)
+# (athena_data_source.py:256-259).
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_within_group_renders_approx_percentile():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = AthenaSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.5))
+    assert sql == 'approx_percentile("c", 0.5)'
+
+
+def test_supports_percentile_within_group_is_true():
+    assert AthenaSqlDialect().supports_percentile_within_group() is True

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -92,11 +92,11 @@ class TestCollapseAthenaPrefixes:
 
 
 # ---------------------------------------------------------------------------
-# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036). Athena engine
-# v3 is Trino-based (https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html):
-# seconds date_diff divided by the float seconds-per-interval (v3
-# athena_data_source.py:269-273) with the v3-trino int cast added (date_add's
-# value argument must be integer-typed); date_add with lowercase unit names.
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes. Athena engine v3 is
+# Trino-based (https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html):
+# seconds date_diff divided by the float seconds-per-interval, cast to int
+# (date_add's value argument must be integer-typed); date_add with lowercase
+# unit names.
 # ---------------------------------------------------------------------------
 
 
@@ -149,9 +149,8 @@ def test_add_interval_weeks_unit_name():
 
 
 # ---------------------------------------------------------------------------
-# PERCENTILE_WITHIN_GROUP — the base WITHIN GROUP form is not accepted by the
-# Trino-based Athena engine; v3 rendered approx_percentile(expr, p)
-# (athena_data_source.py:256-259).
+# PERCENTILE_WITHIN_GROUP — the Trino-based Athena engine does not accept the
+# base WITHIN GROUP form; approx_percentile(expr, p) is its aggregate.
 # ---------------------------------------------------------------------------
 
 

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -113,6 +113,19 @@ def test_time_delta_renders_date_diff_seconds_form():
     )
 
 
+def test_time_delta_date_diff_count_2_hours():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = AthenaSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr('"ts"'), "hours", 2)
+    )
+    assert sql == (
+        "cast(floor(date_diff('second', From_iso8601_timestamp('2020-06-20T00:00:00'), (\"ts\")) / 7200.0) as int)"
+    )
+
+
 def test_add_interval_renders_date_add_lowercase_unit():
     from datetime import datetime
 
@@ -122,6 +135,17 @@ def test_add_interval_renders_date_add_lowercase_unit():
         ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
     )
     assert sql == "date_add('day', ((soda_partition__ + 1) * 1), From_iso8601_timestamp('2020-06-20T00:00:00'))"
+
+
+def test_add_interval_weeks_unit_name():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = AthenaSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "date_add('week', ((soda_partition__ + 1) * 1), From_iso8601_timestamp('2020-06-20T00:00:00'))"
 
 
 # ---------------------------------------------------------------------------

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -384,12 +384,11 @@ class SqlDialect:
         return self.literal_datetime(datetime)
 
     def literal_timestamp_typed(self, dt: datetime) -> str:
-        """Typed timestamp literal for use INSIDE timestamp arithmetic
+        """Typed timestamp literal for use inside timestamp arithmetic
         (TIME_DELTA / ADD_INTERVAL operands), where some engines refuse a bare
-        string literal (duckdb in particular). Base form = v3's
-        ``sql_time_filter_to_timestamp`` (v3 data_source.py:1524-1529),
-        incl. the sub-second truncation. Not a replacement for
-        ``literal_datetime``, which renders comparison literals.
+        string literal (duckdb in particular). Truncates sub-second precision.
+        Not a replacement for ``literal_datetime``, which renders comparison
+        literals.
         """
         return f"TIMESTAMP '{dt.strftime('%Y-%m-%d %H:%M:%S')}'"
 
@@ -1080,8 +1079,7 @@ class SqlDialect:
 
     def supports_percentile_within_group(self) -> bool:
         """False when the engine has no percentile aggregate at all — exact or
-        approximate (Synapse: v3 synapse_data_source.py:56-58 warned and
-        returned a dummy 1). Consumers skip the Q1/median/Q3 metrics instead
+        approximate (Synapse). Consumers skip the Q1/median/Q3 metrics instead
         of rendering PERCENTILE_WITHIN_GROUP.
         """
         return True
@@ -1526,7 +1524,7 @@ class SqlDialect:
         """NaN-exclusion predicate for float aggregates, or None when the
         engine needs no filter (base). Spark/Databricks store IEEE NaN in
         float/double columns and propagate it into aggregate results, so they
-        return ``NOT ISNAN({expr})`` (v3 spark_data_source.py:427-488).
+        return ``NOT ISNAN({expr})``.
         """
         return None
 

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -383,6 +383,16 @@ class SqlDialect:
         # See Fabric for an example
         return self.literal_datetime(datetime)
 
+    def literal_timestamp_typed(self, dt: datetime) -> str:
+        """Typed timestamp literal for use INSIDE timestamp arithmetic
+        (TIME_DELTA / ADD_INTERVAL operands), where some engines refuse a bare
+        string literal (duckdb in particular). Base form = v3's
+        ``sql_time_filter_to_timestamp`` (v3 data_source.py:1524-1529),
+        incl. the sub-second truncation. Not a replacement for
+        ``literal_datetime``, which renders comparison literals.
+        """
+        return f"TIMESTAMP '{dt.strftime('%Y-%m-%d %H:%M:%S')}'"
+
     def literal_boolean(self, boolean: bool):
         return "TRUE" if boolean is True else "FALSE"
 
@@ -1068,6 +1078,14 @@ class SqlDialect:
         over_sql: str = " ".join(over_clauses)
         return f"{wf.name}({args_list_sql}) OVER ({over_sql})"
 
+    def supports_percentile_within_group(self) -> bool:
+        """False when the engine has no percentile aggregate at all — exact or
+        approximate (Synapse: v3 synapse_data_source.py:56-58 warned and
+        returned a dummy 1). Consumers skip the Q1/median/Q3 metrics instead
+        of rendering PERCENTILE_WITHIN_GROUP.
+        """
+        return True
+
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """Ordered-set aggregate; valid on postgres/duckdb/snowflake. BigQuery
         overrides with APPROX_QUANTILES."""
@@ -1503,6 +1521,14 @@ class SqlDialect:
         temporal column types themselves. See BigQuerySqlDialect for the exception.
         """
         return expr
+
+    def sql_expr_is_not_nan(self, expr: str) -> Optional[str]:
+        """NaN-exclusion predicate for float aggregates, or None when the
+        engine needs no filter (base). Spark/Databricks store IEEE NaN in
+        float/double columns and propagate it into aggregate results, so they
+        return ``NOT ISNAN({expr})`` (v3 spark_data_source.py:427-488).
+        """
+        return None
 
     def supports_regex_advanced(self) -> bool:
         return True  # Default to true, but specific dialects can override to false

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from abc import abstractmethod
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from numbers import Number
 from textwrap import indent
 from typing import Any, ClassVar, Optional, Tuple
@@ -383,6 +383,19 @@ class SqlDialect:
         # See Fabric for an example
         return self.literal_datetime(datetime)
 
+    @staticmethod
+    def _typed_timestamp_str(dt: datetime) -> str:
+        """Render the wall-clock string for a typed timestamp literal, in UTC.
+
+        A tz-aware datetime is normalized to UTC first (``strftime`` alone drops
+        tzinfo and would emit local wall-clock against a UTC-typed column). A
+        naive datetime is assumed to already be UTC and rendered as-is.
+        Sub-second precision is truncated.
+        """
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+
     def literal_timestamp_typed(self, dt: datetime) -> str:
         """Typed timestamp literal for use inside timestamp arithmetic
         (TIME_DELTA / ADD_INTERVAL operands), where some engines refuse a bare
@@ -390,7 +403,7 @@ class SqlDialect:
         Not a replacement for ``literal_datetime``, which renders comparison
         literals.
         """
-        return f"TIMESTAMP '{dt.strftime('%Y-%m-%d %H:%M:%S')}'"
+        return f"TIMESTAMP '{self._typed_timestamp_str(dt)}'"
 
     def literal_boolean(self, boolean: bool):
         return "TRUE" if boolean is True else "FALSE"

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -13,10 +13,13 @@ from soda_core.common.metadata_types import (
     SodaDataTypeName,
 )
 from soda_core.common.sql_ast import (
+    ADD_INTERVAL,
     ALTER_TABLE_ADD_COLUMN,
     ALTER_TABLE_DROP_COLUMN,
     CREATE_TABLE_COLUMN,
     RANDOM,
+    TIME_DELTA,
+    seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
@@ -129,6 +132,44 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
             return f"TABLESAMPLE ({sample_size} PERCENT)"
         else:
             raise ValueError(f"Unsupported sampler type: {sampler_type.name}")
+
+    # Singular unit names for DATEDIFF/TIMESTAMPADD (v3 used ``TimeUnit.name``,
+    # spark_data_source.py:1154-1156).
+    _TIME_BUCKET_UNIT_NAMES: dict = {
+        "weeks": "WEEK",
+        "days": "DAY",
+        "hours": "HOUR",
+        "seconds": "SECOND",
+    }
+
+    def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
+        """Spark DATEDIFF(unit, ...) counts crossed boundaries of the given
+        unit, so v3 computes in SECONDS and divides by the int seconds-per-
+        interval (v3 spark_data_source.py:1158-1161) — kept verbatim. The
+        3-arg DATEDIFF is the documented TIMESTAMPDIFF synonym on Databricks
+        (DBR 10.4+) and OSS Spark 3.3+ (SPARK-38389)."""
+        start_sql: str = self.build_expression_sql(time_delta.start)
+        end_sql: str = self.build_expression_sql(time_delta.end)
+        sec_per_interval: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)
+        return f"FLOOR(DATEDIFF(SECOND, {start_sql}, {end_sql}) / {sec_per_interval})"
+
+    def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
+        """TIMESTAMPADD(UNIT, count, ts) — documented on Databricks (DBR
+        10.4+) and OSS Spark 3.3+ (SPARK-38195). Deviation from v3, which
+        inherited the base ``ts + INTERVAL '1 {unit}' * n`` form
+        (data_source.py:1305-1307): Spark parses the plural-unit string
+        literal as a legacy CalendarInterval, so the explicit function form
+        is the safe documented rendering."""
+        timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
+        count_sql: str = self.build_expression_sql(add_interval.count_expression)
+        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
+        return f"TIMESTAMPADD({unit_name}, {count_sql}, {timestamp_sql})"
+
+    def sql_expr_is_not_nan(self, expr: str) -> Optional[str]:
+        """Spark stores IEEE NaN in float/double columns and propagates it
+        into aggregates; v3 filtered with NOT ISNAN (v3
+        spark_data_source.py:427-488)."""
+        return f"NOT ISNAN({expr})"
 
     def column_data_type(self) -> str:
         return self.default_casify("data_type")

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -133,8 +133,7 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
         else:
             raise ValueError(f"Unsupported sampler type: {sampler_type.name}")
 
-    # Singular unit names for DATEDIFF/TIMESTAMPADD (v3 used ``TimeUnit.name``,
-    # spark_data_source.py:1154-1156).
+    # Singular unit names for DATEDIFF/TIMESTAMPADD.
     _TIME_BUCKET_UNIT_NAMES: dict = {
         "weeks": "WEEK",
         "days": "DAY",
@@ -144,10 +143,9 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
 
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
         """Spark DATEDIFF(unit, ...) counts crossed boundaries of the given
-        unit, so v3 computes in SECONDS and divides by the int seconds-per-
-        interval (v3 spark_data_source.py:1158-1161) — kept verbatim. The
-        3-arg DATEDIFF is the documented TIMESTAMPDIFF synonym on Databricks
-        (DBR 10.4+) and OSS Spark 3.3+ (SPARK-38389)."""
+        unit, so compute in SECONDS and divide by the seconds-per-interval.
+        The 3-arg DATEDIFF is the documented TIMESTAMPDIFF synonym on
+        Databricks (DBR 10.4+) and OSS Spark 3.3+ (SPARK-38389)."""
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         sec_per_interval: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)
@@ -155,11 +153,9 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
         """TIMESTAMPADD(UNIT, count, ts) — documented on Databricks (DBR
-        10.4+) and OSS Spark 3.3+ (SPARK-38195). Deviation from v3, which
-        inherited the base ``ts + INTERVAL '1 {unit}' * n`` form
-        (data_source.py:1305-1307): Spark parses the plural-unit string
-        literal as a legacy CalendarInterval, so the explicit function form
-        is the safe documented rendering."""
+        10.4+) and OSS Spark 3.3+ (SPARK-38195) — rather than the base
+        ``ts + INTERVAL '1 {unit}' * n`` form: Spark parses the plural-unit
+        string literal as a legacy CalendarInterval."""
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
@@ -167,8 +163,7 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
 
     def sql_expr_is_not_nan(self, expr: str) -> Optional[str]:
         """Spark stores IEEE NaN in float/double columns and propagates it
-        into aggregates; v3 filtered with NOT ISNAN (v3
-        spark_data_source.py:427-488)."""
+        into aggregates; filter with NOT ISNAN."""
         return f"NOT ISNAN({expr})"
 
     def column_data_type(self) -> str:

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -118,3 +118,86 @@ def test_drop_table_does_not_emit_cascade():
     sql_dialect = DatabricksSqlDialect()
     sql = sql_dialect.build_drop_table_sql(DROP_TABLE(fully_qualified_table_name="`c`.`s`.`t`", cascade=True))
     assert "CASCADE" not in sql
+
+
+# ---------------------------------------------------------------------------
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036).
+# v3 spark form: DATEDIFF(unit, ...) counts crossed boundaries, so v3 computes
+# in SECONDS and divides by the int seconds-per-interval
+# (spark_data_source.py:1158-1161). 3-arg DATEDIFF and TIMESTAMPADD are
+# documented on Databricks (DBR 10.4+) and OSS Spark 3.3+
+# (SPARK-38389 / SPARK-38195).
+# ---------------------------------------------------------------------------
+
+
+def test_time_delta_renders_datediff_seconds_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = DatabricksSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "days", 1)
+    )
+    assert sql == "FLOOR(DATEDIFF(SECOND, '2020-06-20T00:00:00', (`ts`)) / 86400)"
+
+
+def test_time_delta_datediff_count_2_hours():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = DatabricksSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "hours", 2)
+    )
+    assert sql == "FLOOR(DATEDIFF(SECOND, '2020-06-20T00:00:00', (`ts`)) / 7200)"
+
+
+def test_add_interval_renders_timestampadd_singular_unit():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = DatabricksSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "TIMESTAMPADD(DAY, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00')"
+
+
+def test_add_interval_weeks_unit_name():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = DatabricksSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "TIMESTAMPADD(WEEK, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00')"
+
+
+# ---------------------------------------------------------------------------
+# PERCENTILE_WITHIN_GROUP — Databricks supports the base ordered-set form
+# percentile_disc(p) WITHIN GROUP (ORDER BY expr) since DBR 11.3
+# (https://docs.databricks.com/en/sql/language-manual/functions/percentile_disc.html),
+# so there is deliberately NO override; this pins the inherited rendering.
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_within_group_inherits_base_within_group_form():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = DatabricksSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.25))
+    assert sql == "PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY `c`)"
+
+
+def test_supports_percentile_within_group_is_true():
+    assert DatabricksSqlDialect().supports_percentile_within_group() is True
+
+
+# ---------------------------------------------------------------------------
+# sql_expr_is_not_nan — Spark stores IEEE NaN in float/double columns and
+# propagates it into aggregates (v3 spark_data_source.py:427-488).
+# ---------------------------------------------------------------------------
+
+
+def test_sql_expr_is_not_nan_renders_not_isnan():
+    assert DatabricksSqlDialect().sql_expr_is_not_nan("`c`") == "NOT ISNAN(`c`)"

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -121,11 +121,10 @@ def test_drop_table_does_not_emit_cascade():
 
 
 # ---------------------------------------------------------------------------
-# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036).
-# v3 spark form: DATEDIFF(unit, ...) counts crossed boundaries, so v3 computes
-# in SECONDS and divides by the int seconds-per-interval
-# (spark_data_source.py:1158-1161). 3-arg DATEDIFF and TIMESTAMPADD are
-# documented on Databricks (DBR 10.4+) and OSS Spark 3.3+
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes.
+# Spark DATEDIFF(unit, ...) counts crossed boundaries, so the dialect computes
+# in SECONDS and divides by the seconds-per-interval. 3-arg DATEDIFF and
+# TIMESTAMPADD are documented on Databricks (DBR 10.4+) and OSS Spark 3.3+
 # (SPARK-38389 / SPARK-38195).
 # ---------------------------------------------------------------------------
 
@@ -195,7 +194,7 @@ def test_supports_percentile_within_group_is_true():
 
 # ---------------------------------------------------------------------------
 # sql_expr_is_not_nan — Spark stores IEEE NaN in float/double columns and
-# propagates it into aggregates (v3 spark_data_source.py:427-488).
+# propagates it into aggregates.
 # ---------------------------------------------------------------------------
 
 

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -56,6 +56,11 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
         # which discovery includes.
         return schema_name.lower() in ["sys", "queryinsights"] or super().is_system_schema(schema_name)
 
+    def supports_percentile_within_group(self) -> bool:
+        # The Fabric Warehouse engine always supports the APPROX_PERCENTILE_DISC
+        # aggregate, so pin the capability and ignore the SQL-Server-version probe.
+        return True
+
     def sql_expr_timestamp_truncate_day(self, timestamp_literal: str) -> str:
         return f"DATETIMEFROMPARTS((datepart(YEAR, {timestamp_literal})), (datepart(MONTH, {timestamp_literal})), (datepart(DAY, {timestamp_literal})), 0, 0, 0, 0)"
 

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -58,7 +58,7 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
 
     def supports_percentile_within_group(self) -> bool:
         # The Fabric Warehouse engine always supports the APPROX_PERCENTILE_DISC
-        # aggregate, so pin the capability and ignore the SQL-Server-version probe.
+        # aggregate, so pin the capability regardless of any synced server facts.
         return True
 
     def sql_expr_timestamp_truncate_day(self, timestamp_literal: str) -> str:

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -76,3 +76,45 @@ def test_is_system_schema():
     assert dialect.is_system_schema("SYS") is True
     assert dialect.is_system_schema("queryinsights") is True
     assert dialect.is_system_schema("dbo") is False
+
+
+def test_time_delta_inherits_sqlserver_datediff_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = FabricSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
+    )
+    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+
+
+def test_add_interval_inherits_sqlserver_dateadd_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = FabricSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "DATEADD(DAY, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00.000')"
+
+
+def test_percentile_within_group_inherits_approx_percentile_disc():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = FabricSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.5))
+    assert sql == "APPROX_PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY [c])"
+
+
+def test_supports_percentile_within_group_is_true():
+    assert FabricSqlDialect().supports_percentile_within_group() is True
+
+
+def test_literal_timestamp_typed_inherits_datetime2_cast():
+    from datetime import datetime
+
+    assert (
+        FabricSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 1, 2, 3))
+        == "CAST('2020-06-20 01:02:03' AS DATETIME2)"
+    )

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -111,11 +111,12 @@ def test_supports_percentile_within_group_is_true():
     assert FabricSqlDialect().supports_percentile_within_group() is True
 
 
-def test_supports_percentile_within_group_pinned_true_ignores_probe():
+def test_supports_percentile_within_group_pinned_true_ignores_server_facts():
     # The Fabric engine always supports APPROX_PERCENTILE_DISC, so it pins the
-    # capability and ignores the SQL-Server-version probe seam entirely.
+    # capability even when synced server facts would gate plain SQL Server.
     dialect = FabricSqlDialect()
-    dialect.set_approx_percentile_disc_supported(False)
+    dialect.server_major_version = 15
+    dialect.engine_edition = 3
     assert dialect.supports_percentile_within_group() is True
 
 

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -86,7 +86,7 @@ def test_time_delta_inherits_sqlserver_datediff_form():
     sql = FabricSqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
     )
-    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+    assert sql == "(DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400)"
 
 
 def test_add_interval_inherits_sqlserver_dateadd_form():

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -112,8 +112,6 @@ def test_supports_percentile_within_group_is_true():
 
 
 def test_supports_percentile_within_group_pinned_true_ignores_server_facts():
-    # The Fabric engine always supports APPROX_PERCENTILE_DISC, so it pins the
-    # capability even when synced server facts would gate plain SQL Server.
     dialect = FabricSqlDialect()
     dialect.server_major_version = 15
     dialect.engine_edition = 3

--- a/soda-fabric/tests/unit/test_fabric_dialect.py
+++ b/soda-fabric/tests/unit/test_fabric_dialect.py
@@ -111,6 +111,14 @@ def test_supports_percentile_within_group_is_true():
     assert FabricSqlDialect().supports_percentile_within_group() is True
 
 
+def test_supports_percentile_within_group_pinned_true_ignores_probe():
+    # The Fabric engine always supports APPROX_PERCENTILE_DISC, so it pins the
+    # capability and ignores the SQL-Server-version probe seam entirely.
+    dialect = FabricSqlDialect()
+    dialect.set_approx_percentile_disc_supported(False)
+    assert dialect.supports_percentile_within_group() is True
+
+
 def test_literal_timestamp_typed_inherits_datetime2_cast():
     from datetime import datetime
 

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -211,19 +211,17 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
     def supports_materialized_views(self) -> bool:
         return True
 
-    # TIME_DELTA / ADD_INTERVAL deliberately have NO overrides: the base
-    # epoch-floor TIME_DELTA form IS v3's redshift override byte-for-byte
-    # (v3 redshift_data_source.py:287-290), and v3 redshift shipped the base
-    # interval-multiply ADD_INTERVAL form unchanged (Redshift supports
-    # interval-literal arithmetic incl. plural units and interval * numeric,
-    # https://docs.aws.amazon.com/redshift/latest/dg/r_interval_data_types.html).
+    # TIME_DELTA / ADD_INTERVAL deliberately have NO overrides: Redshift
+    # supports both the base epoch-floor form and interval-literal arithmetic
+    # incl. plural units and interval * numeric
+    # (https://docs.aws.amazon.com/redshift/latest/dg/r_interval_data_types.html).
     # Both are pinned in tests/unit/test_redshift_dialect.py.
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """Redshift restricts exact PERCENTILE_DISC (leader-node/window-only
-        limitations); v3 rendered the documented approximate aggregate
-        APPROXIMATE PERCENTILE_DISC (v3 redshift_data_source.py:224-225,
-        https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html)."""
+        limitations); render the documented approximate aggregate
+        APPROXIMATE PERCENTILE_DISC
+        (https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html)."""
         expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
         return (
             f"APPROXIMATE PERCENTILE_DISC({percentile_within_group.percentile}) "

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -19,7 +19,6 @@ from soda_core.common.sql_ast import (
 )
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
-
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSource as RedshiftDataSourceModel,
 )

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -12,12 +12,14 @@ from soda_core.common.sql_ast import (
     COUNT,
     DISTINCT,
     FROM,
+    PERCENTILE_WITHIN_GROUP,
     REGEX_LIKE,
     TUPLE,
     VALUES,
 )
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
+
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSource as RedshiftDataSourceModel,
 )
@@ -209,6 +211,25 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
 
     def supports_materialized_views(self) -> bool:
         return True
+
+    # TIME_DELTA / ADD_INTERVAL deliberately have NO overrides: the base
+    # epoch-floor TIME_DELTA form IS v3's redshift override byte-for-byte
+    # (v3 redshift_data_source.py:287-290), and v3 redshift shipped the base
+    # interval-multiply ADD_INTERVAL form unchanged (Redshift supports
+    # interval-literal arithmetic incl. plural units and interval * numeric,
+    # https://docs.aws.amazon.com/redshift/latest/dg/r_interval_data_types.html).
+    # Both are pinned in tests/unit/test_redshift_dialect.py.
+
+    def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
+        """Redshift restricts exact PERCENTILE_DISC (leader-node/window-only
+        limitations); v3 rendered the documented approximate aggregate
+        APPROXIMATE PERCENTILE_DISC (v3 redshift_data_source.py:224-225,
+        https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html)."""
+        expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
+        return (
+            f"APPROXIMATE PERCENTILE_DISC({percentile_within_group.percentile}) "
+            f"WITHIN GROUP (ORDER BY {expression_sql})"
+        )
 
     def table_columns(self) -> str:
         return self.default_casify("svv_columns")

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -1,5 +1,6 @@
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+
 from soda_redshift.common.data_sources.redshift_data_source import RedshiftSqlDialect
 
 
@@ -44,3 +45,36 @@ def test_is_system_schema():
     assert sql_dialect.is_system_schema("PG_AUTOMV") is True
     assert sql_dialect.is_system_schema("information_schema") is True
     assert sql_dialect.is_system_schema("public") is False
+
+
+def test_time_delta_inherits_base_epoch_floor_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = RedshiftSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr('"ts"'), "days", 1)
+    )
+    assert sql == "FLOOR(EXTRACT(EPOCH FROM (\"ts\") - '2020-06-20T00:00:00') / 86400)"
+
+
+def test_add_interval_inherits_base_interval_multiply_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = RedshiftSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "'2020-06-20T00:00:00' + INTERVAL '1 days' * ((soda_partition__ + 1) * 1)"
+
+
+def test_percentile_within_group_renders_approximate_percentile_disc():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = RedshiftSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.75))
+    assert sql == 'APPROXIMATE PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY "c")'
+
+
+def test_supports_percentile_within_group_is_true():
+    assert RedshiftSqlDialect().supports_percentile_within_group() is True

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -1,6 +1,5 @@
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
-
 from soda_redshift.common.data_sources.redshift_data_source import RedshiftSqlDialect
 
 

--- a/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
@@ -57,7 +57,7 @@ def test_drop_table_cascade_enabled_in_catalog_mode():
 
 
 # ---------------------------------------------------------------------------
-# Time-bucket / percentile / NaN seams (OBSL-1036) — all inherited from
+# Time-bucket / percentile / NaN seams — all inherited from
 # DatabricksSqlDialect (3-arg DATEDIFF, TIMESTAMPADD and percentile_disc
 # WITHIN GROUP are OSS Spark 3.3/3.4+ syntax too: SPARK-38389, SPARK-38195).
 # Pins the inheritance against accidental regressions.

--- a/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
@@ -54,3 +54,43 @@ def test_drop_table_cascade_enabled_in_catalog_mode():
     # DROP TABLE ... CASCADE. The dialect promotes the class default to True per-instance.
     dialect = SparkDataFrameSqlDialect(use_catalog=True)
     assert dialect.SUPPORTS_DROP_TABLE_CASCADE is True
+
+
+# ---------------------------------------------------------------------------
+# Time-bucket / percentile / NaN seams (OBSL-1036) — all inherited from
+# DatabricksSqlDialect (3-arg DATEDIFF, TIMESTAMPADD and percentile_disc
+# WITHIN GROUP are OSS Spark 3.3/3.4+ syntax too: SPARK-38389, SPARK-38195).
+# Pins the inheritance against accidental regressions.
+# ---------------------------------------------------------------------------
+
+
+def test_time_delta_inherits_databricks_datediff_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = SparkDataFrameSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "days", 1)
+    )
+    # SparkDf's literal_datetime wraps in to_utc_timestamp(...) — the DATEDIFF
+    # shape itself is the inherited Databricks form.
+    assert sql == "FLOOR(DATEDIFF(SECOND, to_utc_timestamp('2020-06-20T00:00:00', 'UTC'), (`ts`)) / 86400)"
+
+
+def test_add_interval_inherits_databricks_timestampadd_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = SparkDataFrameSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "TIMESTAMPADD(DAY, ((soda_partition__ + 1) * 1), to_utc_timestamp('2020-06-20T00:00:00', 'UTC'))"
+
+
+def test_sql_expr_is_not_nan_inherits_not_isnan():
+    assert SparkDataFrameSqlDialect().sql_expr_is_not_nan("`c`") == "NOT ISNAN(`c`)"
+
+
+def test_supports_percentile_within_group_is_true():
+    assert SparkDataFrameSqlDialect().supports_percentile_within_group() is True

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -201,7 +201,17 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         """T-SQL DATEDIFF counts crossed boundaries of the given unit, so v3
         computes the difference in SECONDS and divides by the int seconds-per-
         interval (v3 sqlserver_data_source.py:710-716) — kept verbatim, incl.
-        the truncating T-SQL int/int division (== FLOOR for positive deltas)."""
+        the truncating T-SQL int/int division.
+
+        Caller precondition: deltas must be non-negative — truncation toward
+        zero equals the FLOOR of every other dialect only for deltas >= 0.
+        The MM bulk query guarantees this by filtering rows to
+        ``ts >= anchor`` before bucketing; a consumer relying on negative
+        bucket indices would misbucket on the T-SQL family only.
+
+        DATEDIFF(second, ...) returns int and overflows for spans > ~68
+        years; DATEDIFF_BIG is the escape hatch if that ever bites (not
+        switched now: v3 parity)."""
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         multiplier: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -68,10 +68,61 @@ class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
+    def open_connection(self) -> None:
+        super().open_connection()
+        # Only the plain SQL Server dialect needs a runtime capability probe;
+        # Fabric/Synapse pin their percentile support in the dialect itself.
+        if type(self.sql_dialect) is SqlServerSqlDialect:
+            self.sql_dialect.set_approx_percentile_disc_supported(self._probe_approx_percentile_disc_support())
+
+    def _probe_approx_percentile_disc_support(self) -> bool:
+        try:
+            row = self.execute_query(
+                "SELECT CAST(SERVERPROPERTY('ProductMajorVersion') AS INT), "
+                "CAST(SERVERPROPERTY('EngineEdition') AS INT)",
+                log_query=False,
+            ).rows[0]
+            return self._engine_supports_approx_percentile_disc(row[0], row[1])
+        except Exception as e:
+            # Never fail a scan over a capability probe; fall back to assuming
+            # support (v3 behavior) and let the actual query surface any error.
+            logger.warning(f"Could not probe SQL Server APPROX_PERCENTILE_DISC support: {e}")
+            return True
+
+    @staticmethod
+    def _engine_supports_approx_percentile_disc(
+        major_version: Optional[int], engine_edition: Optional[int]
+    ) -> bool:
+        # APPROX_PERCENTILE_DISC aggregate is available on SQL Server 2022+
+        # (ProductMajorVersion >= 16) and on Azure SQL Database (EngineEdition 5)
+        # and Azure SQL Managed Instance (EngineEdition 8), which report a legacy
+        # ProductMajorVersion. Synapse dedicated pools (6) are handled by the
+        # Synapse dialect, which pins support to False.
+        return (major_version is not None and major_version >= 16) or engine_edition in (5, 8)
+
 
 class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
     DEFAULT_QUOTE_CHAR = "["  # Do not use this! Always use quote_default()
     SODA_DATA_TYPE_SYNONYMS = ((SodaDataTypeName.TEXT, SodaDataTypeName.VARCHAR),)
+
+    def __init__(self):
+        super().__init__()
+        # None until the data source probes the engine on connect; see
+        # SqlServerDataSourceImpl._probe_approx_percentile_disc_support.
+        self._approx_percentile_disc_supported: Optional[bool] = None
+
+    def supports_percentile_within_group(self) -> bool:
+        # T-SQL exposes percentiles as an aggregate only via APPROX_PERCENTILE_DISC,
+        # which requires SQL Server 2022+ (ProductMajorVersion >= 16) or Azure SQL
+        # Database / Managed Instance. The capability is probed on connect and
+        # injected here; when unprobed (pure SQL rendering with no live connection)
+        # we assume support so rendering-only paths are unaffected.
+        if self._approx_percentile_disc_supported is None:
+            return True
+        return self._approx_percentile_disc_supported
+
+    def set_approx_percentile_disc_supported(self, supported: bool) -> None:
+        self._approx_percentile_disc_supported = supported
 
     def build_select_sql(self, select_elements: list, add_semicolon: bool = True) -> str:
         statement_lines: list[str] = []

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -56,9 +56,19 @@ from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import 
 logger: logging.Logger = soda_logger
 
 
+# APPROX_PERCENTILE_DISC needs SQL Server 2022+ on-prem, or Azure SQL Database /
+# Managed Instance (which report a legacy ProductMajorVersion).
+SQLSERVER_2022_MAJOR_VERSION = 16
+AZURE_SQL_DATABASE_ENGINE_EDITION = 5
+AZURE_SQL_MANAGED_INSTANCE_ENGINE_EDITION = 8
+
+
 class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceModel):
     def __init__(self, data_source_model: SqlServerDataSourceModel, connection: Optional[DataSourceConnection] = None):
         super().__init__(data_source_model=data_source_model, connection=connection)
+        # A live connection supplied at construction (e.g. a bulk-insert copy)
+        # already carries detected server facts; propagate them right away.
+        self._sync_dialect_server_info()
 
     def _create_sql_dialect(self) -> SqlDialect:
         return SqlServerSqlDialect()
@@ -70,35 +80,32 @@ class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceMod
 
     def open_connection(self) -> None:
         super().open_connection()
-        # Only the plain SQL Server dialect needs a runtime capability probe;
-        # Fabric/Synapse pin their percentile support in the dialect itself.
-        if type(self.sql_dialect) is SqlServerSqlDialect:
-            self.sql_dialect.set_approx_percentile_disc_supported(self._probe_approx_percentile_disc_support())
+        self._sync_dialect_server_info()
 
-    def _probe_approx_percentile_disc_support(self) -> bool:
-        try:
-            row = self.execute_query(
-                "SELECT CAST(SERVERPROPERTY('ProductMajorVersion') AS INT), "
-                "CAST(SERVERPROPERTY('EngineEdition') AS INT)",
-                log_query=False,
-            ).rows[0]
-            return self._engine_supports_approx_percentile_disc(row[0], row[1])
-        except Exception as e:
-            # Never fail a scan over a capability probe; fall back to assuming
-            # support (v3 behavior) and let the actual query surface any error.
-            logger.warning(f"Could not probe SQL Server APPROX_PERCENTILE_DISC support: {e}")
-            return True
+    def _sync_dialect_server_info(self) -> None:
+        """Copy the connection's detected engine facts onto the dialect, which
+        derives version-dependent capabilities from them (see
+        SqlServerSqlDialect.supports_percentile_within_group).
 
-    @staticmethod
-    def _engine_supports_approx_percentile_disc(
-        major_version: Optional[int], engine_edition: Optional[int]
-    ) -> bool:
-        # APPROX_PERCENTILE_DISC aggregate is available on SQL Server 2022+
-        # (ProductMajorVersion >= 16) and on Azure SQL Database (EngineEdition 5)
-        # and Azure SQL Managed Instance (EngineEdition 8), which report a legacy
-        # ProductMajorVersion. Synapse dedicated pools (6) are handled by the
-        # Synapse dialect, which pins support to False.
-        return (major_version is not None and major_version >= 16) or engine_edition in (5, 8)
+        Runs at connection-open time only; the dialect must NOT read the connection
+        during SQL generation — in snapshot replay the connection is a lazy wrapper
+        whose attribute access opens a real connection, so touching it while
+        building SQL breaks replay.
+
+        Gate on the concrete connection type rather than duck-typing the attributes:
+        a replay SnapshotDataSourceConnection is NOT a SqlServerDataSourceConnection,
+        so isinstance() is False and we never touch its attributes (which would fire
+        its __getattr__ fallback and open a real connection). Replay then keeps the
+        dialect's None defaults (assume newest engine), which is exactly what
+        recorded snapshots expect.
+        """
+        conn = self.data_source_connection
+        if isinstance(conn, SqlServerDataSourceConnection):
+            # Guaranteed by every _create_sql_dialect in this hierarchy; the assert
+            # only narrows the declared SqlDialect type for the assignments.
+            assert isinstance(self.sql_dialect, SqlServerSqlDialect)
+            self.sql_dialect.server_major_version = conn.server_major_version
+            self.sql_dialect.engine_edition = conn.engine_edition
 
 
 class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
@@ -107,22 +114,27 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
 
     def __init__(self):
         super().__init__()
-        # None until the data source probes the engine on connect; see
-        # SqlServerDataSourceImpl._probe_approx_percentile_disc_support.
-        self._approx_percentile_disc_supported: Optional[bool] = None
+        # Raw engine facts, synced from the live connection at open by
+        # SqlServerDataSourceImpl._sync_dialect_server_info. None means no live
+        # server facts (pure SQL rendering, unit tests, snapshot replay);
+        # capability checks then assume the newest engine.
+        self.server_major_version: Optional[int] = None
+        self.engine_edition: Optional[int] = None
 
     def supports_percentile_within_group(self) -> bool:
-        # T-SQL exposes percentiles as an aggregate only via APPROX_PERCENTILE_DISC,
-        # which requires SQL Server 2022+ (ProductMajorVersion >= 16) or Azure SQL
-        # Database / Managed Instance. The capability is probed on connect and
-        # injected here; when unprobed (pure SQL rendering with no live connection)
-        # we assume support so rendering-only paths are unaffected.
-        if self._approx_percentile_disc_supported is None:
-            return True
-        return self._approx_percentile_disc_supported
-
-    def set_approx_percentile_disc_supported(self, supported: bool) -> None:
-        self._approx_percentile_disc_supported = supported
+        # T-SQL exposes percentiles as an aggregate only via APPROX_PERCENTILE_DISC:
+        # SQL Server 2022+ (ProductMajorVersion >= 16), Azure SQL Database, or Azure
+        # SQL Managed Instance (both report a legacy ProductMajorVersion, hence the
+        # edition check). Synapse dedicated pools have no percentile aggregate at
+        # all; the Synapse dialect pins this to False.
+        if self.server_major_version is None and self.engine_edition is None:
+            return True  # no live server facts: assume the newest engine
+        return (
+            self.server_major_version is not None and self.server_major_version >= SQLSERVER_2022_MAJOR_VERSION
+        ) or self.engine_edition in (
+            AZURE_SQL_DATABASE_ENGINE_EDITION,
+            AZURE_SQL_MANAGED_INSTANCE_ENGINE_EDITION,
+        )
 
     def build_select_sql(self, select_elements: list, add_semicolon: bool = True) -> str:
         statement_lines: list[str] = []

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -9,6 +9,7 @@ from soda_core.common.dataset_identifier import DatasetIdentifier
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
+    ADD_INTERVAL,
     AND,
     COLUMN,
     COUNT,
@@ -30,16 +31,19 @@ from soda_core.common.sql_ast import (
     LIMIT,
     OFFSET,
     ORDER_BY_ASC,
+    PERCENTILE_WITHIN_GROUP,
     RANDOM,
     REGEX_LIKE,
     SELECT,
     STAR,
     STRING_HASH,
+    TIME_DELTA,
     TUPLE,
     VALUES,
     WHERE,
     WITH,
     SqlExpressionStr,
+    seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
 from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
@@ -175,6 +179,48 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
 
     def sql_expr_timestamp_add_day(self, timestamp_literal: str) -> str:
         return f"DATEADD(DAY, 1, {timestamp_literal})"
+
+    def literal_timestamp_typed(self, dt: datetime) -> str:
+        """T-SQL has no TIMESTAMP '...' literal (TIMESTAMP is the deprecated
+        rowversion type), so cast the string form to DATETIME2 —
+        https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql.
+        v3 rendered the bare string (v3 sqlserver_data_source.py:699-703); the
+        explicit cast keeps the arithmetic operand typed on every consumer."""
+        return f"CAST('{dt.strftime('%Y-%m-%d %H:%M:%S')}' AS DATETIME2)"
+
+    # Singular unit names for DATEADD (v3 used ``TimeUnit.name``,
+    # sqlserver_data_source.py:706-708).
+    _TIME_BUCKET_UNIT_NAMES: dict = {
+        "weeks": "WEEK",
+        "days": "DAY",
+        "hours": "HOUR",
+        "seconds": "SECOND",
+    }
+
+    def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
+        """T-SQL DATEDIFF counts crossed boundaries of the given unit, so v3
+        computes the difference in SECONDS and divides by the int seconds-per-
+        interval (v3 sqlserver_data_source.py:710-716) — kept verbatim, incl.
+        the truncating T-SQL int/int division (== FLOOR for positive deltas)."""
+        start_sql: str = self.build_expression_sql(time_delta.start)
+        end_sql: str = self.build_expression_sql(time_delta.end)
+        multiplier: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)
+        return f"DATEDIFF(second, {start_sql}, {end_sql}) / {multiplier}"
+
+    def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
+        """v3 sqlserver DATEADD form (v3 sqlserver_data_source.py:725-727)."""
+        timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
+        count_sql: str = self.build_expression_sql(add_interval.count_expression)
+        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
+        return f"DATEADD({unit_name}, {count_sql}, {timestamp_sql})"
+
+    def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
+        """T-SQL PERCENTILE_DISC is a window function only; the aggregate form
+        is APPROX_PERCENTILE_DISC (SQL Server 2022+/Azure SQL/Fabric,
+        https://learn.microsoft.com/en-us/sql/t-sql/functions/approx-percentile-disc-transact-sql)
+        — v3 form kept verbatim (v3 sqlserver_data_source.py:336-337)."""
+        expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
+        return f"APPROX_PERCENTILE_DISC({percentile_within_group.percentile}) WITHIN GROUP (ORDER BY {expression_sql})"
 
     def _build_tuple_sql(self, tuple: TUPLE) -> str:
         if tuple.check_context(COUNT) and tuple.check_context(DISTINCT):

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -185,7 +185,7 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         rowversion type), so cast the string form to DATETIME2 to keep the
         arithmetic operand typed —
         https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql."""
-        return f"CAST('{dt.strftime('%Y-%m-%d %H:%M:%S')}' AS DATETIME2)"
+        return f"CAST('{self._typed_timestamp_str(dt)}' AS DATETIME2)"
 
     # Singular unit names for DATEADD.
     _TIME_BUCKET_UNIT_NAMES: dict = {
@@ -207,7 +207,9 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         multiplier: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)
-        return f"DATEDIFF(second, {start_sql}, {end_sql}) / {multiplier}"
+        # Parenthesized so the form stays self-contained if a caller embeds
+        # TIME_DELTA in larger arithmetic (every other dialect wraps in FLOOR/cast).
+        return f"(DATEDIFF(second, {start_sql}, {end_sql}) / {multiplier})"
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -182,14 +182,12 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
 
     def literal_timestamp_typed(self, dt: datetime) -> str:
         """T-SQL has no TIMESTAMP '...' literal (TIMESTAMP is the deprecated
-        rowversion type), so cast the string form to DATETIME2 —
-        https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql.
-        v3 rendered the bare string (v3 sqlserver_data_source.py:699-703); the
-        explicit cast keeps the arithmetic operand typed on every consumer."""
+        rowversion type), so cast the string form to DATETIME2 to keep the
+        arithmetic operand typed —
+        https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql."""
         return f"CAST('{dt.strftime('%Y-%m-%d %H:%M:%S')}' AS DATETIME2)"
 
-    # Singular unit names for DATEADD (v3 used ``TimeUnit.name``,
-    # sqlserver_data_source.py:706-708).
+    # Singular unit names for DATEADD.
     _TIME_BUCKET_UNIT_NAMES: dict = {
         "weeks": "WEEK",
         "days": "DAY",
@@ -198,27 +196,20 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
     }
 
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
-        """T-SQL DATEDIFF counts crossed boundaries of the given unit, so v3
-        computes the difference in SECONDS and divides by the int seconds-per-
-        interval (v3 sqlserver_data_source.py:710-716) — kept verbatim, incl.
-        the truncating T-SQL int/int division.
-
-        Caller precondition: deltas must be non-negative — truncation toward
-        zero equals the FLOOR of every other dialect only for deltas >= 0.
-        The MM bulk query guarantees this by filtering rows to
-        ``ts >= anchor`` before bucketing; a consumer relying on negative
-        bucket indices would misbucket on the T-SQL family only.
+        """T-SQL DATEDIFF counts crossed boundaries of the given unit, so
+        compute the difference in SECONDS and divide by the seconds-per-
+        interval. T-SQL int/int division truncates toward zero, which equals
+        the FLOOR of the other dialects only for deltas >= 0 — callers must
+        guarantee non-negative deltas (the MM window filter does).
 
         DATEDIFF(second, ...) returns int and overflows for spans > ~68
-        years; DATEDIFF_BIG is the escape hatch if that ever bites (not
-        switched now: v3 parity)."""
+        years; switch to DATEDIFF_BIG if that ever bites."""
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         multiplier: int = seconds_per_time_bucket(time_delta.unit, time_delta.count)
         return f"DATEDIFF(second, {start_sql}, {end_sql}) / {multiplier}"
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
-        """v3 sqlserver DATEADD form (v3 sqlserver_data_source.py:725-727)."""
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
@@ -227,8 +218,7 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """T-SQL PERCENTILE_DISC is a window function only; the aggregate form
         is APPROX_PERCENTILE_DISC (SQL Server 2022+/Azure SQL/Fabric,
-        https://learn.microsoft.com/en-us/sql/t-sql/functions/approx-percentile-disc-transact-sql)
-        — v3 form kept verbatim (v3 sqlserver_data_source.py:336-337)."""
+        https://learn.microsoft.com/en-us/sql/t-sql/functions/approx-percentile-disc-transact-sql)."""
         expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
         return f"APPROX_PERCENTILE_DISC({percentile_within_group.percentile}) WITHIN GROUP (ORDER BY {expression_sql})"
 

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -107,6 +107,10 @@ def handle_datetimeoffset(dto_value):
 
 class SqlServerDataSourceConnection(DataSourceConnection):
     def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
+        # Set before super().__init__(), which auto-opens the connection and
+        # populates these from the live server in _create_connection.
+        self.server_major_version: Optional[int] = None
+        self.engine_edition: Optional[int] = None
         super().__init__(name, connection_properties)
 
     # Normalize pyodbc.Row objects so downstream consumers see plain tuples.
@@ -190,9 +194,42 @@ class SqlServerDataSourceConnection(DataSourceConnection):
 
             self.connection.add_output_converter(-155, handle_datetimeoffset)
             self.connection.add_output_converter(-150, handle_datetime)
+            self._detect_server_info(self.connection)
             return self.connection
         except Exception as e:
             raise DataSourceConnectionException(e) from e
+
+    @staticmethod
+    def _parse_server_major_version(dbms_version: Optional[str]) -> Optional[int]:
+        """Parse the leading integer of an ODBC SQL_DBMS_VER string, e.g. '15.00.4123' -> 15."""
+        if not dbms_version:
+            return None
+        try:
+            return int(str(dbms_version).split(".")[0])
+        except (ValueError, IndexError):
+            return None
+
+    def _detect_server_info(self, connection) -> None:
+        """Detect raw engine facts once per connect; the data source syncs them onto
+        the dialect, which derives version-dependent capabilities from them (e.g.
+        APPROX_PERCENTILE_DISC needs SQL Server 2022+ or Azure SQL DB/MI).
+
+        The product version comes from the driver's login handshake — no extra
+        round-trip; EngineEdition costs one query. Detection is never fatal for an
+        otherwise healthy connect: on failure a warning is logged and the fact stays
+        None, which capability checks treat as "assume the newest engine".
+        """
+        try:
+            self.server_major_version = self._parse_server_major_version(connection.getinfo(pyodbc.SQL_DBMS_VER))
+        except Exception as e:
+            logger.warning(f"Could not determine SQL Server product version: {e}")
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT)")
+                row = cursor.fetchone()
+            self.engine_edition = row[0] if row is not None else None
+        except Exception as e:
+            logger.warning(f"Could not determine SQL Server engine edition: {e}")
 
     def _execute_query_get_result_row_column_name(self, column) -> str:
         return column[0]

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -69,3 +69,92 @@ def test_clamp_skips_non_datetime_types():
     column = CREATE_TABLE_COLUMN(name="age", type=SqlDataType(name="int", datetime_precision=9))
     # The base strip pass zeroes datetime_precision on non-datetime types before render.
     assert dialect._build_create_table_column_type(column) == "int"
+
+
+# ---------------------------------------------------------------------------
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036).
+# v3 sqlserver forms: DATEDIFF counts crossed boundaries of the given unit,
+# so v3 computes in SECONDS and divides by the int seconds-per-interval
+# (sqlserver_data_source.py:710-716); add-interval is DATEADD (:725-727).
+# ---------------------------------------------------------------------------
+
+
+def test_time_delta_renders_datediff_seconds_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = SqlServerSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
+    )
+    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+
+
+def test_time_delta_datediff_count_2_hours():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = SqlServerSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "hours", 2)
+    )
+    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 7200"
+
+
+def test_add_interval_renders_dateadd_singular_unit():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = SqlServerSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "DATEADD(DAY, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00.000')"
+
+
+def test_add_interval_weeks_unit_name():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = SqlServerSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "DATEADD(WEEK, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00.000')"
+
+
+# ---------------------------------------------------------------------------
+# PERCENTILE_WITHIN_GROUP — T-SQL PERCENTILE_DISC is window-only; the
+# aggregate form is APPROX_PERCENTILE_DISC (v3 sqlserver_data_source.py:336-337).
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_within_group_renders_approx_percentile_disc():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = SqlServerSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.25))
+    assert sql == "APPROX_PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY [c])"
+
+
+def test_supports_percentile_within_group_is_true():
+    assert SqlServerSqlDialect().supports_percentile_within_group() is True
+
+
+# ---------------------------------------------------------------------------
+# literal_timestamp_typed — T-SQL has no TIMESTAMP '...' literal (TIMESTAMP is
+# the deprecated rowversion type); CAST(... AS DATETIME2) is the typed form.
+# ---------------------------------------------------------------------------
+
+
+def test_literal_timestamp_typed_casts_to_datetime2():
+    from datetime import datetime
+
+    sql = SqlServerSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 1, 2, 3))
+    assert sql == "CAST('2020-06-20 01:02:03' AS DATETIME2)"
+
+
+def test_literal_timestamp_typed_truncates_sub_seconds():
+    from datetime import datetime
+
+    sql = SqlServerSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 1, 2, 3, 999999))
+    assert sql == "CAST('2020-06-20 01:02:03' AS DATETIME2)"

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -136,8 +136,33 @@ def test_percentile_within_group_renders_approx_percentile_disc():
     assert sql == "APPROX_PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY [c])"
 
 
-def test_supports_percentile_within_group_is_true():
+def test_supports_percentile_within_group_defaults_true_when_unprobed():
+    # A dialect with no live connection (pure SQL rendering) hasn't probed the
+    # engine; it assumes support to preserve rendering behavior.
     assert SqlServerSqlDialect().supports_percentile_within_group() is True
+
+
+def test_supports_percentile_within_group_reflects_injected_capability():
+    # APPROX_PERCENTILE_DISC needs SQL Server 2022+/Azure; the data source probes
+    # the engine on connect and injects the result into the dialect seam.
+    dialect = SqlServerSqlDialect()
+    dialect.set_approx_percentile_disc_supported(False)
+    assert dialect.supports_percentile_within_group() is False
+    dialect.set_approx_percentile_disc_supported(True)
+    assert dialect.supports_percentile_within_group() is True
+
+
+def test_engine_supports_approx_percentile_disc_matrix():
+    from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerDataSourceImpl
+
+    f = SqlServerDataSourceImpl._engine_supports_approx_percentile_disc
+    assert f(16, 3) is True  # SQL Server 2022, Enterprise (on-prem)
+    assert f(17, 2) is True  # future major, Standard
+    assert f(15, 3) is False  # SQL Server 2019 — no aggregate APPROX_PERCENTILE_DISC
+    assert f(12, 5) is True  # Azure SQL Database (reports legacy major 12)
+    assert f(12, 8) is True  # Azure SQL Managed Instance
+    assert f(15, 4) is False  # SQL Server 2019 Express
+    assert f(None, None) is False  # unknown engine — be safe
 
 
 # ---------------------------------------------------------------------------

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -87,7 +87,7 @@ def test_time_delta_renders_datediff_seconds_form():
     sql = SqlServerSqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
     )
-    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+    assert sql == "(DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400)"
 
 
 def test_time_delta_datediff_count_2_hours():
@@ -98,7 +98,7 @@ def test_time_delta_datediff_count_2_hours():
     sql = SqlServerSqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "hours", 2)
     )
-    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 7200"
+    assert sql == "(DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 7200)"
 
 
 def test_add_interval_renders_dateadd_singular_unit():
@@ -157,4 +157,14 @@ def test_literal_timestamp_typed_truncates_sub_seconds():
     from datetime import datetime
 
     sql = SqlServerSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 1, 2, 3, 999999))
+    assert sql == "CAST('2020-06-20 01:02:03' AS DATETIME2)"
+
+
+def test_literal_timestamp_typed_normalizes_tz_aware_to_utc():
+    # A tz-aware non-UTC datetime must render its UTC wall-clock, not local time
+    # with the zone silently dropped.
+    from datetime import datetime, timedelta, timezone
+
+    plus_two = timezone(timedelta(hours=2))
+    sql = SqlServerSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 3, 2, 3, tzinfo=plus_two))
     assert sql == "CAST('2020-06-20 01:02:03' AS DATETIME2)"

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -72,10 +72,10 @@ def test_clamp_skips_non_datetime_types():
 
 
 # ---------------------------------------------------------------------------
-# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes (OBSL-1036).
-# v3 sqlserver forms: DATEDIFF counts crossed boundaries of the given unit,
-# so v3 computes in SECONDS and divides by the int seconds-per-interval
-# (sqlserver_data_source.py:710-716); add-interval is DATEADD (:725-727).
+# TIME_DELTA / ADD_INTERVAL — MM time-bucket nodes.
+# DATEDIFF counts crossed boundaries of the given unit, so the dialect
+# computes in SECONDS and divides by the seconds-per-interval; add-interval
+# is DATEADD.
 # ---------------------------------------------------------------------------
 
 
@@ -125,7 +125,7 @@ def test_add_interval_weeks_unit_name():
 
 # ---------------------------------------------------------------------------
 # PERCENTILE_WITHIN_GROUP — T-SQL PERCENTILE_DISC is window-only; the
-# aggregate form is APPROX_PERCENTILE_DISC (v3 sqlserver_data_source.py:336-337).
+# aggregate form is APPROX_PERCENTILE_DISC.
 # ---------------------------------------------------------------------------
 
 

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -136,35 +136,46 @@ def test_percentile_within_group_renders_approx_percentile_disc():
     assert sql == "APPROX_PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY [c])"
 
 
-def test_supports_percentile_within_group_defaults_true_when_unprobed():
-    # A dialect with no live connection (pure SQL rendering) hasn't probed the
-    # engine; it assumes support to preserve rendering behavior.
+def test_supports_percentile_within_group_defaults_true_without_server_facts():
+    # A dialect with no live connection (pure SQL rendering, snapshot replay) has
+    # no server facts; it assumes the newest engine to preserve rendering behavior.
     assert SqlServerSqlDialect().supports_percentile_within_group() is True
 
 
-def test_supports_percentile_within_group_reflects_injected_capability():
-    # APPROX_PERCENTILE_DISC needs SQL Server 2022+/Azure; the data source probes
-    # the engine on connect and injects the result into the dialect seam.
+def _dialect_with_server_facts(server_major_version, engine_edition) -> SqlServerSqlDialect:
+    # Mimics SqlServerDataSourceImpl._sync_dialect_server_info at connection open.
     dialect = SqlServerSqlDialect()
-    dialect.set_approx_percentile_disc_supported(False)
-    assert dialect.supports_percentile_within_group() is False
-    dialect.set_approx_percentile_disc_supported(True)
-    assert dialect.supports_percentile_within_group() is True
+    dialect.server_major_version = server_major_version
+    dialect.engine_edition = engine_edition
+    return dialect
 
 
-def test_engine_supports_approx_percentile_disc_matrix():
-    from soda_sqlserver.common.data_sources.sqlserver_data_source import (
-        SqlServerDataSourceImpl,
-    )
-
-    f = SqlServerDataSourceImpl._engine_supports_approx_percentile_disc
+def test_supports_percentile_within_group_derived_from_server_facts():
+    # APPROX_PERCENTILE_DISC needs SQL Server 2022+ (ProductMajorVersion >= 16),
+    # Azure SQL Database (EngineEdition 5), or Managed Instance (EngineEdition 8);
+    # the dialect derives the capability from the synced raw facts.
+    f = lambda major, edition: _dialect_with_server_facts(major, edition).supports_percentile_within_group()
     assert f(16, 3) is True  # SQL Server 2022, Enterprise (on-prem)
     assert f(17, 2) is True  # future major, Standard
     assert f(15, 3) is False  # SQL Server 2019 — no aggregate APPROX_PERCENTILE_DISC
     assert f(12, 5) is True  # Azure SQL Database (reports legacy major 12)
     assert f(12, 8) is True  # Azure SQL Managed Instance
     assert f(15, 4) is False  # SQL Server 2019 Express
-    assert f(None, None) is False  # unknown engine — be safe
+    assert f(None, 3) is False  # version detection failed; on-prem edition proves nothing
+    assert f(None, None) is True  # no facts at all — indistinguishable from offline, assume newest
+
+
+def test_parse_server_major_version():
+    from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+        SqlServerDataSourceConnection,
+    )
+
+    parse = SqlServerDataSourceConnection._parse_server_major_version
+    assert parse("15.00.4123") == 15
+    assert parse("12.00.2000") == 12
+    assert parse("garbage") is None
+    assert parse("") is None
+    assert parse(None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -153,7 +153,9 @@ def test_supports_percentile_within_group_reflects_injected_capability():
 
 
 def test_engine_supports_approx_percentile_disc_matrix():
-    from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerDataSourceImpl
+    from soda_sqlserver.common.data_sources.sqlserver_data_source import (
+        SqlServerDataSourceImpl,
+    )
 
     f = SqlServerDataSourceImpl._engine_supports_approx_percentile_disc
     assert f(16, 3) is True  # SQL Server 2022, Enterprise (on-prem)

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -137,13 +137,10 @@ def test_percentile_within_group_renders_approx_percentile_disc():
 
 
 def test_supports_percentile_within_group_defaults_true_without_server_facts():
-    # A dialect with no live connection (pure SQL rendering, snapshot replay) has
-    # no server facts; it assumes the newest engine to preserve rendering behavior.
     assert SqlServerSqlDialect().supports_percentile_within_group() is True
 
 
 def _dialect_with_server_facts(server_major_version, engine_edition) -> SqlServerSqlDialect:
-    # Mimics SqlServerDataSourceImpl._sync_dialect_server_info at connection open.
     dialect = SqlServerSqlDialect()
     dialect.server_major_version = server_major_version
     dialect.engine_edition = engine_edition
@@ -151,9 +148,6 @@ def _dialect_with_server_facts(server_major_version, engine_edition) -> SqlServe
 
 
 def test_supports_percentile_within_group_derived_from_server_facts():
-    # APPROX_PERCENTILE_DISC needs SQL Server 2022+ (ProductMajorVersion >= 16),
-    # Azure SQL Database (EngineEdition 5), or Managed Instance (EngineEdition 8);
-    # the dialect derives the capability from the synced raw facts.
     f = lambda major, edition: _dialect_with_server_facts(major, edition).supports_percentile_within_group()
     assert f(16, 3) is True  # SQL Server 2022, Enterprise (on-prem)
     assert f(17, 2) is True  # future major, Standard

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -82,6 +82,15 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
     def sql_expr_timestamp_truncate_day(self, timestamp_literal: str) -> str:
         return f"DATETIMEFROMPARTS((datepart(YEAR, {timestamp_literal})), (datepart(MONTH, {timestamp_literal})), (datepart(DAY, {timestamp_literal})), 0, 0, 0, 0)"
 
+    def supports_percentile_within_group(self) -> bool:
+        """Synapse dedicated SQL pools have no percentile aggregate: T-SQL
+        PERCENTILE_DISC is window-only and APPROX_PERCENTILE_DISC's applies-to
+        list excludes Synapse (https://learn.microsoft.com/en-us/sql/t-sql/
+        functions/approx-percentile-disc-transact-sql). v3 warned and returned
+        a dummy 1 (v3 synapse_data_source.py:56-58); v4 consumers skip the
+        Q1/median/Q3 metrics instead."""
+        return False
+
     def _build_insert_into_values_sql(self, insert_into: INSERT_INTO) -> str:
         values_sql: str = "\n" + "\nUNION ALL ".join(
             [self._build_insert_into_values_row_sql(value) for value in insert_into.values]

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -86,9 +86,8 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         """Synapse dedicated SQL pools have no percentile aggregate: T-SQL
         PERCENTILE_DISC is window-only and APPROX_PERCENTILE_DISC's applies-to
         list excludes Synapse (https://learn.microsoft.com/en-us/sql/t-sql/
-        functions/approx-percentile-disc-transact-sql). v3 warned and returned
-        a dummy 1 (v3 synapse_data_source.py:56-58); v4 consumers skip the
-        Q1/median/Q3 metrics instead."""
+        functions/approx-percentile-disc-transact-sql). Consumers skip the
+        Q1/median/Q3 metrics."""
         return False
 
     def _build_insert_into_values_sql(self, insert_into: INSERT_INTO) -> str:

--- a/soda-synapse/tests/unit/test_synapse_dialect.py
+++ b/soda-synapse/tests/unit/test_synapse_dialect.py
@@ -34,7 +34,7 @@ def test_time_delta_inherits_sqlserver_datediff_form():
     sql = SynapseSqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
     )
-    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+    assert sql == "(DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400)"
 
 
 def test_add_interval_inherits_sqlserver_dateadd_form():

--- a/soda-synapse/tests/unit/test_synapse_dialect.py
+++ b/soda-synapse/tests/unit/test_synapse_dialect.py
@@ -15,10 +15,10 @@ def test_count_renders_as_count_big():
 
 
 # ---------------------------------------------------------------------------
-# Time-bucket + percentile seams (OBSL-1036). DATEDIFF/DATEADD and the typed
-# DATETIME2 literal are inherited from SqlServerSqlDialect; percentile is NOT
-# available on Synapse dedicated SQL pools (APPROX_PERCENTILE_DISC's applies-to
-# list excludes Synapse; v3 synapse_data_source.py:56-58 returned a dummy 1).
+# Time-bucket + percentile seams. DATEDIFF/DATEADD and the typed DATETIME2
+# literal are inherited from SqlServerSqlDialect; percentile is not available
+# on Synapse dedicated SQL pools (APPROX_PERCENTILE_DISC's applies-to list
+# excludes Synapse).
 # ---------------------------------------------------------------------------
 
 

--- a/soda-synapse/tests/unit/test_synapse_dialect.py
+++ b/soda-synapse/tests/unit/test_synapse_dialect.py
@@ -12,3 +12,46 @@ def test_random():
 def test_count_renders_as_count_big():
     # Inherits the COUNT_BIG override from SqlServerSqlDialect — guards against accidental regressions.
     assert SynapseSqlDialect().build_expression_sql(COUNT(STAR())) == "COUNT_BIG(*)"
+
+
+# ---------------------------------------------------------------------------
+# Time-bucket + percentile seams (OBSL-1036). DATEDIFF/DATEADD and the typed
+# DATETIME2 literal are inherited from SqlServerSqlDialect; percentile is NOT
+# available on Synapse dedicated SQL pools (APPROX_PERCENTILE_DISC's applies-to
+# list excludes Synapse; v3 synapse_data_source.py:56-58 returned a dummy 1).
+# ---------------------------------------------------------------------------
+
+
+def test_supports_percentile_within_group_is_false():
+    assert SynapseSqlDialect().supports_percentile_within_group() is False
+
+
+def test_time_delta_inherits_sqlserver_datediff_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = SynapseSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("[ts]"), "days", 1)
+    )
+    assert sql == "DATEDIFF(second, '2020-06-20T00:00:00.000', ([ts])) / 86400"
+
+
+def test_add_interval_inherits_sqlserver_dateadd_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = SynapseSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "DATEADD(DAY, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00.000')"
+
+
+def test_literal_timestamp_typed_inherits_datetime2_cast():
+    from datetime import datetime
+
+    assert (
+        SynapseSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 1, 2, 3))
+        == "CAST('2020-06-20 01:02:03' AS DATETIME2)"
+    )

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -1,22 +1,18 @@
-"""Base-dialect seams for the all-datasource profiling/MM groundwork (OBSL-1036).
+"""Base-dialect seams for the all-datasource profiling/MM groundwork.
 
-v3 parity contract:
-
-- ``literal_timestamp_typed(dt)`` — typed timestamp literal for use INSIDE
-  timestamp arithmetic. Base form = v3's ``sql_time_filter_to_timestamp``
-  ``TIMESTAMP 'YYYY-MM-DD HH:MM:SS'`` (v3 data_source.py:1524-1529), incl.
-  sub-second truncation. Must reproduce the MM bulk query builder's
-  ``_timestamp_anchor_literal`` (soda-metric-monitoring
-  bulk_query_builder.py:74-79) byte-for-byte. SQL Server family overrides
-  with ``CAST('...' AS DATETIME2)`` — T-SQL has no TIMESTAMP '...' literal.
+- ``literal_timestamp_typed(dt)`` — typed timestamp literal for use inside
+  timestamp arithmetic: ``TIMESTAMP 'YYYY-MM-DD HH:MM:SS'``, sub-seconds
+  truncated. Must match the MM bulk query builder's anchor literal
+  byte-for-byte. The SQL Server family overrides with
+  ``CAST('...' AS DATETIME2)`` — T-SQL has no TIMESTAMP '...' literal.
 
 - ``sql_expr_is_not_nan(expr)`` — NaN-exclusion predicate for float
-  aggregates; base None = no filter needed. Spark family overrides with
-  ``NOT ISNAN({expr})`` (v3 spark_data_source.py:427-488).
+  aggregates; base None = no filter needed. The Spark family overrides with
+  ``NOT ISNAN({expr})``.
 
 - ``supports_percentile_within_group()`` — base True; Synapse overrides to
-  False (v3 synapse_data_source.py:56-58 warned and returned a dummy 1; v4
-  consumers skip the Q1/median/Q3 metrics instead).
+  False (no percentile aggregate) and consumers skip the Q1/median/Q3
+  metrics.
 """
 
 from __future__ import annotations
@@ -31,7 +27,7 @@ def dialect() -> SqlDialect:
 
 
 # ---------------------------------------------------------------------------
-# literal_timestamp_typed — v3 sql_time_filter_to_timestamp form
+# literal_timestamp_typed
 # ---------------------------------------------------------------------------
 
 
@@ -40,7 +36,7 @@ def test_literal_timestamp_typed_base_form():
 
 
 def test_literal_timestamp_typed_truncates_sub_seconds():
-    """v3 strftime('%Y-%m-%d %H:%M:%S') drops microseconds — kept verbatim."""
+    """Microseconds are dropped, not rounded."""
     assert dialect().literal_timestamp_typed(datetime(2025, 1, 2, 3, 4, 5, 999999)) == "TIMESTAMP '2025-01-02 03:04:05'"
 
 

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -1,0 +1,66 @@
+"""Base-dialect seams for the all-datasource profiling/MM groundwork (OBSL-1036).
+
+v3 parity contract:
+
+- ``literal_timestamp_typed(dt)`` — typed timestamp literal for use INSIDE
+  timestamp arithmetic. Base form = v3's ``sql_time_filter_to_timestamp``
+  ``TIMESTAMP 'YYYY-MM-DD HH:MM:SS'`` (v3 data_source.py:1524-1529), incl.
+  sub-second truncation. Must reproduce the MM bulk query builder's
+  ``_timestamp_anchor_literal`` (soda-metric-monitoring
+  bulk_query_builder.py:74-79) byte-for-byte. SQL Server family overrides
+  with ``CAST('...' AS DATETIME2)`` — T-SQL has no TIMESTAMP '...' literal.
+
+- ``sql_expr_is_not_nan(expr)`` — NaN-exclusion predicate for float
+  aggregates; base None = no filter needed. Spark family overrides with
+  ``NOT ISNAN({expr})`` (v3 spark_data_source.py:427-488).
+
+- ``supports_percentile_within_group()`` — base True; Synapse overrides to
+  False (v3 synapse_data_source.py:56-58 warned and returned a dummy 1; v4
+  consumers skip the Q1/median/Q3 metrics instead).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from soda_core.common.sql_dialect import SqlDialect
+
+
+def dialect() -> SqlDialect:
+    return SqlDialect()
+
+
+# ---------------------------------------------------------------------------
+# literal_timestamp_typed — v3 sql_time_filter_to_timestamp form
+# ---------------------------------------------------------------------------
+
+
+def test_literal_timestamp_typed_base_form():
+    assert dialect().literal_timestamp_typed(datetime(2020, 6, 20, 0, 0, 0)) == "TIMESTAMP '2020-06-20 00:00:00'"
+
+
+def test_literal_timestamp_typed_truncates_sub_seconds():
+    """v3 strftime('%Y-%m-%d %H:%M:%S') drops microseconds — kept verbatim."""
+    assert dialect().literal_timestamp_typed(datetime(2025, 1, 2, 3, 4, 5, 999999)) == "TIMESTAMP '2025-01-02 03:04:05'"
+
+
+def test_literal_timestamp_typed_pads_components():
+    assert dialect().literal_timestamp_typed(datetime(2025, 1, 2, 3, 4, 5)) == "TIMESTAMP '2025-01-02 03:04:05'"
+
+
+# ---------------------------------------------------------------------------
+# sql_expr_is_not_nan — base has no NaN values to filter
+# ---------------------------------------------------------------------------
+
+
+def test_sql_expr_is_not_nan_base_is_none():
+    assert dialect().sql_expr_is_not_nan('"c"') is None
+
+
+# ---------------------------------------------------------------------------
+# supports_percentile_within_group — base True
+# ---------------------------------------------------------------------------
+
+
+def test_supports_percentile_within_group_base_is_true():
+    assert dialect().supports_percentile_within_group() is True

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -44,6 +44,18 @@ def test_literal_timestamp_typed_pads_components():
     assert dialect().literal_timestamp_typed(datetime(2025, 1, 2, 3, 4, 5)) == "TIMESTAMP '2025-01-02 03:04:05'"
 
 
+def test_literal_timestamp_typed_normalizes_tz_aware_to_utc():
+    """A tz-aware datetime is converted to UTC before rendering; strftime alone
+    would drop tzinfo and emit local wall-clock against a UTC-typed column."""
+    from datetime import timedelta, timezone
+
+    plus_two = timezone(timedelta(hours=2))
+    assert (
+        dialect().literal_timestamp_typed(datetime(2025, 1, 2, 5, 4, 5, tzinfo=plus_two))
+        == "TIMESTAMP '2025-01-02 03:04:05'"
+    )
+
+
 # ---------------------------------------------------------------------------
 # sql_expr_is_not_nan — base has no NaN values to filter
 # ---------------------------------------------------------------------------

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
@@ -313,8 +313,6 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
 
     # Lowercase singular unit names for date_add, as listed in the Trino
     # datetime-functions doc (https://trino.io/docs/current/functions/datetime.html).
-    # v3 trino passed the uppercase enum names (trino_data_source.py:265-266);
-    # v3 athena already used the documented lowercase forms (:233-242).
     _TIME_BUCKET_UNIT_NAMES: dict = {
         "weeks": "week",
         "days": "day",
@@ -323,17 +321,15 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
     }
 
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
-        """Trino date_diff('second', ...) divided by the float seconds-per-
-        interval, cast to int (v3 trino_data_source.py:269-271 kept verbatim).
-        The cast matters: floor() returns double on Trino and date_add's
-        value argument must be integer-typed."""
+        """Seconds date_diff divided by the float seconds-per-interval, cast
+        to int. The cast matters: floor() returns double on Trino and
+        date_add's value argument must be integer-typed."""
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
         secs_per_interval: float = seconds_per_time_bucket(time_delta.unit, time_delta.count) / 1.0
         return f"cast(floor(date_diff('second', {start_sql}, {end_sql}) / {secs_per_interval}) as int)"
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
-        """v3 trino date_add form (v3 trino_data_source.py:280-281)."""
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
@@ -341,8 +337,7 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """Trino has no ordered-set aggregates (the base WITHIN GROUP form is
-        not Trino syntax); v3 rendered approx_percentile(expr, p)
-        (v3 trino_data_source.py:245-246)."""
+        not Trino syntax); approx_percentile is its percentile aggregate."""
         expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
         return f"approx_percentile({expression_sql}, {percentile_within_group.percentile})"
 

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
@@ -11,7 +11,14 @@ from soda_core.common.datetime_conversions import (
 )
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
-from soda_core.common.sql_ast import INSERT_INTO_VIA_SELECT, STRING_HASH
+from soda_core.common.sql_ast import (
+    ADD_INTERVAL,
+    INSERT_INTO_VIA_SELECT,
+    PERCENTILE_WITHIN_GROUP,
+    STRING_HASH,
+    TIME_DELTA,
+    seconds_per_time_bucket,
+)
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_trino.common.data_sources.trino_data_source_connection import (
@@ -303,6 +310,41 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
 
     def sql_expr_timestamp_add_day(self, timestamp_literal: str) -> str:
         return f"DATE_ADD('day', 1, {timestamp_literal})"
+
+    # Lowercase singular unit names for date_add, as listed in the Trino
+    # datetime-functions doc (https://trino.io/docs/current/functions/datetime.html).
+    # v3 trino passed the uppercase enum names (trino_data_source.py:265-266);
+    # v3 athena already used the documented lowercase forms (:233-242).
+    _TIME_BUCKET_UNIT_NAMES: dict = {
+        "weeks": "week",
+        "days": "day",
+        "hours": "hour",
+        "seconds": "second",
+    }
+
+    def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
+        """Trino date_diff('second', ...) divided by the float seconds-per-
+        interval, cast to int (v3 trino_data_source.py:269-271 kept verbatim).
+        The cast matters: floor() returns double on Trino and date_add's
+        value argument must be integer-typed."""
+        start_sql: str = self.build_expression_sql(time_delta.start)
+        end_sql: str = self.build_expression_sql(time_delta.end)
+        secs_per_interval: float = seconds_per_time_bucket(time_delta.unit, time_delta.count) / 1.0
+        return f"cast(floor(date_diff('second', {start_sql}, {end_sql}) / {secs_per_interval}) as int)"
+
+    def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
+        """v3 trino date_add form (v3 trino_data_source.py:280-281)."""
+        timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
+        count_sql: str = self.build_expression_sql(add_interval.count_expression)
+        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
+        return f"date_add('{unit_name}', {count_sql}, {timestamp_sql})"
+
+    def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
+        """Trino has no ordered-set aggregates (the base WITHIN GROUP form is
+        not Trino syntax); v3 rendered approx_percentile(expr, p)
+        (v3 trino_data_source.py:245-246)."""
+        expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
+        return f"approx_percentile({expression_sql}, {percentile_within_group.percentile})"
 
     def build_select_sql(self, select_elements: list, add_semicolon: Optional[bool] = None) -> str:
         # Trino requires OFFSET before LIMIT (standard SQL order).

--- a/soda-trino/tests/unit/test_trino_dialect.py
+++ b/soda-trino/tests/unit/test_trino_dialect.py
@@ -19,3 +19,58 @@ def test_literal_datetime_pads_year_to_four_digits():
         sql_dialect.literal(datetime(200, 12, 17, 1, 2, 3, 456, tzinfo=timezone.utc))
         == "TIMESTAMP '0200-12-17 01:02:03.000456+00:00'"
     )
+
+
+def test_time_delta_renders_date_diff_seconds_form():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = TrinoSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr('"ts"'), "days", 1)
+    )
+    assert sql == "cast(floor(date_diff('second', TIMESTAMP '2020-06-20 00:00:00.000000', (\"ts\")) / 86400.0) as int)"
+
+
+def test_time_delta_date_diff_count_2_hours():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = TrinoSqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr('"ts"'), "hours", 2)
+    )
+    assert sql == "cast(floor(date_diff('second', TIMESTAMP '2020-06-20 00:00:00.000000', (\"ts\")) / 7200.0) as int)"
+
+
+def test_add_interval_renders_date_add_lowercase_unit():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = TrinoSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "date_add('day', ((soda_partition__ + 1) * 1), TIMESTAMP '2020-06-20 00:00:00.000000')"
+
+
+def test_add_interval_weeks_unit_name():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = TrinoSqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 1"))
+    )
+    assert sql == "date_add('week', ((soda_partition__ + 1) * 1), TIMESTAMP '2020-06-20 00:00:00.000000')"
+
+
+def test_percentile_within_group_renders_approx_percentile():
+    from soda_core.common.sql_ast import COLUMN, PERCENTILE_WITHIN_GROUP
+
+    sql = TrinoSqlDialect().build_expression_sql(PERCENTILE_WITHIN_GROUP(COLUMN("c"), 0.25))
+    assert sql == 'approx_percentile("c", 0.25)'
+
+
+def test_supports_percentile_within_group_is_true():
+    assert TrinoSqlDialect().supports_percentile_within_group() is True


### PR DESCRIPTION
Ticket: OBSL-1036

## PR chain (soda-core)
1. #2773 — ship table/column discovery
2. #2774 — emit `metrics[]` in scan-results payload
3. #2776 — SQL AST window functions + UNION-in-CTE
4. #2777 — raw feature-config passthrough (config DTO)
5. #2787 — all-datasource dialect groundwork  ← this PR

---

## What & why ([OBSL-1036](https://linear.app/sodadata/issue/OBSL-1036))

Extends the v4 profiling and metric-monitoring engines to **all** data sources, porting the per-warehouse SQL forms from the v3 engine (soda-library) into the v4 `SqlDialect` layer: time-bucket arithmetic (`TIME_DELTA` / `ADD_INTERVAL`), the percentile aggregate (`PERCENTILE_WITHIN_GROUP`), a typed timestamp literal, and a NaN-exclusion predicate. Every override cites its v3 source (`file:line`) in its docstring, per the existing convention.

## New base seams (soda-core `SqlDialect`)

- **`literal_timestamp_typed(dt)`** — typed timestamp literal for use *inside* timestamp arithmetic. Base `TIMESTAMP 'YYYY-MM-DD HH:MM:SS'` = v3 `sql_time_filter_to_timestamp` (data_source.py:1524-1529), incl. sub-second truncation; byte-parity with the MM bulk builder's `_timestamp_anchor_literal`.
- **`sql_expr_is_not_nan(expr)`** — NaN-exclusion predicate for float aggregates; base `None` = no filter needed (v3 spark_data_source.py:427-488).
- **`supports_percentile_within_group()`** — base `True`; consumers skip the Q1/median/Q3 metrics when `False` instead of rendering invalid SQL. SQL Server version-gates this at runtime (the `APPROX_PERCENTILE_DISC` aggregate is 2022+/Azure only — see deviations).

These base seams are consumed by the downstream profiling and metric-monitoring engines.

## Per-dialect forms

| Dialect | TIME_DELTA | ADD_INTERVAL | PERCENTILE_WITHIN_GROUP | Other |
|---|---|---|---|---|
| SQL Server | `DATEDIFF(second, s, e) / n` (v3 :710-716) | `DATEADD(UNIT, c, ts)` (v3 :725-727) | `APPROX_PERCENTILE_DISC(p) WITHIN GROUP (...)` (v3 :336-337); `supports_percentile_within_group()` version-gated ⚠️ | `literal_timestamp_typed` → `CAST('...' AS DATETIME2)` ⚠️ |
| Synapse | inherited | inherited | `supports_percentile_within_group()` → `False` ⚠️ | typed literal inherited |
| Fabric | inherited (pinned) | inherited (pinned) | `supports_percentile_within_group()` → `True` (pinned; Fabric engine is always current) | |
| Databricks | `FLOOR(DATEDIFF(SECOND, s, e) / n)` (v3 spark :1158-1161) | `TIMESTAMPADD(UNIT, c, ts)` ⚠️ | no override — base `PERCENTILE_DISC(p) WITHIN GROUP` valid since DBR 11.3 (pinned) | `sql_expr_is_not_nan` → `NOT ISNAN(expr)` |
| SparkDf / DatabricksHive | inherited (pinned) | inherited (pinned) | inherited | inherited |
| Trino | `cast(floor(date_diff('second', s, e) / n.0) as int)` (v3 :269-271) | `date_add('unit', c, ts)` (v3 :280-281) ⚠️ | `approx_percentile(expr, p)` (v3 :245-246) | |
| Athena | same as Trino ⚠️ | same as Trino ⚠️ | `approx_percentile(expr, p)` (v3 :256-259) | |
| Redshift | no override — base epoch-floor IS v3's redshift form (v3 :287-290, pinned) | no override — v3 shipped the base interval-multiply on Redshift (pinned) | `APPROXIMATE PERCENTILE_DISC(p) WITHIN GROUP (...)` (v3 :224-225) | |

## Deviations from v3 (⚠️ above), with doc citations

- **T-SQL TIME_DELTA truncates toward zero** (v3-verbatim `DATEDIFF(second,...)/n` int division) while every other dialect FLOORs toward -inf. Equal only for non-negative deltas — guaranteed by the MM bulk query's `ts >= anchor` filter; a consumer relying on negative bucket indices would misbucket on the T-SQL family only. Also noted: `DATEDIFF(second,...)` overflows at ~68-year spans (`DATEDIFF_BIG` is the escape hatch; not switched, v3 parity).
- **SQL Server `literal_timestamp_typed`**: v3 rendered a bare string (:699-703). T-SQL has no `TIMESTAMP '...'` literal (`TIMESTAMP` = deprecated rowversion), so the seam renders `CAST('...' AS DATETIME2)` ([DATETIME2 docs](https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql)).
- **SQL Server percentile version gate**: v3 emitted `APPROX_PERCENTILE_DISC` unconditionally (:336-337), which errors on SQL Server ≤2019 (the aggregate is [2022+/Azure only](https://learn.microsoft.com/en-us/sql/t-sql/functions/approx-percentile-disc-transact-sql)). Instead of inheriting that assumption, the data source probes `SERVERPROPERTY('ProductMajorVersion')`/`('EngineEdition')` on connect and injects the result into `supports_percentile_within_group()` (`major >= 16`, or Azure DB/MI editions 5/8) — strictly safer than v3 without regressing 2022+/Azure. Unprobed dialects (pure SQL rendering, no connection) assume support; a probe failure falls back to assuming support and never fails the scan. Fabric pins the flag `True` (engine is always current); Synapse pins `False`.
- **Synapse percentile**: v3 warned and returned a dummy `1` (:56-58). v4 skips the metric via the support flag; Synapse is absent from [APPROX_PERCENTILE_DISC's applies-to list](https://learn.microsoft.com/en-us/sql/t-sql/functions/approx-percentile-disc-transact-sql).
- **Databricks ADD_INTERVAL**: v3 inherited the base `ts + INTERVAL '1 <unit>' * n`; Spark parses the plural-unit string as a legacy CalendarInterval, so v4 uses `TIMESTAMPADD`, documented on [Databricks DBR 10.4+](https://docs.databricks.com/en/sql/language-manual/functions/timestampadd.html) and OSS Spark 3.3+ (SPARK-38195). The 3-arg `DATEDIFF` used for TIME_DELTA is the documented [TIMESTAMPDIFF synonym](https://docs.databricks.com/en/sql/language-manual/functions/datediff3.html) (OSS: SPARK-38389).
- **Trino/Athena units lowercased**: v3 trino passed uppercase enum names; the [Trino datetime docs](https://trino.io/docs/current/functions/datetime.html) list lowercase units (v3 athena already used them).
- **Athena TIME_DELTA int cast**: v3 athena (:269-273) lacked v3-trino's `as int` cast; it is required because `floor()` returns `double` on the Trino engine and `date_add`'s value argument is integer-typed. [Athena engine v3 functions are Trino's](https://docs.aws.amazon.com/athena/latest/ug/functions-env3.html).
- **Redshift base forms kept**: interval-literal arithmetic incl. plural units and `interval * numeric` are documented ([interval types](https://docs.aws.amazon.com/redshift/latest/dg/r_interval_data_types.html), [interval literals](https://docs.aws.amazon.com/redshift/latest/dg/r_interval_literals.html)); `APPROXIMATE PERCENTILE_DISC` per [its docs](https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html).

## Tests

Per-package snapshot tests pin every rendered form (incl. inheritance-pinning tests for Synapse/Fabric/SparkDf and the deliberate no-override cases on Databricks/Redshift), plus base-seam unit tests in `soda-tests/tests/unit/test_sql_dialect_seams.py`.

`soda-tests` unit (1191 passed, 2 skipped), feature (13 passed) and integration (164 passed, 14 skipped) green, plus all touched-package unit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

