### PR TITLE
feat(discovery): upload run logs with successful discovery results

### DIFF
--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -541,8 +541,9 @@ def _setup_data_source_discover_command(data_source_parsers) -> None:
             # SODA_SCAN_DEFINITION) resolve inside the wrapped command: their
             # failures take the standard mark-with-logs mapping.
             # Discovery constructs no inner Logs (discover_dataset_dqns emits via soda_logger,
-            # which already lands in the active wrapper collector), so the wrapper's
-            # ``logs`` is accepted and ignored here.
+            # which already lands in the active wrapper collector); the wrapper's
+            # ``logs`` is threaded through so the success payload carries the
+            # run's logs to Soda Cloud.
             exit_code = run_with_failure_reporting(
                 soda_cloud,
                 lambda logs: handle_discover_data_source(
@@ -551,6 +552,7 @@ def _setup_data_source_discover_command(data_source_parsers) -> None:
                     scan_definition_name=resolve_scan_definition_name(args.scan_definition_name),
                     include=args.include,
                     exclude=args.exclude,
+                    logs=logs,
                 ),
             )
             exit_with_code(exit_code)

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -166,6 +166,7 @@ def handle_discover_data_source(
     scan_definition_name: str,
     include: Optional[list[str]] = None,
     exclude: Optional[list[str]] = None,
+    logs: Optional[Logs] = None,
 ) -> ExitCode:
     """Discover datasets and send the results to Soda Cloud.
 
@@ -190,6 +191,7 @@ def handle_discover_data_source(
         scan_definition_name=scan_definition_name,
         scan_start_timestamp=scan_start_timestamp,
         scan_end_timestamp=scan_end_timestamp,
+        log_records=logs.get_log_records() if logs else None,
     )
     if not soda_cloud.insert_scan_results(payload):
         soda_logger.error(f"{Emoticons.POLICE_CAR_LIGHT} Discovery results were not accepted by Soda Cloud.")

--- a/soda-core/src/soda_core/discovery/discovery_payload.py
+++ b/soda-core/src/soda_core/discovery/discovery_payload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
+from logging import LogRecord
 from typing import Optional
 
 from soda_core.common.datetime_conversions import (
@@ -9,6 +10,7 @@ from soda_core.common.datetime_conversions import (
     convert_str_to_datetime,
 )
 from soda_core.common.env_config_helper import EnvConfigHelper
+from soda_core.common.soda_cloud import build_log_cloud_json_dict
 from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO
 
 
@@ -30,6 +32,7 @@ def build_discovery_payload(
     data_timestamp: Optional[datetime] = None,
     scan_start_timestamp: Optional[datetime] = None,
     scan_end_timestamp: Optional[datetime] = None,
+    log_records: Optional[list[LogRecord]] = None,
 ) -> SodaCoreInsertScanResultsDTO:
     """Build a DQN-only sodaCoreInsertScanResults body for discovery.
 
