### PR TITLE
fix(bigquery): qualify CREATE SCHEMA with the project (SAS-13229)

### DIFF
--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -153,6 +153,15 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     def information_schema_namespace_elements(self, data_source_namespace: BigQueryDataSourceNamespace) -> list[str]:
         return [data_source_namespace.project_id, data_source_namespace.dataset, "INFORMATION_SCHEMA"]
 
+    def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: Optional[bool] = None) -> str:
+        # BigQuery datasets are project-scoped, so qualify the dataset with the project
+        # (prefixes[0]) — otherwise it lands in the client's default (compute) project
+        # instead of the storage project. The base implementation uses the dataset name alone.
+        add_semicolon = self.apply_default_add_semicolon(add_semicolon)
+        project_id, dataset = prefixes
+        qualified_schema_name: str = f"{self.quote_for_ddl(project_id)}.{self.quote_for_ddl(dataset)}"
+        return f"CREATE SCHEMA IF NOT EXISTS {qualified_schema_name}" + (";" if add_semicolon else "")
+
     def default_casify(self, identifier: str) -> str:
         return identifier.upper()
 

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -158,10 +158,10 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         # (prefixes[0]) — otherwise it lands in the client's default (compute) project
         # instead of the storage project. The base implementation uses the dataset name alone.
         add_semicolon = self.apply_default_add_semicolon(add_semicolon)
-        # Prefixes are normally produced by the BigQuery data source as [project, dataset]; a
-        # different shape points at a caller bug, so warn to make it easy to trace.
+        # Prefixes are produced by the BigQuery data source as [project, dataset]; a different
+        # shape is a caller bug, so fail fast with a clear, traceable error.
         if len(prefixes) != 2:
-            logger.warning(f"Expected [project, dataset] prefixes for BigQuery CREATE SCHEMA, got {prefixes}")
+            raise ValueError(f"BigQuery CREATE SCHEMA expects [project, dataset] prefixes, got {prefixes}")
         project_id, dataset = prefixes
         qualified_schema_name: str = f"{self.quote_for_ddl(project_id)}.{self.quote_for_ddl(dataset)}"
         return f"CREATE SCHEMA IF NOT EXISTS {qualified_schema_name}" + (";" if add_semicolon else "")

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -158,6 +158,10 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         # (prefixes[0]) — otherwise it lands in the client's default (compute) project
         # instead of the storage project. The base implementation uses the dataset name alone.
         add_semicolon = self.apply_default_add_semicolon(add_semicolon)
+        # Prefixes are normally produced by the BigQuery data source as [project, dataset]; a
+        # different shape points at a caller bug, so warn to make it easy to trace.
+        if len(prefixes) != 2:
+            logger.warning(f"Expected [project, dataset] prefixes for BigQuery CREATE SCHEMA, got {prefixes}")
         project_id, dataset = prefixes
         qualified_schema_name: str = f"{self.quote_for_ddl(project_id)}.{self.quote_for_ddl(dataset)}"
         return f"CREATE SCHEMA IF NOT EXISTS {qualified_schema_name}" + (";" if add_semicolon else "")

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -126,8 +126,9 @@ class BigQueryDataSourceConnection(DataSourceConnection):
         self.location = config.location
         self.client_options = config.client_options
 
-        # Storage project ID is currently not used, because the project is configured via the DQN in the data contract.
-        # When we implement discovery, we'll need to use this value.
+        # Diagnostics-warehouse writes are qualified with the storage project (see
+        # BigQueryDataSourceExtension.build_dwh_prefixes); it defaults to the compute project
+        # when not configured. Reads target the project carried by the contract's DQN.
         self.storage_project_id = config.storage_project_id if config.storage_project_id else self.project_id
 
         self.labels = config.labels

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -12,7 +12,7 @@ def test_random():
 
 
 def test_create_schema_if_not_exists_sql_is_project_qualified():
-    """SAS-13229: CREATE SCHEMA must be qualified with the project (prefixes[0]) so the
+    """CREATE SCHEMA must be qualified with the project (prefixes[0]) so the
     dataset lands in the intended project — the storage project in a split compute/storage
     setup — rather than the client's default (compute) project. The base implementation
     qualifies with the dataset name only, which created the diagnostics dataset in the wrong

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from soda_bigquery.common.data_sources.bigquery_data_source import BigQuerySqlDialect
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
@@ -23,6 +25,16 @@ def test_create_schema_if_not_exists_sql_is_project_qualified():
 def test_create_schema_if_not_exists_sql_default_appends_semicolon():
     dialect = BigQuerySqlDialect()
     assert dialect.create_schema_if_not_exists_sql(["proj", "ds"]).endswith("`proj`.`ds`;")
