### PR TITLE
fix(logging): don't mutate frame.f_locals while iterating in _mask_exception

### DIFF
--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -136,12 +136,21 @@ def _mask_exception(e: Optional[BaseException]) -> Optional[BaseException]:
     tb = e.__traceback__
     while tb is not None:
         frame = tb.tb_frame
-        # Mask local variables in the frame that are strings
+        # Mask local variables in the frame that are strings.
+        # Iterate over a snapshot (``list(...)``): assigning ``frame.f_locals[...]``
+        # re-syncs the frame's fast locals, mutating the very mapping being iterated,
+        # which raises "dictionary keys changed during iteration" on Python < 3.13 for
+        # some frames (e.g. the closure frames added by the SQL Server deadlock-retry
+        # wrapper). Masking is best-effort and cosmetic, so it must never break logging:
+        # a failure here previously propagated out of the logging handler and silently
+        # dropped the record, swallowing the very error being logged.
         if frame.f_locals:
-            for var_name, var_value in frame.f_locals.items():
-                if isinstance(var_value, str):
-                    masked_value = _mask_message(var_value)
-                    frame.f_locals[var_name] = masked_value
+            try:
+                for var_name, var_value in list(frame.f_locals.items()):
+                    if isinstance(var_value, str):
+                        frame.f_locals[var_name] = _mask_message(var_value)
+            except Exception:
+                pass
         tb = tb.tb_next
 
     # Recursively mask chained exceptions

--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -101,8 +101,19 @@ def _mask_record(record: LogRecord):
     record.args = ()
     if record.exc_info:
         exc_type, exc_value, exc_tb = record.exc_info
-        masked_exc = _mask_exception(exc_value)
-        record.exc_info = (exc_type, masked_exc, exc_tb)
+        try:
+            masked_exc = _mask_exception(exc_value)
+        except MaskingError:
+            # Masking is a security control, not best-effort: an exception whose
+            # secrets could not be masked must never reach a handler. The record
+            # itself is kept (its message is already masked above, and an ERROR must
+            # stay an ERROR so check outcomes are not silently downgraded), but the
+            # exception and any cached traceback text are dropped entirely.
+            record.exc_info = None
+            record.exc_text = None
+            record.msg = f"{record.msg} {REDACTED_EXCEPTION_MARKER}"
+        else:
+            record.exc_info = (exc_type, masked_exc, exc_tb)
     else:
         record.exc_info = None
 
@@ -117,47 +128,65 @@ def _mask_message(message: Optional[str]) -> Optional[str]:
     return message
 
 
+class MaskingError(Exception):
+    """Secret masking of an exception could not be completed.
+
+    Raised by ``_mask_exception`` instead of letting the underlying error escape: the
+    original error is deliberately not chained (``from None``) because its traceback
+    frames are exactly what could not be masked.
+    """
+
+
+REDACTED_EXCEPTION_MARKER = "[exception redacted: secret masking failed]"
+
+
 def _mask_exception(e: Optional[BaseException]) -> Optional[BaseException]:
+    """Mask registered secrets in an exception's args and traceback frame locals.
+
+    Raises ``MaskingError`` if any part of the exception could not be masked. Callers
+    must then treat the whole exception as unmaskable and drop it (see ``_mask_record``)
+    rather than log it partially masked.
+    """
     if e is None:
         return None
 
-    # Mask the exception's args (usually contains the error message)
-    if e.args:
-        masked_args = []
-        for arg in e.args:
-            if isinstance(arg, str):
-                masked_arg = _mask_message(arg)
-                masked_args.append(masked_arg)
-            else:
-                masked_args.append(arg)
-        e.args = tuple(masked_args)
+    try:
+        # Mask the exception's args (usually contains the error message)
+        if e.args:
+            masked_args = []
+            for arg in e.args:
+                if isinstance(arg, str):
+                    masked_arg = _mask_message(arg)
+                    masked_args.append(masked_arg)
+                else:
+                    masked_args.append(arg)
+            e.args = tuple(masked_args)
 
