### PR TITLE
fix(sqlserver): retry deadlock victims with jittered exponential backoff

### DIFF
--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import logging
+import random
 import struct
+import time
 from abc import ABC
 from datetime import datetime, timedelta, timezone, tzinfo
-from typing import Any, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 import pyodbc
 from pydantic import Field, SecretStr
 from soda_core.__version__ import SODA_CORE_VERSION
 from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_results import QueryResult
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
@@ -106,6 +109,48 @@ def handle_datetimeoffset(dto_value):
 
 
 class SqlServerDataSourceConnection(DataSourceConnection):
+    # SQL Server resolves lock conflicts by killing one participant with error 1205
+    # (SQLSTATE 40001) and rolling its transaction back; Microsoft's guidance is to
+    # rerun the killed transaction. Concurrent DDL and catalog scans in the same
+    # database can deadlock on the system base tables, so statements are retried a
+    # few times before the error is propagated. The pause is drawn uniformly from
+    # an exponentially growing window (full jitter) so that the parties of a killed
+    # deadlock don't retry in lockstep and immediately deadlock again.
+    DEADLOCK_MAX_ATTEMPTS: int = 3
+    DEADLOCK_RETRY_BACKOFF_SECONDS: float = 0.1
+
+    def execute_query(self, sql: str, log_query: bool = True) -> QueryResult:
+        execute = super().execute_query
+        return self._execute_with_deadlock_retry(lambda: execute(sql, log_query))
+
+    def execute_update(self, sql: str, log_query: bool = True) -> int:
+        execute = super().execute_update
+        return self._execute_with_deadlock_retry(lambda: execute(sql, log_query))
+
+    @staticmethod
+    def _is_deadlock_error(e: pyodbc.Error) -> bool:
+        # pyodbc error args are (sqlstate, message); 40001 is the serialization
+        # failure SQLSTATE that SQL Server raises for deadlock victims (1205).
+        return bool(e.args) and e.args[0] == "40001"
+
+    def _execute_with_deadlock_retry(self, operation: Callable[[], Any]) -> Any:
+        for attempt in range(1, self.DEADLOCK_MAX_ATTEMPTS + 1):
+            try:
+                return operation()
+            except pyodbc.Error as e:
+                if not self._is_deadlock_error(e) or attempt == self.DEADLOCK_MAX_ATTEMPTS:
+                    raise
+                logger.warning(
+                    f"Deadlock victim on '{self.name}' "
+                    f"(attempt {attempt}/{self.DEADLOCK_MAX_ATTEMPTS}), retrying: {e}"
+                )
+                try:
+                    self.connection.rollback()
+                except Exception as rollback_error:
+                    logger.warning(f"Rollback after deadlock on '{self.name}' failed: {rollback_error}")
+                backoff_cap = self.DEADLOCK_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                time.sleep(random.uniform(0, backoff_cap))
+
     def __init__(self, name: str, connection_properties: DataSourceConnectionProperties):
         # Set before super().__init__(), which auto-opens the connection and
         # populates these from the live server in _create_connection.

