### PR TITLE
Apply python_scan_all_frames to externally supplied duckdb connections

### DIFF
--- a/soda/core/soda/configuration/configuration.py
+++ b/soda/core/soda/configuration/configuration.py
@@ -35,9 +35,10 @@ class Configuration:
             "context": dask_context,
         }
 
-    def add_duckdb_connection(self, data_source_name: str, duckdb_connection):
+    def add_duckdb_connection(self, data_source_name: str, duckdb_connection, configuration: dict | None = None):
         self.data_source_properties_by_name[data_source_name] = {
             "type": "duckdb",
             "connection": "duckdb_connection_data_source",
             "duckdb_connection": duckdb_connection,
+            "configuration": configuration or {},
         }

--- a/soda/core/soda/scan.py
+++ b/soda/core/soda/scan.py
@@ -193,14 +193,23 @@ class Scan:
         )
         environment_parse.parse_environment_yaml_str(configuration_yaml_str)
 
-    def add_duckdb_connection(self, duckdb_connection, data_source_name: str = "duckdb"):
+    def add_duckdb_connection(
+        self, duckdb_connection, data_source_name: str = "duckdb", configuration: dict | None = None
+    ):
         """
         Adds a duckdb connection to the scan. Only requireed in case of using a pre-existing
         duckdb connection object as a data source.
+
+        Optionally pass `configuration` to override the duckdb data source settings applied to the
+        connection. By default Soda sets `python_scan_all_frames=True` so DataFrames defined in
+        caller frames keep resolving on duckdb >= 1.1.0; pass e.g.
+        `configuration={"python_scan_all_frames": False}` to opt out.
         """
         try:
             self._configuration.add_duckdb_connection(
-                data_source_name=data_source_name, duckdb_connection=duckdb_connection
+                data_source_name=data_source_name,
+                duckdb_connection=duckdb_connection,
+                configuration=configuration,
             )
         except Exception as e:
             self._logs.error(

--- a/soda/duckdb/soda/data_sources/duckdb_data_source.py
+++ b/soda/duckdb/soda/data_sources/duckdb_data_source.py
@@ -118,6 +118,15 @@ class DuckDBDataSource(DataSource):
         try:
             if self.duckdb_connection:
                 self.connection = DuckDBDataSourceConnectionWrapper(self.duckdb_connection)
+                # An externally supplied connection is created outside of Soda, so the connect-time
+                # `config` above never reached it. duckdb >= 1.1.0 defaults python_scan_all_frames to
+                # False, which stops replacement scans from resolving pandas/polars DataFrames defined
+                # in caller frames -- the canonical add_duckdb_connection workflow. Restore the
+                # pre-1.1.0 behavior at runtime. (custom_user_agent can only be set at connect time,
+                # so it cannot be applied to a pre-existing connection.)
+                python_scan_all_frames = self.configuration.get("python_scan_all_frames")
+                if python_scan_all_frames is not None:
+                    self.connection.execute(f"SET python_scan_all_frames = {str(bool(python_scan_all_frames)).lower()}")
             elif (read_function := self.REGISTERED_FORMAT_MAP.get(self.extract_format())) is not None:
                 self.connection = DuckDBDataSourceConnectionWrapper(
                     duckdb.connect(":memory:", config=self.configuration)

--- a/soda/duckdb/tests/test_duckdb.py
+++ b/soda/duckdb/tests/test_duckdb.py
@@ -25,6 +25,75 @@ def test_pandas_df(data_source_fixture: DataSourceFixture):
     scan.assert_no_error_logs()
 
 
+def test_pandas_df_externally_supplied_connection():
+    """Regression test for the ``add_duckdb_connection`` workflow on duckdb >= 1.1.0.
+
+    duckdb >= 1.1.0 defaults ``python_scan_all_frames`` to ``False``, which stops replacement
+    scans from resolving a DataFrame that only lives in a caller frame. When the user supplies
+    their own connection, Soda's connect-time ``config`` never reaches it, so ``DuckDBDataSource``
+    must restore the setting at runtime -- otherwise the check fails with "Table ... does not exist".
+
+    This uses a bare ``Scan`` on purpose: the shared test fixture pre-registers its own duckdb
+    connection (created through the config path, which already sets the flag), so a fixture-based
+    scan never exercises -- and therefore masks -- the externally-supplied-connection branch.
+    """
+    import duckdb
+    import pandas as pd
+    from soda.scan import Scan
+
+    # Default config -> python_scan_all_frames is False on duckdb >= 1.1.0.
+    con = duckdb.connect(database=":memory:")
+    test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
+
+    scan = Scan()
+    scan.set_scan_definition_name("test_pandas_df_externally_supplied_connection")
+    scan.set_data_source_name("duckdb")
+    scan.add_duckdb_connection(con)
+    scan.add_sodacl_yaml_str(
+        """
+          checks for test_df:
+            - row_count = 4
+            - missing_count(i) = 0
+            - missing_count(j) = 0
+        """
+    )
+    scan.execute()
+
+    scan.assert_no_error_logs()
+    assert not scan.get_checks_fail(), scan.get_checks_fail_text()
+
+
+def test_add_duckdb_connection_honors_configuration_override():
+    """The `configuration` argument of `add_duckdb_connection` overrides the applied settings.
+
+    By default Soda forces `python_scan_all_frames=True` on the supplied connection; a user can
+    opt out (or set any other duckdb setting) by passing `configuration`. Checked against a real
+    table so the scan succeeds regardless of the flag, then the connection setting is asserted.
+    """
+    import duckdb
+    from soda.scan import Scan
+
+    con = duckdb.connect(database=":memory:")
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (2), (3)) AS v(i)")
+
+    scan = Scan()
+    scan.set_scan_definition_name("test_add_duckdb_connection_honors_configuration_override")
+    scan.set_data_source_name("duckdb")
+    scan.add_duckdb_connection(con, configuration={"python_scan_all_frames": False})
+    scan.add_sodacl_yaml_str(
+        """
+          checks for t:
+            - row_count = 3
+        """
+    )
+    scan.execute()
+
+    scan.assert_no_error_logs()
+    assert not scan.get_checks_fail(), scan.get_checks_fail_text()
+    # Override honored: the flag was left at the user-requested value instead of being forced True.
+    assert con.sql("SELECT current_setting('python_scan_all_frames')").fetchone()[0] is False
+
+
 def test_df_from_csv(data_source_fixture: DataSourceFixture, tmp_path: Path):
     import pandas as pd
 


### PR DESCRIPTION
## Summary

Follow-up to #2527. That PR restored the pre-1.1.0 `python_scan_all_frames` behavior by passing it via connect-time `config`, but the config only reaches connections **Soda creates itself** (the file-read and `:memory:`/path branches). It never reaches the `duckdb_connection` branch used by `Scan.add_duckdb_connection(...)` — the canonical pandas/polars DataFrame workflow.

Since duckdb ≥1.1.0 defaults `python_scan_all_frames` to `False`, a user-supplied connection can no longer resolve a DataFrame defined in a caller frame, and the check fails with `Table ... does not exist`.

## Why the existing test didn't catch it

`test_pandas_df` uses the shared fixture, which pre-registers its own duckdb connection (built through the config path, which already sets the flag). `DataSourceManager.get_data_source` returns that cached instance, so `add_duckdb_connection(con)` writes to a dict that's never read — the branch is never exercised, and the bug is masked.

## Changes

- **`duckdb_data_source.py`** — restore `python_scan_all_frames` at runtime (via `SET`) on externally supplied connections, driven by `self.configuration` so overrides still win. (`custom_user_agent` can only be set at connect time, so it can't be applied to a pre-existing connection.)
- **`scan.py` / `configuration.py`** — new optional `configuration` argument on `add_duckdb_connection`, reusing the existing data-source `configuration` plumbing. **Default restores the old behavior**; pass `configuration={"python_scan_all_frames": False}` to opt out.
- **`test_duckdb.py`** — two regression tests that exercise the *real* user-connection branch (bare `Scan`, not the fixture): one guards the restored default (fails without this fix), one verifies the override is honored.

## Behavior

| Call | connection setting after connect | DataFrame check |
|------|------|------|
| `add_duckdb_connection(con)` (default) | `True` | passes (old behavior restored) |
| `add_duckdb_connection(con, configuration={"python_scan_all_frames": False})` | `False` | fails (opted out) |
| `add_duckdb_connection(con, configuration={"python_scan_all_frames": True})` | `True` | passes |

## Testing

Verified against a dedicated venv with `duckdb==1.5.4` (resolved from the `>=1.1.0,<2.0` range). Full duckdb suite: **6 passed**. The restored-default test fails without the source fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)