-    # Mask the traceback frames
-    tb = e.__traceback__
-    while tb is not None:
-        frame = tb.tb_frame
-        # Mask local variables in the frame that are strings.
-        # Iterate over a snapshot (``list(...)``): assigning ``frame.f_locals[...]``
-        # re-syncs the frame's fast locals, mutating the very mapping being iterated,
-        # which raises "dictionary keys changed during iteration" on Python < 3.13 for
-        # some frames (e.g. the closure frames added by the SQL Server deadlock-retry
-        # wrapper). Masking is best-effort and cosmetic, so it must never break logging:
-        # a failure here previously propagated out of the logging handler and silently
-        # dropped the record, swallowing the very error being logged.
-        if frame.f_locals:
-            try:
+        # Mask the traceback frames
+        tb = e.__traceback__
+        while tb is not None:
+            frame = tb.tb_frame
+            # Mask local variables in the frame that are strings.
+            # Iterate over a snapshot (``list(...)``): assigning ``frame.f_locals[...]``
+            # re-syncs the frame's fast locals, mutating the very mapping being iterated,
+            # which raises "dictionary keys changed during iteration" on Python < 3.13 for
+            # some frames (e.g. a bound-method local plus a closure frame, the shape the
+            # SQL Server deadlock-retry wrapper introduced).
+            if frame.f_locals:
                 for var_name, var_value in list(frame.f_locals.items()):
                     if isinstance(var_value, str):
                         frame.f_locals[var_name] = _mask_message(var_value)
-            except Exception:
-                pass
-        tb = tb.tb_next
+            tb = tb.tb_next
 
-    # Recursively mask chained exceptions
-    if e.__cause__ is not None:
-        _mask_exception(e.__cause__)
-    if e.__context__ is not None:
-        _mask_exception(e.__context__)
+        # Recursively mask chained exceptions
+        if e.__cause__ is not None:
+            _mask_exception(e.__cause__)
+        if e.__context__ is not None:
+            _mask_exception(e.__context__)
+    except MaskingError:
+        raise
+    except Exception as masking_failure:
+        raise MaskingError(f"Could not mask secrets in {type(e).__name__}: {type(masking_failure).__name__}") from None
     return e
 
 

--- a/soda-tests/tests/unit/test_logging_masking.py
+++ b/soda-tests/tests/unit/test_logging_masking.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
-from soda_core.common.logging_configuration import _mask_exception, _masked_values
+import logging
+
+import pytest
+from soda_core.common import logging_configuration
+from soda_core.common.logging_configuration import (
+    REDACTED_EXCEPTION_MARKER,
+    MaskingError,
+    SodaConsoleFormatter,
+    _mask_exception,
+    _mask_record,
+    _masked_values,
+)
 
 
 class _FakeRetryingConnection:
@@ -50,18 +61,107 @@ def _value_error_containing(secret: str) -> ValueError:
         return e
 
 
-def test_mask_exception_masks_registered_secret_in_args() -> None:
-    """Masking still redacts registered secrets in the exception args."""
+def _error_record_with_exception(message: str, exception: BaseException) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="soda_core.test",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=0,
+        msg=message,
+        args=(),
+        exc_info=(type(exception), exception, exception.__traceback__),
+    )
+
+
+@pytest.fixture
+def registered_secret():
     secret = "s3cr3t-token-value"
     _masked_values.add(secret)
     try:
-        masked = _mask_exception(_value_error_containing(secret))
-        assert masked is not None
-        assert "s3cr3t-token-value" not in masked.args[0]
-        assert "***" in masked.args[0]
+        yield secret
     finally:
         _masked_values.discard(secret)
 
 
+def test_mask_exception_masks_registered_secret_in_args(registered_secret: str) -> None:
+    """Masking still redacts registered secrets in the exception args."""
+    masked = _mask_exception(_value_error_containing(registered_secret))
+    assert masked is not None
+    assert registered_secret not in masked.args[0]
+    assert "***" in masked.args[0]
+
+
 def test_mask_exception_returns_none_for_none() -> None:
     assert _mask_exception(None) is None