--- a/soda-sqlserver/tests/unit/test_sqlserver_deadlock_retry.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_deadlock_retry.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import random
+import time
+
+import pyodbc
+import pytest
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+    SqlServerDataSourceConnection,
+)
+
+
+def deadlock_error() -> pyodbc.Error:
+    return pyodbc.Error(
+        "40001",
+        "[40001] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]"
+        "Transaction (Process ID 71) was deadlocked on lock resources with "
+        "another process and has been chosen as the deadlock victim. "
+        "Rerun the transaction. (1205) (SQLExecDirectW)",
+    )
+
+
+class FakeCursor:
+    def __init__(self, connection: FakeConnection):
+        self._connection = connection
+        self.description = [("col",)]
+        self.rowcount = 1
+
+    def execute(self, sql: str) -> None:
+        self._connection.executed_sqls.append(sql)
+        if self._connection.outcomes:
+            outcome = self._connection.outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+
+    def fetchall(self) -> list[tuple]:
+        return [("row1",)]
+
+    def close(self) -> None:
+        pass
+
+
+class FakeConnection:
+    def __init__(self, outcomes: list):
+        # One entry per expected execute() call: an Exception to raise, or None for success.
+        self.outcomes = outcomes
+        self.executed_sqls: list[str] = []
+        self.rollback_count = 0
+        self.commit_count = 0
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def rollback(self) -> None:
+        self.rollback_count += 1
+
+    def commit(self) -> None:
+        self.commit_count += 1
+
+
+def make_data_source_connection(fake_connection: FakeConnection) -> SqlServerDataSourceConnection:
+    data_source_connection = SqlServerDataSourceConnection.__new__(SqlServerDataSourceConnection)
+    data_source_connection.name = "test_sqlserver"
+    data_source_connection.connection = fake_connection
+    return data_source_connection
+
+
+def test_execute_query_reraises_when_deadlock_persists(monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    fake_connection = FakeConnection(outcomes=[deadlock_error(), deadlock_error(), deadlock_error()])
+    data_source_connection = make_data_source_connection(fake_connection)
+
+    with pytest.raises(pyodbc.Error):
+        data_source_connection.execute_query("SELECT 1")
+
+    assert len(fake_connection.executed_sqls) == SqlServerDataSourceConnection.DEADLOCK_MAX_ATTEMPTS
+    assert fake_connection.rollback_count == SqlServerDataSourceConnection.DEADLOCK_MAX_ATTEMPTS - 1
+
+
+def test_deadlock_backoff_is_exponential_with_jitter(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda seconds: sleeps.append(seconds))
+    # Make the jitter deterministic: uniform(0, cap) -> cap, so the recorded
+    # sleeps expose the exponential caps the jitter is drawn from.
+    monkeypatch.setattr(random, "uniform", lambda low, high: high)
+    fake_connection = FakeConnection(outcomes=[deadlock_error(), deadlock_error(), deadlock_error()])
+    data_source_connection = make_data_source_connection(fake_connection)
+
+    with pytest.raises(pyodbc.Error):
+        data_source_connection.execute_query("SELECT 1")
+
+    base = SqlServerDataSourceConnection.DEADLOCK_RETRY_BACKOFF_SECONDS
+    assert base < 0.5
+    assert sleeps == [base, base * 2]
+
+
+def test_execute_update_retries_after_deadlock(monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    fake_connection = FakeConnection(outcomes=[deadlock_error(), None])
+    data_source_connection = make_data_source_connection(fake_connection)
+
+    rowcount = data_source_connection.execute_update("DROP SCHEMA [test_schema];")
+
+    assert rowcount == 1
+    assert len(fake_connection.executed_sqls) == 2
+    assert fake_connection.rollback_count == 1
+    assert fake_connection.commit_count == 1
+
+
+def test_execute_query_does_not_retry_non_deadlock_errors(monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    syntax_error = pyodbc.ProgrammingError("42000", "[42000] Incorrect syntax near 'SELEC'.")
+    fake_connection = FakeConnection(outcomes=[syntax_error, None])
+    data_source_connection = make_data_source_connection(fake_connection)
+
+    with pytest.raises(pyodbc.ProgrammingError):
+        data_source_connection.execute_query("SELEC 1")
+
+    assert len(fake_connection.executed_sqls) == 1
+    assert fake_connection.rollback_count == 0
+
+
+def test_execute_query_retries_after_deadlock(monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    fake_connection = FakeConnection(outcomes=[deadlock_error(), None])
+    data_source_connection = make_data_source_connection(fake_connection)
+
+    query_result = data_source_connection.execute_query("SELECT 1")
+
+    assert query_result.rows == [("row1",)]
+    assert len(fake_connection.executed_sqls) == 2
+    assert fake_connection.rollback_count == 1


### PR DESCRIPTION
## Problem

SQL Server CI jobs fail intermittently with:

```
pyodbc.Error: ('40001', '... Transaction (Process ID N) was deadlocked on lock resources
with another process and has been chosen as the deadlock victim. Rerun the transaction. (1205) ...')
```

Root cause: under pytest-xdist all workers share one database. Per-worker schemas isolate the *user tables*, but not the **system catalog** — the test harness's frequent metadata scans (`information_schema.tables` lookups in `ensure_test_table` and schema teardown) take shared locks across catalog rows of *all* schemas, while other workers run `CREATE TABLE` / `DROP TABLE` / `DROP SCHEMA` DDL holding exclusive locks on the same system base tables. SQL Server resolves the resulting deadlock by killing the (cheaper) reader.

## Fix

`SqlServerDataSourceConnection.execute_query` / `execute_update` now retry statements killed as deadlock victims (SQLSTATE `40001`), which is Microsoft's documented remedy for error 1205:

- up to 3 attempts, then the error propagates
- `rollback()` between attempts to clear the aborted transaction
- full-jitter exponential backoff (`uniform(0, 0.1s)`, then `uniform(0, 0.2s)`) so both parties of a killed deadlock don't retry in lockstep
- all other `pyodbc` errors propagate unchanged

Fabric and Synapse connections subclass this connection and inherit the behavior.

## Testing

- 4 new unit tests in `soda-sqlserver/tests/unit/test_sqlserver_deadlock_retry.py` (retry-then-succeed, non-deadlock errors not retried, re-raise after persistent deadlocks, `execute_update` path, backoff shape) — written test-first
- Full `soda-sqlserver`, `soda-fabric`, `soda-synapse` suites pass (63 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)