### PR TITLE
fix: zero-pad years below 1000 in SQL date and datetime literals

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1516,7 +1516,8 @@ def to_jsonnable(o: Any, remove_null_values_in_dicts: bool = True) -> object:
     if isinstance(o, datetime):
         return convert_datetime_to_str(o)
     if isinstance(o, date):
-        return o.strftime("%Y-%m-%d")
+        # Not strftime("%Y-%m-%d"): C strftime does not zero-pad years < 1000 on glibc.
+        return o.isoformat()
     if isinstance(o, time):
         return o.strftime("%H:%M:%S")
     if isinstance(o, timedelta):

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -362,8 +362,9 @@ class SqlDialect:
         return "(" + (",".join([self.literal(e) for e in l])) + ")"
 
     def literal_date(self, date: date):
-        date_string = date.strftime("%Y-%m-%d")
-        return f"DATE '{date_string}'"
+        # Not strftime("%Y-%m-%d"): C strftime does not zero-pad years < 1000 on glibc,
+        # producing literals like DATE '200-12-17' that Spark/Databricks reject.
+        return f"DATE '{date.isoformat()}'"
 
     def literal_datetime(self, datetime: datetime):
         return f"'{datetime.isoformat()}'"

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from soda_core.common.metadata_types import SodaDataTypeName
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
@@ -54,6 +56,12 @@ def test_random():
     sql_dialect: DatabricksSqlDialect = DatabricksSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT RAND()\nFROM `a`;"
+
+
+def test_literal_date_pads_year_to_four_digits():
+    """Spark SQL rejects DATE literals without a 4-digit year as INVALID_TYPED_LITERAL,
+    and C strftime("%Y") drops the leading zeros for years < 1000 on glibc."""
+    assert DatabricksSqlDialect().literal(date(200, 12, 17)) == "DATE '0200-12-17'"
 
 
 class TestTimestampReverseMapping:

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -120,8 +120,7 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
 
     def literal_date(self, date: date):
         """Technically dates can be passed directly as strings, but this is more explicit."""
-        date_string = date.strftime("%Y-%m-%d")
-        return f"CAST('{date_string}' AS DATE)"
+        return f"CAST('{date.isoformat()}' AS DATE)"
 
     def literal_datetime(self, datetime: datetime):
         return f"'{datetime.isoformat(timespec='milliseconds')}'"

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from soda_core.common.metadata_types import SqlDataType
 from soda_core.common.sql_ast import COUNT, CREATE_TABLE_COLUMN, STAR
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
@@ -8,6 +10,12 @@ def test_random():
     sql_dialect: SqlServerSqlDialect = SqlServerSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+def test_literal_date_pads_year_to_four_digits():
+    """C strftime("%Y") drops leading zeros for years < 1000 on glibc; the CAST
+    string must always carry a 4-digit, zero-padded year."""
+    assert SqlServerSqlDialect().literal(date(200, 12, 17)) == "CAST('0200-12-17' AS DATE)"
 
 
 def test_count_renders_as_count_big():

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -204,6 +204,26 @@ def test_sql_ast_insert_into_with_datetimes():
     )
 
 
+def test_sql_ast_insert_into_pads_date_years_below_1000():
+    """C strftime("%Y") drops leading zeros for years < 1000 on glibc, which used to
+    render DATE '200-12-17' — an INVALID_TYPED_LITERAL for Spark/Databricks. Date
+    literals must always carry a 4-digit, zero-padded year."""
+    sql_dialect: SqlDialect = SqlDialect()
+
+    assert sql_dialect.literal(date(200, 12, 17)) == "DATE '0200-12-17'"
+
+    my_insert_into_statement = sql_dialect.build_insert_into_sql(
+        INSERT_INTO(
+            fully_qualified_table_name='"customers"',
+            columns=[COLUMN("id"), COLUMN("birth_date")],
+            values=[VALUES_ROW([LITERAL(1), LITERAL(date(200, 12, 17))])],
+        )
+    )
+    assert my_insert_into_statement == (
+        'INSERT INTO "customers" ("id", "birth_date") VALUES\n' "(1, DATE '0200-12-17');"
+    )
+
+
 def test_sql_ast_insert_into_via_select():
     sql_dialect: SqlDialect = SqlDialect()
     my_insert_into_statement = sql_dialect.build_insert_into_via_select_sql(

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
@@ -279,10 +279,11 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
         ]
 
     def literal_datetime(self, datetime: datetime):