+
+
+def test_mask_exception_raises_masking_error_when_masking_fails(monkeypatch, registered_secret: str) -> None:
+    """A failure while masking must surface as MaskingError — never be swallowed, and
+    never leak the original error (whose frames are exactly what could not be masked)."""
+
+    def _broken_mask_message(message):
+        raise RuntimeError("dictionary keys changed during iteration")
+
+    monkeypatch.setattr(logging_configuration, "_mask_message", _broken_mask_message)
+
+    with pytest.raises(MaskingError) as exc_info:
+        _mask_exception(_value_error_containing(registered_secret))
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+    assert registered_secret not in str(exc_info.value)
+
+
+def test_mask_record_keeps_masked_exception_when_masking_succeeds(registered_secret: str) -> None:
+    record = _error_record_with_exception(
+        f"query failed for {registered_secret}", _value_error_containing(registered_secret)
+    )
+
+    _mask_record(record)
+
+    assert record.exc_info is not None
+    exc_type, exc_value, _ = record.exc_info
+    assert exc_type is ValueError
+    assert registered_secret not in exc_value.args[0]
+    assert registered_secret not in record.getMessage()
+    assert REDACTED_EXCEPTION_MARKER not in record.getMessage()
+
+
+def test_mask_record_redacts_exception_when_masking_fails(monkeypatch, registered_secret: str) -> None:
+    """If the exception cannot be masked it must not be logged at all: the record keeps
+    its (masked) message and ERROR level, but the exception and traceback are dropped and
+    the message says so."""
+
+    def _broken_mask_message(message):
+        raise RuntimeError("dictionary keys changed during iteration")
+
+    monkeypatch.setattr(logging_configuration, "_mask_message", _broken_mask_message)
+    record = _error_record_with_exception(
+        f"query failed for {registered_secret}", _value_error_containing(registered_secret)
+    )
+
+    _mask_record(record)
+
+    assert record.levelno == logging.ERROR
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert REDACTED_EXCEPTION_MARKER in record.getMessage()
+    assert registered_secret not in record.getMessage()
+
+
+def test_console_formatter_output_has_no_secret_when_masking_fails(monkeypatch, registered_secret: str) -> None:
+    """End-to-end through the console formatter: no secret and no traceback in the output."""
+
+    def _broken_mask_message(message):
+        raise RuntimeError("dictionary keys changed during iteration")
+
+    monkeypatch.setattr(logging_configuration, "_mask_message", _broken_mask_message)
+    record = _error_record_with_exception(
+        f"query failed for {registered_secret}", _value_error_containing(registered_secret)
+    )
+
+    rendered = SodaConsoleFormatter().format(record)
+
+    assert registered_secret not in rendered
+    assert "Traceback" not in rendered
+    assert "ValueError" not in rendered
+    assert REDACTED_EXCEPTION_MARKER in rendered

--- a/soda-tests/tests/unit/test_logging_masking.py
+++ b/soda-tests/tests/unit/test_logging_masking.py
@@ -38,17 +38,26 @@ def test_mask_exception_survives_retry_wrapper_traceback() -> None:
         assert masked is e
 
 
+def _value_error_containing(secret: str) -> ValueError:
+    # Raise and catch inside this throwaway helper so the returned exception's
+    # traceback contains only this frame, not the caller's. On Python 3.13+
+    # ``frame.f_locals`` is a write-through proxy (PEP 667), so masking a frame's
+    # locals rewrites the live variables; keeping the raise here means the caller's
+    # assertion variables can't be clobbered by the masking under test.
+    try:
+        raise ValueError(f"connection failed for {secret}")
+    except ValueError as e:
+        return e
+
+
 def test_mask_exception_masks_registered_secret_in_args() -> None:
     """Masking still redacts registered secrets in the exception args."""
     secret = "s3cr3t-token-value"
     _masked_values.add(secret)
     try:
-        try:
-            raise ValueError(f"connection failed for {secret}")
-        except ValueError as e:
-            masked = _mask_exception(e)
+        masked = _mask_exception(_value_error_containing(secret))
         assert masked is not None
-        assert secret not in masked.args[0]
+        assert "s3cr3t-token-value" not in masked.args[0]
         assert "***" in masked.args[0]
     finally:
         _masked_values.discard(secret)

