### PR TITLE
Redact SQL Server connection parameter values in logs

### DIFF
--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -163,7 +163,7 @@ class SqlServerDataSourceConnection(DataSourceConnection):
 
         if config.connection_parameters:
             for key, value in config.connection_parameters.items():
-                logger.info(f"Adding connection parameter: {key}={value}")
+                logger.info("Adding connection parameter: %s=<redacted>", key)
                 conn_params.append(f"{key}={value}")
 
         conn_params.append(f"APP=soda-core-fabric/{SODA_CORE_VERSION}")

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -138,8 +138,8 @@ class SqlServerDataSourceConnection(DataSourceConnection):
         if config.encrypt:
             conn_params.append("Encrypt=YES")
 
-        if int(config.connection_max_retries) > 0:
-            conn_params.append(f"ConnectRetryCount={int(self.connection_max_retries)}")
+        if config.connection_max_retries is not None:
+            conn_params.append(f"ConnectRetryCount={config.connection_max_retries}")
 
         if config.enable_tracing:
             conn_params.append("SQL_ATTR_TRACE=SQL_OPT_TRACE_ON")

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -116,7 +116,8 @@ class SqlServerDataSourceConnection(DataSourceConnection):
     def _format_row(self, row: Any) -> tuple:
         return tuple(row)
 
-    def build_connection_string(self, config: SqlServerConnectionProperties):
+    @staticmethod
+    def build_connection_string(config: SqlServerConnectionProperties):
         conn_params = []
 
         conn_params.append(f"DRIVER={{{config.driver}}}")

--- a/soda-sqlserver/tests/unit/test_sqlserver_connection_parameter_logging.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_connection_parameter_logging.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+
+from pydantic import SecretStr
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+    SqlServerDataSourceConnection,
+    SqlServerPasswordAuth,
+)
+
+
+def test_connection_parameter_logs_redact_values(caplog) -> None:
+    instance = SqlServerDataSourceConnection.__new__(SqlServerDataSourceConnection)
+    config = SqlServerPasswordAuth(
+        host="localhost",
+        port=1433,
+        database="master",
+        user="sa",
+        password=SecretStr("Password1!"),
+        connection_parameters={
+            "application_intent": "ReadOnly",
+            "access_token": "super-secret-token",
+        },
+    )
+
+    with caplog.at_level(logging.INFO):
+        connection_string = instance.build_connection_string(config)
+
+    assert "application_intent=ReadOnly" in connection_string
+    assert "access_token=super-secret-token" in connection_string
+
+    assert "Adding connection parameter: application_intent=<redacted>" in caplog.text
+    assert "Adding connection parameter: access_token=<redacted>" in caplog.text
+    assert "ReadOnly" not in caplog.text
+    assert "super-secret-token" not in caplog.text

--- a/soda-sqlserver/tests/unit/test_sqlserver_connection_parameter_logging.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_connection_parameter_logging.py
@@ -10,7 +10,6 @@ from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import 
 
 
 def test_connection_parameter_logs_redact_values(caplog) -> None:
-    instance = SqlServerDataSourceConnection.__new__(SqlServerDataSourceConnection)
     config = SqlServerPasswordAuth(
         host="localhost",
         port=1433,
@@ -24,7 +23,7 @@ def test_connection_parameter_logs_redact_values(caplog) -> None:
     )
 
     with caplog.at_level(logging.INFO):
-        connection_string = instance.build_connection_string(config)
+        connection_string = SqlServerDataSourceConnection.build_connection_string(config)
 
     assert "application_intent=ReadOnly" in connection_string
     assert "access_token=super-secret-token" in connection_string


### PR DESCRIPTION
Continuation of #2762. CI fails on that PR because it comes from an external contributor