-        return f"TIMESTAMP '{datetime.strftime('%Y-%m-%d %H:%M:%S.%f')}'"
+        return f"TIMESTAMP '{datetime.isoformat(sep=' ', timespec='microseconds')}'"
 
     def literal_datetime_with_tz(self, datetime: datetime):
-        return f"TIMESTAMP '{datetime.strftime('%Y-%m-%d %H:%M:%S.%f%z')}'"
+        # isoformat appends the +HH:MM offset for tz-aware values.
+        return f"TIMESTAMP '{datetime.isoformat(sep=' ', timespec='microseconds')}'"
 
     def literal_time(self, time: time):
         formatted_time = time.strftime("%H:%M:%S.%f")

--- a/soda-trino/tests/unit/test_trino_dialect.py
+++ b/soda-trino/tests/unit/test_trino_dialect.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_trino.common.data_sources.trino_data_source import TrinoSqlDialect
 
@@ -6,3 +8,14 @@ def test_random():
     sql_dialect: TrinoSqlDialect = TrinoSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == 'SELECT RANDOM()\nFROM "a"'
+
+
+def test_literal_datetime_pads_year_to_four_digits():
+    """C strftime("%Y") drops leading zeros for years < 1000 on glibc, producing
+    TIMESTAMP literals Trino cannot parse; the year must always be 4 digits."""
+    sql_dialect: TrinoSqlDialect = TrinoSqlDialect()
+    assert sql_dialect.literal(datetime(200, 12, 17, 1, 2, 3, 456)) == "TIMESTAMP '0200-12-17 01:02:03.000456'"
+    assert (
+        sql_dialect.literal(datetime(200, 12, 17, 1, 2, 3, 456, tzinfo=timezone.utc))
+        == "TIMESTAMP '0200-12-17 01:02:03.000456+00:00'"
+    )


### PR DESCRIPTION
## Description

**What problem are you solving?**

Failed-row-keys inserts into the Databricks diagnostics warehouse fail with `[INVALID_TYPED_LITERAL] The value of the typed literal "DATE" is invalid: '200-12-17'` when a source date has a year below 1000 (customer report: SCS-1320).

Root cause: `SqlDialect.literal_date` formatted dates with `strftime("%Y-%m-%d")`, and C `strftime("%Y")` does **not** zero-pad years < 1000 on glibc (where scan pods run) — it does pad on macOS, so the bug never reproduces on a dev Mac. `date.isoformat()` always emits a 4-digit year on every platform.

Fixed the same pattern at every `%Y` site that feeds SQL literals or wire payloads:
- base `SqlDialect.literal_date` (inherited by Databricks, Spark, Postgres, Snowflake, …)
- `SqlServerSqlDialect.literal_date` (same bug in its override)
- Trino `literal_datetime` / `literal_datetime_with_tz` (same bug for timestamps)
- `to_jsonnable` date serialization in `soda_cloud.py`

**Any expected impact on downstream packages/services?**

For years ≥ 1000 all outputs are byte-identical except Trino's tz-aware timestamp offset, which now renders `+02:00` (the format Trino documents) instead of `+0200`. Grepped soda-extensions: nothing pins the old formats.

**Reference issue:** SCS-1320

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1] (no extensions code pins the changed literal formats; only edge-case years < 1000 and the Trino offset rendering change).

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)