### PR TITLE
feat(dialect): athena FLOAT casts + weekly BigQuery buckets, lenient athena timestamps, sample-stat nodes, redshift percentile capability

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -18,6 +18,7 @@ from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
     ADD_INTERVAL,
     ALTER_TABLE_ADD_COLUMN,
+    CAST,
     COLUMN,
     CREATE_TABLE,
     CREATE_TABLE_COLUMN,
@@ -354,6 +355,17 @@ class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
         form; approx_percentile is its percentile aggregate."""
         expression_sql: str = self.build_expression_sql(percentile_within_group.expression)
         return f"approx_percentile({expression_sql}, {percentile_within_group.percentile})"
+
+    def _build_cast_sql(self, cast: CAST) -> str:
+        """Athena splits its SQL across two parsers: DDL is Hive (FLOAT is the
+        float32 type; REAL does not exist) while DML/expressions are Trino
+        (REAL is the float32 type; FLOAT does not exist). The canonical type
+        map serves DDL (see get_data_source_data_type_name_by_soda_data_type_names
+        and its create-table consumers), so canonical FLOAT casts must render
+        the Trino name here instead."""
+        if cast.to_type == SodaDataTypeName.FLOAT:
+            return f"CAST({self.build_expression_sql(cast.expression)} AS real)"
+        return super()._build_cast_sql(cast)
 
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from datetime import timezone, tzinfo
+from datetime import datetime, timezone, tzinfo
 from typing import Literal, Optional, Union
 
 import pyathena
+from pyathena.converter import DefaultTypeConverter
 from pydantic import Field, SecretStr, model_validator
 from soda_core.common.aws_credentials import AwsCredentials
 from soda_core.common.data_source_connection import DataSourceConnection
@@ -19,6 +20,25 @@ logger: logging.Logger = soda_logger
 
 
 DEFAULT_CATALOG = "awsdatacatalog"
+
+
+def _to_datetime_lenient(varchar_value: Optional[str]) -> Optional[datetime]:
+    """pyathena's default timestamp converter requires fractional seconds,
+    but Athena renders timestamp(0) values (e.g. second-precision literals
+    fed through date arithmetic) without them — which would fail the whole
+    fetch. Accept both forms."""
+    if varchar_value is None:
+        return None
+    try:
+        return datetime.strptime(varchar_value, "%Y-%m-%d %H:%M:%S.%f")
+    except ValueError:
+        return datetime.strptime(varchar_value, "%Y-%m-%d %H:%M:%S")
+
+
+class LenientTypeConverter(DefaultTypeConverter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mappings["timestamp"] = _to_datetime_lenient
 
 
 class AthenaConnectionProperties(DataSourceConnectionProperties, ABC):
@@ -81,6 +101,7 @@ class AthenaDataSourceConnection(DataSourceConnection):
         )
 
         self.connection = pyathena.connect(
+            converter=LenientTypeConverter(),
             profile_name=self.aws_credentials.profile_name,
             aws_access_key_id=self.aws_credentials.access_key_id,
             aws_secret_access_key=self.aws_credentials.secret_access_key,

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -163,3 +163,42 @@ def test_percentile_within_group_renders_approx_percentile():
 
 def test_supports_percentile_within_group_is_true():
     assert AthenaSqlDialect().supports_percentile_within_group() is True
+
+
+# ---------------------------------------------------------------------------
+# CAST — Athena splits its SQL across two parsers: DDL is Hive (FLOAT exists,
+# REAL does not) while DML/expressions are Trino (REAL exists, FLOAT does
+# not). The canonical type map serves DDL, so canonical FLOAT casts render the
+# Trino name 'real' via the _build_cast_sql override.
+# ---------------------------------------------------------------------------
+
+
+def test_cast_canonical_float_renders_trino_real():
+    from soda_core.common.metadata_types import SodaDataTypeName
+    from soda_core.common.sql_ast import CAST, COLUMN
+
+    sql = AthenaSqlDialect().build_expression_sql(CAST(COLUMN("c"), SodaDataTypeName.FLOAT))
+    assert sql == 'CAST("c" AS real)'
+
+
+def test_cast_other_canonical_types_keep_the_map():
+    from soda_core.common.metadata_types import SodaDataTypeName
+    from soda_core.common.sql_ast import CAST, COLUMN
+
+    dialect = AthenaSqlDialect()
+    assert dialect.build_expression_sql(CAST(COLUMN("c"), SodaDataTypeName.DOUBLE)) == 'CAST("c" AS double)'
+    assert dialect.build_expression_sql(CAST(COLUMN("c"), SodaDataTypeName.VARCHAR)) == 'CAST("c" AS varchar)'
+
+
+def test_cast_raw_string_type_passes_through():
+    from soda_core.common.sql_ast import CAST, COLUMN
+
+    assert AthenaSqlDialect().build_expression_sql(CAST(COLUMN("c"), "varchar")) == 'CAST("c" AS varchar)'
+
+
+def test_ddl_float_type_name_stays_hive_float():
+    """The DDL map keeps the Hive name — CREATE EXTERNAL TABLE consumers
+    resolve through it and Hive has no 'real'."""
+    from soda_core.common.metadata_types import SodaDataTypeName
+
+    assert AthenaSqlDialect().get_data_source_data_type_name_for_soda_data_type_name(SodaDataTypeName.FLOAT) == "float"

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -202,3 +202,23 @@ def test_ddl_float_type_name_stays_hive_float():
     from soda_core.common.metadata_types import SodaDataTypeName
 
     assert AthenaSqlDialect().get_data_source_data_type_name_for_soda_data_type_name(SodaDataTypeName.FLOAT) == "float"
+
+
+# ---------------------------------------------------------------------------
+# Result timestamp parsing — Athena renders timestamp(0) values without a
+# fractional part, which pyathena's default converter rejects.
+# ---------------------------------------------------------------------------
+
+
+def test_lenient_timestamp_converter_accepts_both_precisions():
+    from datetime import datetime
+
+    from soda_athena.common.data_sources.athena_data_source_connection import (
+        LenientTypeConverter,
+    )
+
+    converter = LenientTypeConverter()
+    convert = converter.mappings["timestamp"]
+    assert convert("2026-07-04 00:00:00.123000") == datetime(2026, 7, 4, 0, 0, 0, 123000)
+    assert convert("2026-07-04 00:00:00") == datetime(2026, 7, 4)
+    assert convert(None) is None

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -196,6 +196,15 @@ def test_cast_raw_string_type_passes_through():
     assert AthenaSqlDialect().build_expression_sql(CAST(COLUMN("c"), "varchar")) == 'CAST("c" AS varchar)'
 
 
+def test_cast_raw_string_float_also_renders_real():
+    """SodaDataTypeName is a str-enum, so a raw 'float' cast type compares
+    equal to SodaDataTypeName.FLOAT and takes the override too — desirable,
+    since a passed-through 'float' would be invalid Trino DML anyway."""
+    from soda_core.common.sql_ast import CAST, COLUMN
+
+    assert AthenaSqlDialect().build_expression_sql(CAST(COLUMN("c"), "float")) == 'CAST("c" AS real)'
+
+
 def test_ddl_float_type_name_stays_hive_float():
     """The DDL map keeps the Hive name — CREATE EXTERNAL TABLE consumers
     resolve through it and Hive has no 'real'."""

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -234,9 +234,11 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         quantile_number: int = int(percentile_within_group.percentile * 1000)
         return f"APPROX_QUANTILES({expression_sql}, 1000)[{quantile_number}]"
 
-    # Singular unit names for TIMESTAMP_DIFF/TIMESTAMP_ADD.
+    # Singular unit names for TIMESTAMP_DIFF/TIMESTAMP_ADD. WEEK is deliberately
+    # absent: BigQuery's TIMESTAMP functions only accept MICROSECOND..DAY parts
+    # (WEEK is a DATE_DIFF/DATETIME_DIFF-only part), so weekly arithmetic
+    # renders day-denominated in both builders below.
     _TIME_BUCKET_UNIT_NAMES: dict = {
-        "weeks": "WEEK",
         "days": "DAY",
         "hours": "HOUR",
         "seconds": "SECOND",
@@ -245,18 +247,21 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
         start_sql: str = self.build_expression_sql(time_delta.start)
         end_sql: str = self.build_expression_sql(time_delta.end)
-        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[time_delta.unit]
+        # Weekly buckets index as day-buckets of 7×count: floor(days / 7·count)
+        # is the same partition index.
+        unit, count = time_delta.unit, time_delta.count
+        if unit == "weeks":
+            unit, count = "days", count * 7
+        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[unit]
         sql: str = f"TIMESTAMP_DIFF({end_sql}, {start_sql}, {unit_name})"
-        if time_delta.count != 1:
-            sql = f"CAST(FLOOR({sql} / {time_delta.count}) AS INT)"
+        if count != 1:
+            sql = f"CAST(FLOOR({sql} / {count}) AS INT)"
         return sql
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
-        # BigQuery TIMESTAMP_ADD only accepts MICROSECOND..DAY parts — WEEK is invalid here
-        # (it is valid for TIMESTAMP_DIFF, hence the asymmetry with _build_time_delta_sql).
-        # Express weekly buckets as INTERVAL <count> * 7 DAY.
+        # Weekly intervals render as INTERVAL <count> * 7 DAY.
         if add_interval.unit == "weeks":
             return f"TIMESTAMP_ADD({timestamp_sql}, INTERVAL {count_sql} * 7 DAY)"
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -247,18 +247,6 @@ def test_add_interval_weeks_renders_as_days_times_seven():
     assert sql == "TIMESTAMP_ADD('2020-06-20T00:00:00', INTERVAL ((soda_partition__ + 1) * 1) * 7 DAY)"
 
 
-def test_time_delta_weeks_keeps_week_part():
-    # The TIMESTAMP_DIFF path DOES accept WEEK; it must stay unchanged.
-    from datetime import datetime
-
-    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
-
-    sql = BigQuerySqlDialect().build_expression_sql(
-        TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "weeks", 1)
-    )
-    assert sql == "TIMESTAMP_DIFF((`ts`), '2020-06-20T00:00:00', WEEK)"
-
-
 # ---------------------------------------------------------------------------
 # BigQuery string literal escaping — literal_string wraps values in triple
 # single quotes ('''...'''). If a bare ''' survives inside the content it
@@ -343,3 +331,46 @@ def test_literal_string_embedded_scan_id_query_roundtrips():
 
 def test_literal_string_none_returns_none():
     assert BigQuerySqlDialect().literal_string(None) is None
+
+
+# ---------------------------------------------------------------------------
+# TIME_DELTA / ADD_INTERVAL — weekly arithmetic renders day-denominated:
+# BigQuery TIMESTAMP functions only accept MICROSECOND..DAY parts (WEEK is a
+# DATE_DIFF/DATETIME_DIFF-only part).
+# ---------------------------------------------------------------------------
+
+
+def test_time_delta_weekly_buckets_render_day_denominated():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = BigQuerySqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 1)), SqlExpressionStr("`ts`"), "weeks", 2)
+    )
+    assert "WEEK" not in sql
+    assert sql.endswith("DAY) / 14) AS INT)")
+
+
+def test_time_delta_single_week_still_floors_by_seven_days():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
+
+    sql = BigQuerySqlDialect().build_expression_sql(
+        TIME_DELTA(LITERAL(datetime(2020, 6, 1)), SqlExpressionStr("`ts`"), "weeks", 1)
+    )
+    assert "WEEK" not in sql
+    assert sql.endswith("DAY) / 7) AS INT)")
+
+
+def test_add_interval_weekly_renders_seven_day_multiple():
+    from datetime import datetime
+
+    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
+
+    sql = BigQuerySqlDialect().build_expression_sql(
+        ADD_INTERVAL(LITERAL(datetime(2020, 6, 1)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 2"))
+    )
+    assert "WEEK" not in sql
+    assert "* 7 DAY)" in sql

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -234,8 +234,8 @@ def test_add_interval_renders_timestamp_add():
 
 
 def test_add_interval_weeks_renders_as_days_times_seven():
-    # BigQuery TIMESTAMP_ADD accepts only MICROSECOND..DAY parts; WEEK is invalid
-    # there (though valid for TIMESTAMP_DIFF), so weekly buckets must be expressed
+    # BigQuery TIMESTAMP functions accept only MICROSECOND..DAY parts (WEEK is a
+    # DATE_DIFF/DATETIME_DIFF-only part), so weekly intervals must be expressed
     # as INTERVAL <count> * 7 DAY.
     from datetime import datetime
 
@@ -362,15 +362,3 @@ def test_time_delta_single_week_still_floors_by_seven_days():
     )
     assert "WEEK" not in sql
     assert sql.endswith("DAY) / 7) AS INT)")
-
-
-def test_add_interval_weekly_renders_seven_day_multiple():
-    from datetime import datetime
-
-    from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
-
-    sql = BigQuerySqlDialect().build_expression_sql(
-        ADD_INTERVAL(LITERAL(datetime(2020, 6, 1)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 2"))
-    )
-    assert "WEEK" not in sql
-    assert "* 7 DAY)" in sql

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -534,6 +534,28 @@ class AVERAGE(SqlExpression):
 
 
 @dataclass
+class STDDEV_SAMP(SqlExpression):
+    """Sample standard deviation aggregate."""
+
+    expression: SqlExpression | str
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.handle_parent_node_update(self.expression)
+
+
+@dataclass
+class VAR_SAMP(SqlExpression):
+    """Sample variance aggregate."""
+
+    expression: SqlExpression | str
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.handle_parent_node_update(self.expression)
+
+
+@dataclass
 class MAX(SqlExpression):
     expression: SqlExpression | str
 

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -91,6 +91,7 @@ from soda_core.common.sql_ast import (
     REGEX_LIKE,
     SELECT,
     STAR,
+    STDDEV_SAMP,
     STRING_HASH,
     SUM,
     TIME_DELTA,
@@ -99,6 +100,7 @@ from soda_core.common.sql_ast import (
     UNION_ALL,
     VALUES,
     VALUES_ROW,
+    VAR_SAMP,
     WHERE,
     WINDOW_FUNCTION,
     WITH,
@@ -867,6 +869,10 @@ class SqlDialect:
             return self._build_min_sql(expression)
         elif isinstance(expression, AVERAGE):
             return self._build_average_sql(expression)
+        elif isinstance(expression, STDDEV_SAMP):
+            return self._build_stddev_samp_sql(expression)
+        elif isinstance(expression, VAR_SAMP):
+            return self._build_var_samp_sql(expression)
         elif isinstance(expression, COALESCE):
             return self._build_coalesce_sql(expression)
         elif isinstance(expression, CAST):
@@ -1090,6 +1096,12 @@ class SqlDialect:
         over_sql: str = " ".join(over_clauses)
         return f"{wf.name}({args_list_sql}) OVER ({over_sql})"
 
+    def supports_percentiles_with_other_distinct_aggregates(self) -> bool:
+        """Whether percentile aggregates (PERCENTILE_CONT/DISC, MEDIAN) can
+        share one SELECT with other DISTINCT aggregates. Redshift refuses the
+        combination; consumers batch percentile aggregates separately there."""
+        return True
+
     def supports_percentile_within_group(self) -> bool:
         """False when the engine has no percentile aggregate at all — exact or
         approximate (Synapse). Consumers skip the Q1/median/Q3 metrics instead