--- a/soda-tests/tests/unit/test_logging_masking.py
+++ b/soda-tests/tests/unit/test_logging_masking.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from soda_core.common.logging_configuration import _mask_exception, _masked_values
+
+
+class _FakeRetryingConnection:
+    """Mirrors the traceback shape of ``SqlServerDataSourceConnection.execute_query``:
+
+        execute_query -> _execute_with_deadlock_retry -> lambda -> super().execute_query
+
+    i.e. a bound-method captured in a local (``execute = self._base_execute``) plus a
+    closure frame. That combination made ``_mask_exception`` raise
+    ``RuntimeError: dictionary keys changed during iteration`` on Python 3.10 — masking a
+    frame's locals re-syncs ``frame.f_locals`` and invalidates the iterator. The raise
+    happened inside the logging handler, which dropped the log record and silently
+    swallowed the underlying error (so the failing check ended up NOT_EVALUATED).
+    """
+
+    def _execute_with_retry(self, operation):
+        return operation()
+
+    def execute_query(self, sql: str, log_query: bool = True):
+        execute = self._base_execute
+        return self._execute_with_retry(lambda: execute(sql, log_query))
+
+    def _base_execute(self, sql: str, log_query: bool = True):
+        raise ValueError(f"Invalid column name in {sql}")
+
+
+def test_mask_exception_survives_retry_wrapper_traceback() -> None:
+    """Regression: masking an exception raised through the retry-wrapper traceback
+    shape must not raise (previously RuntimeError: dictionary keys changed during
+    iteration)."""
+    try:
+        _FakeRetryingConnection().execute_query("SELECT please_crash")
+    except ValueError as e:
+        masked = _mask_exception(e)
+        assert masked is e
+
+
+def test_mask_exception_masks_registered_secret_in_args() -> None:
+    """Masking still redacts registered secrets in the exception args."""
+    secret = "s3cr3t-token-value"
+    _masked_values.add(secret)
+    try:
+        try:
+            raise ValueError(f"connection failed for {secret}")
+        except ValueError as e:
+            masked = _mask_exception(e)
+        assert masked is not None
+        assert secret not in masked.args[0]
+        assert "***" in masked.args[0]
+    finally:
+        _masked_values.discard(secret)
+
+
+def test_mask_exception_returns_none_for_none() -> None:
+    assert _mask_exception(None) is None


### PR DESCRIPTION
## Problem

After #2803 merged, the `(3.10, sqlserver)` CI lane started failing on `soda-groupby`'s `test_groupby_check_single_group_cloud_please_crash`:

```
AssertionError: Expected contract verification failed
```

The test deliberately injects an invalid column (`please_crash`) to force a query error and asserts the contract reports a failure. Instead the check came back `NOT_EVALUATED` with `hasErrors: false`.

## Root cause

`_mask_exception` (`logging_configuration.py`) masks secrets in a logged exception by walking its traceback frames and reassigning string locals **while iterating the same mapping**:

```python
for var_name, var_value in frame.f_locals.items():
    if isinstance(var_value, str):
        frame.f_locals[var_name] = _mask_message(var_value)   # re-accesses frame.f_locals
```

Each `frame.f_locals` access re-syncs the frame's fast locals into that dict. Mutating it mid-iteration raises `RuntimeError: dictionary keys changed during iteration` on **Python 3.10** for certain frame shapes — specifically a bound-method local plus a closure frame.

That is exactly the traceback shape #2803 introduced on the SQL Server path:

```python
def execute_query(self, sql, log_query=True):
    execute = super().execute_query                       # bound-method local
    return self._execute_with_deadlock_retry(lambda: execute(sql, log_query))  # closure frame
```

So the pre-existing latent bug in `_mask_exception` became reachable. And because it raised **inside the logging handler** (`logger.error(..., exc_info=True)`), Python dropped the log record — silently swallowing the query error, which is why the check ended up `NOT_EVALUATED` rather than failed.

Only 3.10 is affected for this shape (3.11/3.12/3.13 don't crash here), matching the single failing CI lane.

## Fix

- Iterate over a `list(...)` **snapshot** of the frame locals, so the in-loop reassignment can't invalidate the iterator.
- Guard the per-frame masking with `try/except` — masking is best-effort and cosmetic, so it must never break logging (that swallowing is exactly what turned a real error into a green-but-wrong check).

## Testing

New unit tests in `soda-tests/tests/unit/test_logging_masking.py`:
- **regression**: masking an exception raised through the retry-wrapper traceback shape must not raise;
- masking still redacts registered secrets in the exception args;
- `None` handling.

Verified against the real fixed module on CPython **3.10 / 3.11 / 3.12 / 3.13**: the pre-fix code raises `dictionary keys changed during iteration` on 3.10; the fixed code passes all three tests on every version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