+
+
+def test_create_schema_if_not_exists_sql_warns_on_unexpected_prefix_count(caplog):
+    """Prefixes are normally [project, dataset]; a different shape is a caller bug and
+    should be logged as a warning to make it easy to trace."""
+    dialect = BigQuerySqlDialect()
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError):
+            dialect.create_schema_if_not_exists_sql(["only_one_prefix"])
+    assert any("prefixes" in record.getMessage() for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 from soda_bigquery.common.data_sources.bigquery_data_source import BigQuerySqlDialect
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
@@ -27,14 +25,13 @@ def test_create_schema_if_not_exists_sql_default_appends_semicolon():
     assert dialect.create_schema_if_not_exists_sql(["proj", "ds"]).endswith("`proj`.`ds`;")
 
 
-def test_create_schema_if_not_exists_sql_warns_on_unexpected_prefix_count(caplog):
-    """Prefixes are normally [project, dataset]; a different shape is a caller bug and
-    should be logged as a warning to make it easy to trace."""
+def test_create_schema_if_not_exists_sql_raises_on_unexpected_prefix_count():
+    """Prefixes must be [project, dataset]; any other shape is a caller bug and must raise a
+    clear error rather than silently crashing on the tuple unpack."""
     dialect = BigQuerySqlDialect()
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError):
-            dialect.create_schema_if_not_exists_sql(["only_one_prefix"])
-    assert any("prefixes" in record.getMessage() for record in caplog.records)
+    for bad_prefixes in (["only_one_prefix"], ["a", "b", "c"]):
+        with pytest.raises(ValueError, match="prefixes"):
+            dialect.create_schema_if_not_exists_sql(bad_prefixes)
 
 
 # ---------------------------------------------------------------------------

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -9,6 +9,22 @@ def test_random():
     assert sql == "SELECT RAND()\nFROM `a`;"
 
 
+def test_create_schema_if_not_exists_sql_is_project_qualified():
+    """SAS-13229: CREATE SCHEMA must be qualified with the project (prefixes[0]) so the
+    dataset lands in the intended project — the storage project in a split compute/storage
+    setup — rather than the client's default (compute) project. The base implementation
+    qualifies with the dataset name only, which created the diagnostics dataset in the wrong
+    project and made every diagnostics-warehouse write fail."""
+    dialect = BigQuerySqlDialect()
+    sql = dialect.create_schema_if_not_exists_sql(["mm-storage-project", "soda_diagnostics"], add_semicolon=False)
+    assert sql == "CREATE SCHEMA IF NOT EXISTS `mm-storage-project`.`soda_diagnostics`"
+
+
+def test_create_schema_if_not_exists_sql_default_appends_semicolon():
+    dialect = BigQuerySqlDialect()
+    assert dialect.create_schema_if_not_exists_sql(["proj", "ds"]).endswith("`proj`.`ds`;")
+
+
 # ---------------------------------------------------------------------------
 # BigQuery NUMERIC / BIGNUMERIC precision & scale — INFORMATION_SCHEMA.COLUMNS
 # doesn't expose precision/scale for either type, so the dialect hardcodes the


### PR DESCRIPTION
## Description

**What problem are you solving?**

In a split BigQuery setup (separate compute/execution and storage projects), the diagnostics warehouse failed to write. `BigQuerySqlDialect` inherited the base `create_schema_if_not_exists_sql`, which qualifies with the dataset name only. BigQuery datasets are project-scoped, so `CREATE SCHEMA` created the dataset in the client's default (compute) project while the tables were addressed in the storage project — producing `404 Not found: Dataset <storage-project>:<dataset>` on every write.

**Fix**

Override `create_schema_if_not_exists_sql` in `BigQuerySqlDialect` to qualify the dataset with the project (`prefixes[0]`), consistent with the schema-existence check which already uses it.

```sql
-- before
CREATE SCHEMA IF NOT EXISTS `soda_diagnostics`;
-- after
CREATE SCHEMA IF NOT EXISTS `mm-storage-project`.`soda_diagnostics`;
```

Single-project setups are unchanged (the project equals the client's default, so the dataset lands in the same place as before).

**Expected impact on downstream packages/services**

- This is one half of the SAS-13229 fix. The companion change lives in soda-extensions (`build_dwh_prefixes` → storage project) and is required for the full fix. Verified end-to-end against a live split compute/storage BigQuery setup.
- Snapshots: this changes the emitted BigQuery `CREATE SCHEMA` SQL, so BigQuery snapshot replay falls back to live until the nightly re-record refreshes recordings. Fallback is enabled on PR/main replay, so CI stays green; only BigQuery recordings are affected.

**Reference:** SAS-13229

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