@@ -1191,6 +1203,15 @@ class SqlDialect:
 
     def _build_average_sql(self, average: AVERAGE) -> str:
         return f"AVG({self.build_expression_sql(average.expression)})"
+
+    def _build_stddev_samp_sql(self, stddev_samp: STDDEV_SAMP) -> str:
+        """Sample standard deviation; the T-SQL family overrides with STDEV
+        (STDDEV_SAMP is not a recognized function there)."""
+        return f"STDDEV_SAMP({self.build_expression_sql(stddev_samp.expression)})"
+
+    def _build_var_samp_sql(self, var_samp: VAR_SAMP) -> str:
+        """Sample variance; the T-SQL family overrides with VAR."""
+        return f"VAR_SAMP({self.build_expression_sql(var_samp.expression)})"
 
     def _build_coalesce_sql(self, coalesce: COALESCE) -> str:
         args: str = ", ".join([self.build_expression_sql(expression) for expression in coalesce.args])

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -55,6 +55,12 @@ class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel
 
 
 class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
+    def supports_percentiles_with_other_distinct_aggregates(self) -> bool:
+        # Redshift: "Using LISTAGG/PERCENTILE_CONT/MEDIAN aggregate functions
+        # with other distinct aggregate function not supported" — consumers
+        # batch percentile aggregates into their own SELECT.
+        return False
+
     SODA_DATA_TYPE_SYNONYMS = (
         (SodaDataTypeName.TEXT, SodaDataTypeName.VARCHAR),
         (SodaDataTypeName.CHAR, SodaDataTypeName.VARCHAR),  # Char is mapped to varchar in the cursor description.

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -77,3 +77,9 @@ def test_percentile_within_group_renders_approximate_percentile_disc():
 
 def test_supports_percentile_within_group_is_true():
     assert RedshiftSqlDialect().supports_percentile_within_group() is True
+
+
+def test_percentiles_cannot_share_select_with_other_distinct_aggregates():
+    """Redshift refuses PERCENTILE_CONT/DISC/MEDIAN combined with other
+    DISTINCT aggregates in one SELECT; consumers batch them separately."""
+    assert RedshiftSqlDialect().supports_percentiles_with_other_distinct_aggregates() is False

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -121,6 +121,14 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         self.server_major_version: Optional[int] = None
         self.engine_edition: Optional[int] = None
 
+    def _build_stddev_samp_sql(self, stddev_samp) -> str:
+        # T-SQL names the sample standard deviation aggregate STDEV.
+        return f"STDEV({self.build_expression_sql(stddev_samp.expression)})"
+
+    def _build_var_samp_sql(self, var_samp) -> str:
+        # T-SQL names the sample variance aggregate VAR.
+        return f"VAR({self.build_expression_sql(var_samp.expression)})"
+
     def supports_percentile_within_group(self) -> bool:
         # T-SQL exposes percentiles as an aggregate only via APPROX_PERCENTILE_DISC:
         # SQL Server 2022+ (ProductMajorVersion >= 16), Azure SQL Database, or Azure

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -200,3 +200,21 @@ def test_literal_timestamp_typed_normalizes_tz_aware_to_utc():
     plus_two = timezone(timedelta(hours=2))
     sql = SqlServerSqlDialect().literal_timestamp_typed(datetime(2020, 6, 20, 3, 2, 3, tzinfo=plus_two))
     assert sql == "CAST('2020-06-20 01:02:03' AS DATETIME2)"
+
+
+# ---------------------------------------------------------------------------
+# Sample-stat aggregates — T-SQL names them STDEV/VAR (STDDEV_SAMP/VAR_SAMP
+# are not recognized functions).
+# ---------------------------------------------------------------------------
+
+
+def test_stddev_samp_renders_stdev():
+    from soda_core.common.sql_ast import COLUMN, STDDEV_SAMP
+
+    assert SqlServerSqlDialect().build_expression_sql(STDDEV_SAMP(COLUMN("c"))) == "STDEV([c])"
+
+
+def test_var_samp_renders_var():
+    from soda_core.common.sql_ast import COLUMN, VAR_SAMP
+
+    assert SqlServerSqlDialect().build_expression_sql(VAR_SAMP(COLUMN("c"))) == "VAR([c])"


### PR DESCRIPTION
## What
Dialect-level seams so soda-extensions observability code stops branching on dialect names (review direction from soda-extensions#516):

1. **Athena `_build_cast_sql` override** — canonical FLOAT casts render the Trino DML type `real` (Athena DDL is Hive where `float` is the float32 name; DML is Trino where it is `real`; the single canonical map serves DDL). The DDL map deliberately keeps `float`, pinned by a test.
2. **`STDDEV_SAMP` / `VAR_SAMP` AST nodes** — base renders the standard names; the T-SQL family (SqlServerSqlDialect + synapse/fabric subclasses) renders `STDEV`/`VAR`.
3. **BigQuery weekly time buckets** — `TIME_DELTA` renders weekly buckets day-denominated (`floor(days / 7·count)`): `TIMESTAMP_DIFF` only accepts MICROSECOND..DAY parts, and the previous `WEEK` rendering fails on the live engine (the test pinning it was authored from the renderer, not the engine — removed). `ADD_INTERVAL` already rendered weeks as `* 7 DAY`.
4. **Athena lenient timestamp converter** — pyathena's default converter requires fractional seconds and fails the whole fetch on `timestamp(0)` values (e.g. second-precision literals fed through date arithmetic); the connection now registers a converter accepting both forms.
5. **`supports_percentiles_with_other_distinct_aggregates()`** capability (base True, Redshift False) — Redshift refuses percentile aggregates combined with other DISTINCT aggregates in one SELECT; consumers batch them separately without naming the dialect.

## Consumers
soda-extensions#516 pins this branch (`SODA_CORE_BRANCH=athena-cast-real-not-float`) and removes all corresponding dialect-name branches from profiling/metric-monitoring; soda-extensions#515 reverts the FLOAT-cast workarounds once this merges.

## Tests
Unit pins in soda-athena / soda-bigquery / soda-sqlserver / soda-redshift dialect test files; live validation via soda-extensions#516's full data-source matrix against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)