### PR TITLE
fix(cloud): rename hasWarns to hasWarnings in scan results payload

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1869,9 +1869,6 @@ def _build_check_collection_results_json_dict(
         "scanStartTimestamp": min(started_timestamps) if started_timestamps else head.started_timestamp,
         "scanEndTimestamp": max(ended_timestamps) if ended_timestamps else head.ended_timestamp,
         "hasErrors": any(r.has_errors for r in results),
-        # "hasWarnings" is the field the backend maps for scan-state
-        # derivation (COMPLETED_WITH_WARNINGS); unknown keys are silently
-        # dropped, so any other spelling loses the warning severity.
         "hasWarnings": any(r.is_warned for r in results),
         "hasFailures": any(r.is_failed for r in results),
         # Empty checks list serialises as ``None`` to match the legacy

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1792,7 +1792,7 @@ def _build_check_collection_results_json_dict(
 
     - ``scanStartTimestamp`` = min of per-result starts
     - ``scanEndTimestamp`` = max of per-result ends
-    - ``hasErrors``/``hasWarns``/``hasFailures`` = ORs over per-result flags
+    - ``hasErrors``/``hasWarnings``/``hasFailures`` = ORs over per-result flags
     - ``checks`` / ``logs`` / ``tokenUsage`` = flattened across results
     - ``postProcessingStages`` = de-duped by name (the backend tracks
       one ONGOING stage per scan)
@@ -1869,7 +1869,10 @@ def _build_check_collection_results_json_dict(
         "scanStartTimestamp": min(started_timestamps) if started_timestamps else head.started_timestamp,
         "scanEndTimestamp": max(ended_timestamps) if ended_timestamps else head.ended_timestamp,
         "hasErrors": any(r.has_errors for r in results),
-        "hasWarns": any(r.is_warned for r in results),
+        # "hasWarnings" is the field the backend maps for scan-state
+        # derivation (COMPLETED_WITH_WARNINGS); unknown keys are silently
+        # dropped, so any other spelling loses the warning severity.
+        "hasWarnings": any(r.is_warned for r in results),
         "hasFailures": any(r.is_failed for r in results),
         # Empty checks list serialises as ``None`` to match the legacy
         # combined-builder behaviour the backend already accepts.

--- a/soda-tests/tests/unit/test_combined_results_wire.py
+++ b/soda-tests/tests/unit/test_combined_results_wire.py
@@ -110,7 +110,7 @@ def test_combined_payload_flattens_check_results():
 
 
 def test_combined_payload_or_aggregates_status_flags():
-    """``hasErrors / hasWarns / hasFailures`` are ORs over per-file values."""
+    """``hasErrors / hasWarnings / hasFailures`` are ORs over per-file values."""
     r_passed = _make_result(label="ok", status=CheckCollectionStatus.PASSED)
     r_warned = _make_result(label="warn", status=CheckCollectionStatus.WARNED)
     r_failed = _make_result(label="fail", status=CheckCollectionStatus.FAILED)
@@ -121,7 +121,7 @@ def test_combined_payload_or_aggregates_status_flags():
     )
 
     assert payload["hasErrors"] is True
-    assert payload["hasWarns"] is True
+    assert payload["hasWarnings"] is True
     assert payload["hasFailures"] is True
 
 
@@ -131,7 +131,7 @@ def test_combined_payload_status_flags_all_false_when_no_problems():
     r2 = _make_result(label="beta")
     payload = _build_check_collection_results_json_dict([r1, r2], wire_source="data-standard")
     assert payload["hasErrors"] is False
-    assert payload["hasWarns"] is False
+    assert payload["hasWarnings"] is False
     assert payload["hasFailures"] is False
 
 

--- a/soda-tests/tests/unit/test_single_result_wire_equivalence.py
+++ b/soda-tests/tests/unit/test_single_result_wire_equivalence.py
@@ -111,7 +111,7 @@ def test_n1_session_fields_match_single_result():
     assert payload["dataTimestamp"] == "2026-01-01T12:00:00+00:00"
     assert payload["hasErrors"] is False
     assert payload["hasFailures"] is True
-    assert payload["hasWarns"] is False
+    assert payload["hasWarnings"] is False
     assert payload["definitionName"] == "test_ds/s/t"
     assert payload["defaultDataSource"] == "test_ds"
     assert payload["defaultDataSourceProperties"] == {"type": "postgres"}


### PR DESCRIPTION
## Problem

Every v4 `sodaCoreInsertScanResults` payload emits the warning flag as `hasWarns`, but the backend command DTO only maps `hasWarnings` and silently drops unknown keys (GSON). The scan-state derivation (`getScanState`: hasErrors > hasFailures > hasWarnings) therefore never sees warnings from v4 clients — a scan whose checks warned reports **SUCCESS** instead of **COMPLETED_WITH_WARNINGS** in Soda Cloud. This affects all v4 flows that ship check results (contract verification, metric monitoring).

Found during the v3↔v4 parity crosscheck against the backend on the soda-extensions parity gate; v3 (soda-library) sends `hasWarnings`, and soda-core's own payload model (`soda_cloud_dto.py`) already declares `hasWarnings` — only the emitter in `_build_check_collection_results_json_dict` drifted.

## Change

Rename the emitted key to `hasWarnings`. No compatibility shim needed: the old spelling was never read by the backend, so nothing can regress by dropping it.

A companion PR on soda-extensions updates the MM parity contract, which currently pins the drifted spelling.

## Testing

`test_combined_results_wire.py` + `test_single_result_wire_equivalence.py` updated and passing (21/21); soda-extensions MM parity suite run against this branch (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)