@@ -38,8 +41,11 @@ def build_discovery_payload(
     missing timestamps default to now (UTC) and the data timestamp falls back to
     ``SODA_SCAN_DATA_TIMESTAMP`` / scan start. ``hasErrors`` is False because the
     discovery handler only sends the payload after a successful discovery run.
-    Timestamps are serialized like soda-core's ``to_jsonnable`` (ISO-8601 UTC).
-    Sent via ``SodaCloud.insert_scan_results``."""
+    ``log_records`` are the run's collected logs; they travel inside the payload
+    (``SodaCoreInsertScanResultsCommand.logs``) so a successful scan has logs in
+    Soda Cloud too — failures are reported with logs separately, via
+    ``mark_scan_as_failed``. Timestamps are serialized like soda-core's
+    ``to_jsonnable`` (ISO-8601 UTC). Sent via ``SodaCloud.insert_scan_results``."""
     now: datetime = datetime.now(timezone.utc)
     scan_start_timestamp = scan_start_timestamp or now
     scan_end_timestamp = scan_end_timestamp or now
@@ -56,6 +62,9 @@ def build_discovery_payload(
         "scanEndTimestamp": convert_datetime_to_str(scan_end_timestamp),
         "hasErrors": False,
         "metadata": [{"datasetQualifiedName": dqn} for dqn in dqns],
+        "logs": [build_log_cloud_json_dict(record, index) for index, record in enumerate(log_records)]
+        if log_records
+        else [],
         "checks": [],
         "metrics": [],
         "profiling": [],

--- a/soda-tests/tests/unit/test_cli_discover.py
+++ b/soda-tests/tests/unit/test_cli_discover.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from soda_core.cli.cli import create_cli_parser
@@ -48,11 +48,15 @@ def test_cli_arg_mapping_for_data_source_discover(
     mock_resolve_data_source.assert_called_once_with("ds.yaml")
     run_args, _ = mock_run_with_failure_reporting.call_args
     assert run_args[0] is soda_cloud
+    # The wrapper's Logs collector is threaded through to the handler so the
+    # success payload can carry the run's logs; ANY because the collector is
+    # constructed inside the wrapper.
     mock_handler.assert_called_once_with(
         data_source_impl,
         soda_cloud,
         include=["cust%"],
         exclude=["tmp%"],
+        logs=ANY,
         scan_definition_name="my_scan",
     )
 

--- a/soda-tests/tests/unit/test_discovery_payload.py
+++ b/soda-tests/tests/unit/test_discovery_payload.py
@@ -127,3 +127,31 @@ def test_payload_data_timestamp_falls_back_to_scan_start_on_unparseable_env(monk
         scan_end_timestamp=datetime(2026, 7, 10, 8, 30, 5, tzinfo=timezone.utc),
     )
     assert payload["dataTimestamp"] == "2026-07-10T08:30:00+00:00"
+
+
+def test_payload_carries_run_logs():
+    import logging
+
+    record = logging.LogRecord(
+        name="soda", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="Discovered 2 datasets", args=(), exc_info=None,
+    )
+    payload = build_discovery_payload(
+        dqns=["postgres/soda/public/customers"],
+        data_source_name="postgres",
+        scan_definition_name="postgres_schema_discovery_scan",
+        log_records=[record],
+    )
+    assert len(payload["logs"]) == 1
+    assert payload["logs"][0]["message"] == "Discovered 2 datasets"
+    assert payload["logs"][0]["level"] == "info"
+    assert payload["logs"][0]["index"] == 0
+
+
+def test_payload_logs_default_to_empty():
+    payload = build_discovery_payload(
+        dqns=[],
+        data_source_name="postgres",
+        scan_definition_name="postgres_schema_discovery_scan",
+    )
+    assert payload["logs"] == []

--- a/soda-tests/tests/unit/test_discovery_payload.py
+++ b/soda-tests/tests/unit/test_discovery_payload.py
@@ -133,8 +133,13 @@ def test_payload_carries_run_logs():
     import logging
 
     record = logging.LogRecord(
-        name="soda", level=logging.INFO, pathname=__file__, lineno=1,
-        msg="Discovered 2 datasets", args=(), exc_info=None,
+        name="soda",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Discovered 2 datasets",
+        args=(),
+        exc_info=None,
     )
     payload = build_discovery_payload(
         dqns=["postgres/soda/public/customers"],


### PR DESCRIPTION
## What

Successful discovery scans currently have no logs in Soda Cloud (`logLocation` stays null): scan logs travel inside the `sodaCoreInsertScanResults` payload (`SodaCoreInsertScanResultsCommand.logs` → parquet on the backend), and the shared check-collection payload builder includes them (`soda_cloud.py` `"logs": logs`) — but discovery builds its own envelope and never did. Only *failed* runs got logs, via `mark_scan_as_failed` / the launcher — exactly backwards for debugging a successful-but-odd run.

This threads the CLI wrapper's `Logs` collector (`run_with_failure_reporting` already hands it to every command) through `handle_discover_data_source` into `build_discovery_payload`, which now emits the `logs` field using the same `build_log_cloud_json_dict` conversion the check-collection and failure paths use.

Profiling has the same gap on its own envelope — companion PR: sodadata/soda-extensions#520.

Found during the v4 observability runner-rollout E2E (OBSL-1030): discovery/profiling successes showed `logLocation NULL` while contract/MM successes showed `parquet`.

## Testing

`test_discovery_payload.py`: payload carries converted run logs (message/level/index); defaults to `[]` without records; existing DTO shape-conformance test covers the new key (`logs` was already declared on `SodaCoreInsertScanResultsDTO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
