### PR TITLE
feat(data-source): bulk primary-key introspection for more data sources

### DIFF
--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -193,6 +193,10 @@ class AthenaDataSourceImpl(DataSourceImpl, model_class=AthenaDataSourceModel):
 class AthenaSqlDialect(SqlDialect, sqlglot_dialect="athena"):
     SUPPORTS_DROP_TABLE_CASCADE = False
 
+    # Primary-key introspection stays opt-out (supports_primary_keys inherits False from the
+    # base dialect): Athena runs over Glue/Hive-style catalogs that neither declare primary keys
+    # in CREATE TABLE nor expose them through information_schema constraint views.
+
     SODA_DATA_TYPE_SYNONYMS = (
         (SodaDataTypeName.TEXT, SodaDataTypeName.VARCHAR),
         (SodaDataTypeName.NUMERIC, SodaDataTypeName.DECIMAL),

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -110,13 +110,10 @@ class BigQueryDataSourceImpl(DataSourceImpl, model_class=BigQueryDataSourceModel
         return BigQueryDataSourceNamespace(project_id=prefixes[0], dataset=prefixes[1])
 
     def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        # BigQuery exposes primary keys through the dataset-qualified INFORMATION_SCHEMA constraint views.
         return BigQueryMetadataPrimaryKeysQuery(
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
-
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # BigQuery exposes primary keys through the dataset-qualified INFORMATION_SCHEMA constraint views.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     def _build_table_namespace_for_schema_query(self, prefixes: list[str]) -> tuple[DataSourceNamespace, str]:
         table_namespace: DataSourceNamespace = BigQueryDataSourceNamespace(

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -114,7 +114,7 @@ class BigQueryDataSourceImpl(DataSourceImpl, model_class=BigQueryDataSourceModel
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         # BigQuery exposes primary keys through the dataset-qualified INFORMATION_SCHEMA constraint views.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -17,6 +17,8 @@ from soda_core.common.sql_ast import (
     COLUMN,
     CONCAT_WS,
     COUNT,
+    CREATE_TABLE,
+    CREATE_TABLE_IF_NOT_EXISTS,
     DISTINCT,
     LITERAL,
     PERCENTILE_WITHIN_GROUP,
@@ -31,6 +33,9 @@ from soda_core.common.sql_ast import (
     WITH,
 )
 from soda_core.common.sql_dialect import SqlDialect
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
+)
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 
 logger: logging.Logger = soda_logger
@@ -53,6 +58,19 @@ class BigQueryDataSourceNamespace(DataSourceNamespace):
 
     def get_schema_for_metadata_query(self) -> str:
         return self.dataset
+
+
+class BigQueryMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
+    """Primary-key introspection for BigQuery.
+
+    BigQuery's INFORMATION_SCHEMA is qualified as
+    ``<project>.<dataset>.INFORMATION_SCHEMA.TABLE_CONSTRAINTS`` and its namespace
+    elements are read from a BigQueryDataSourceNamespace, so the dataset prefixes
+    ([project, dataset]) are mapped onto that namespace here.
+    """
+
+    def _build_namespace(self, prefixes: list[str]) -> DataSourceNamespace:
+        return BigQueryDataSourceNamespace(project_id=prefixes[0], dataset=prefixes[1])
 
 
 class BigQueryDataSourceImpl(DataSourceImpl, model_class=BigQueryDataSourceModel):
@@ -90,6 +108,15 @@ class BigQueryDataSourceImpl(DataSourceImpl, model_class=BigQueryDataSourceModel
 
     def _build_columns_metadata_namespace(self, prefixes: list[str]) -> DataSourceNamespace:
         return BigQueryDataSourceNamespace(project_id=prefixes[0], dataset=prefixes[1])
+
+    def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        return BigQueryMetadataPrimaryKeysQuery(
+            sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
+        )
+
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # BigQuery exposes primary keys through the dataset-qualified INFORMATION_SCHEMA constraint views.
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     def _build_table_namespace_for_schema_query(self, prefixes: list[str]) -> tuple[DataSourceNamespace, str]:
         table_namespace: DataSourceNamespace = BigQueryDataSourceNamespace(
@@ -211,6 +238,32 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         project_id, dataset = prefixes
         qualified_schema_name: str = f"{self.quote_for_ddl(project_id)}.{self.quote_for_ddl(dataset)}"
         return f"CREATE SCHEMA IF NOT EXISTS {qualified_schema_name}" + (";" if add_semicolon else "")
+
+    def supports_primary_keys(self) -> bool:
+        # BigQuery stores non-enforced primary keys and reports them through the
+        # dataset-qualified INFORMATION_SCHEMA constraint views.
+        return True
+
+    def _build_create_table_primary_key(self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS) -> Optional[str]:
+        # BigQuery only accepts a primary key declared as NOT ENFORCED.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
+        if not primary_key_column_names:
+            return None
+        quoted_columns: str = ", ".join(
+            self._quote_column_for_create_table(column_name) for column_name in primary_key_column_names
+        )
+        return f"\tPRIMARY KEY ({quoted_columns}) NOT ENFORCED"
+
+    def build_create_table_sql(
+        self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: Optional[bool] = None
+    ) -> str:
+        # A BigQuery primary key requires its columns to be NOT NULL, so force that on the
+        # participating columns before the base builder renders the column and PK clauses.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None) or []
+        for column in create_table.columns:
+            if column.name in primary_key_column_names:
+                column.nullable = False
+        return super().build_create_table_sql(create_table, add_semicolon=add_semicolon)
 
     def default_casify(self, identifier: str) -> str:
         return identifier.upper()

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -254,22 +253,6 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
             self._quote_column_for_create_table(column_name) for column_name in primary_key_column_names
         )
         return f"\tPRIMARY KEY ({quoted_columns}) NOT ENFORCED"
-
-    def build_create_table_sql(
-        self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: Optional[bool] = None
-    ) -> str:
-        # A BigQuery primary key requires its columns to be NOT NULL, so force that on the
-        # participating columns before the base builder renders the column and PK clauses.
-        # CREATE_TABLE_COLUMN objects are reused across renders (e.g. cross-source flows render
-        # the same source columns on two dialects), so mutate a deep copy rather than the caller's
-        # objects — otherwise nullable=False leaks onto the shared column list.
-        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
-        if primary_key_column_names:
-            create_table = copy.deepcopy(create_table)
-            for column in create_table.columns:
-                if column.name in primary_key_column_names:
-                    column.nullable = False
-        return super().build_create_table_sql(create_table, add_semicolon=add_semicolon)
 
     def default_casify(self, identifier: str) -> str:
         return identifier.upper()

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -259,10 +260,15 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     ) -> str:
         # A BigQuery primary key requires its columns to be NOT NULL, so force that on the
         # participating columns before the base builder renders the column and PK clauses.
-        primary_key_column_names = getattr(create_table, "primary_key_column_names", None) or []
-        for column in create_table.columns:
-            if column.name in primary_key_column_names:
-                column.nullable = False
+        # CREATE_TABLE_COLUMN objects are reused across renders (e.g. cross-source flows render
+        # the same source columns on two dialects), so mutate a deep copy rather than the caller's
+        # objects — otherwise nullable=False leaks onto the shared column list.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
+        if primary_key_column_names:
+            create_table = copy.deepcopy(create_table)
+            for column in create_table.columns:
+                if column.name in primary_key_column_names:
+                    column.nullable = False
         return super().build_create_table_sql(create_table, add_semicolon=add_semicolon)
 
     def default_casify(self, identifier: str) -> str:

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -1,5 +1,10 @@
 import pytest
-from soda_bigquery.common.data_sources.bigquery_data_source import BigQuerySqlDialect
+from soda_bigquery.common.data_sources.bigquery_data_source import (
+    BigQueryMetadataPrimaryKeysQuery,
+    BigQuerySqlDialect,
+)
+from soda_core.common.metadata_types import SqlDataType
+from soda_core.common.sql_ast import CREATE_TABLE, CREATE_TABLE_COLUMN
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 
 
@@ -7,6 +12,35 @@ def test_random():
     sql_dialect: BigQuerySqlDialect = BigQuerySqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT RAND()\nFROM `a`;"
+
+
+def test_primary_key_create_table_requires_not_enforced_and_not_null():
+    # BigQuery only accepts a NOT ENFORCED primary key, and its columns must be NOT NULL.
+    dialect = BigQuerySqlDialect()
+    create_table = CREATE_TABLE(
+        fully_qualified_table_name="proj.ds.orders",
+        columns=[
+            CREATE_TABLE_COLUMN(name="tenant_id", type=SqlDataType("int64")),
+            CREATE_TABLE_COLUMN(name="id", type=SqlDataType("int64")),
+            CREATE_TABLE_COLUMN(name="label", type=SqlDataType("string")),
+        ],
+        primary_key_column_names=["tenant_id", "id"],
+    )
+    sql = dialect.build_create_table_sql(create_table)
+    assert "`tenant_id` int64 NOT NULL" in sql
+    assert "`id` int64 NOT NULL" in sql
+    assert "`label` string" in sql and "`label` string NOT NULL" not in sql
+    assert "PRIMARY KEY (`tenant_id`, `id`) NOT ENFORCED" in sql
+
+
+def test_primary_keys_query_is_dataset_qualified():
+    # The primary-key query must read the dataset-qualified INFORMATION_SCHEMA views.
+    dialect = BigQuerySqlDialect()
+    query = BigQueryMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
+    namespace = query._build_namespace(["proj", "ds"])
+    sql = dialect.build_select_sql(query.build_sql_statement(namespace, ["orders"]))
+    assert "`proj`.`ds`.`INFORMATION_SCHEMA`.`TABLE_CONSTRAINTS`" in sql
+    assert "`proj`.`ds`.`INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE`" in sql
 
 
 def test_create_schema_if_not_exists_sql_is_project_qualified():

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -15,7 +15,9 @@ def test_random():
 
 
 def test_primary_key_create_table_requires_not_enforced_and_not_null():
-    # BigQuery only accepts a NOT ENFORCED primary key, and its columns must be NOT NULL.
+    # BigQuery only accepts a NOT ENFORCED primary key. The NOT NULL on the key columns is
+    # Soda's uniform DDL choice applied by the base builder (PK columns are non-null by
+    # definition), not a BigQuery grammar requirement.
     dialect = BigQuerySqlDialect()
     create_table = CREATE_TABLE(
         fully_qualified_table_name="proj.ds.orders",

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -277,10 +277,14 @@ class DataSourceImpl(ABC):
         look up via sql_dialect.metadata_casify(requested_name). Tables without a primary key, and
         requested tables that don't exist, are simply absent from the result.
 
-        The base implementation returns an empty dict: primary key introspection is opt-in per
-        data source. Data sources with a standard information_schema constraints layer can override
-        by delegating to create_metadata_primary_keys_query().execute(...)."""
-        return {}
+        Gated on sql_dialect.supports_primary_keys() so callers can invoke this unconditionally:
+        a data source that cannot introspect primary keys (or whose active dialect opts out, e.g.
+        the Databricks Hive metastore) returns an empty dict without issuing a query. Data sources
+        specialize via supports_primary_keys() and create_metadata_primary_keys_query(), not by
+        overriding this method."""
+        if not self.sql_dialect.supports_primary_keys():
+            return {}
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     @property
     def bulk_columns_metadata_available(self) -> bool:

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -65,6 +65,11 @@ class DatabricksDataSourceImpl(DataSourceImpl, model_class=DatabricksDataSourceM
         else:
             return super().create_metadata_tables_query()
 
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # Unity Catalog exposes primary keys through the standard information_schema constraint
+        # views; the Hive metastore does not, and gates itself off via DatabricksHiveSqlDialect.
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
+
     def _is_hive_catalog(self):
         # Check the connection "catalog"
         catalog: Optional[str] = self.data_source_model.connection_properties.catalog
@@ -110,6 +115,12 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
         (SodaDataTypeName.NUMERIC, SodaDataTypeName.DECIMAL),
         (SodaDataTypeName.TIMESTAMP_TZ, SodaDataTypeName.TIMESTAMP),
     )
+
+    def supports_primary_keys(self) -> bool:
+        # Unity Catalog stores non-enforced primary keys (PK columns are implicitly NOT NULL)
+        # and reports them through the standard information_schema constraint views.
+        # The Hive metastore has neither; DatabricksHiveSqlDialect opts back out.
+        return True
 
     def _get_data_type_name_synonyms(self) -> list[list[str]]:
         return [
@@ -411,6 +422,11 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
 
 
 class DatabricksHiveSqlDialect(DatabricksSqlDialect, sqlglot_dialect="databricks"):
+    def supports_primary_keys(self) -> bool:
+        # The Hive metastore neither declares primary keys nor exposes them through
+        # information_schema, so primary-key introspection stays opt-out here.
+        return False
+
     def post_schema_create_sql(self, prefixes: list[str]) -> Optional[list[str]]:
         assert len(prefixes) == 2, f"Expected 2 prefixes, got {len(prefixes)}"
         catalog_name: str = self.quote_default(prefixes[0])

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -65,7 +65,7 @@ class DatabricksDataSourceImpl(DataSourceImpl, model_class=DatabricksDataSourceM
         else:
             return super().create_metadata_tables_query()
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         # Unity Catalog exposes primary keys through the standard information_schema constraint
         # views; the Hive metastore does not, and gates itself off via DatabricksHiveSqlDialect.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -65,11 +65,6 @@ class DatabricksDataSourceImpl(DataSourceImpl, model_class=DatabricksDataSourceM
         else:
             return super().create_metadata_tables_query()
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # Unity Catalog exposes primary keys through the standard information_schema constraint
-        # views; the Hive metastore does not, and gates itself off via DatabricksHiveSqlDialect.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
-
     def _is_hive_catalog(self):
         # Check the connection "catalog"
         catalog: Optional[str] = self.data_source_model.connection_properties.catalog

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -12,9 +12,6 @@ from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
 from soda_core.common.sql_ast import *
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
 from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
     DuckDBConnectionProperties,
 )
@@ -295,17 +292,6 @@ class DuckDBDataSourceConnection(DataSourceConnection):
         return Path(config.database).stem
 
 
-class DuckDBMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
-    """Primary-key introspection for DuckDB.
-
-    DuckDB's information_schema exposes the constraint columns through
-    ``constraint_column_usage`` rather than the ANSI ``key_column_usage`` view.
-    """
-
-    def table_key_column_usage(self) -> str:
-        return self.sql_dialect.default_casify("constraint_column_usage")
-
-
 class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
     def _create_sql_dialect(self) -> SqlDialect:
         return DuckDBSqlDialect()
@@ -315,13 +301,8 @@ class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
-    def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
-        return DuckDBMetadataPrimaryKeysQuery(
-            sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
-        )
-
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
-        # DuckDB exposes primary keys through the information_schema constraint views.
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
+        # DuckDB exposes primary keys through the ANSI information_schema.key_column_usage view.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     @classmethod

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -301,10 +301,6 @@ class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # DuckDB exposes primary keys through the ANSI information_schema.key_column_usage view.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
-
     @classmethod
     def from_existing_cursor(cls, cursor: DuckDBPyConnection, name: str) -> DataSourceImpl:
         ds_model = DuckDBDataSourceModel(

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -12,6 +12,9 @@ from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
 from soda_core.common.sql_ast import *
 from soda_core.common.sql_dialect import SqlDialect
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
+)
 from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
     DuckDBConnectionProperties,
 )
@@ -86,6 +89,11 @@ class DuckDBSqlDialect(SqlDialect, sqlglot_dialect="duckdb"):
         (SodaDataTypeName.TEXT, SodaDataTypeName.VARCHAR, SodaDataTypeName.CHAR),
         (SodaDataTypeName.NUMERIC, SodaDataTypeName.DECIMAL),
     )
+
+    def supports_primary_keys(self) -> bool:
+        # DuckDB enforces primary keys and reports them through the information_schema
+        # constraint views, with the standard PRIMARY KEY (...) DDL.
+        return True
 
     def get_database_prefix_index(self) -> int | None:
         return None
@@ -287,6 +295,17 @@ class DuckDBDataSourceConnection(DataSourceConnection):
         return Path(config.database).stem
 
 
+class DuckDBMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
+    """Primary-key introspection for DuckDB.
+
+    DuckDB's information_schema exposes the constraint columns through
+    ``constraint_column_usage`` rather than the ANSI ``key_column_usage`` view.
+    """
+
+    def table_key_column_usage(self) -> str:
+        return self.sql_dialect.default_casify("constraint_column_usage")
+
+
 class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
     def _create_sql_dialect(self) -> SqlDialect:
         return DuckDBSqlDialect()
@@ -295,6 +314,15 @@ class DuckDBDataSourceImpl(DataSourceImpl, model_class=DuckDBDataSourceModel):
         return DuckDBDataSourceConnection(
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
+
+    def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        return DuckDBMetadataPrimaryKeysQuery(
+            sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
+        )
+
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # DuckDB exposes primary keys through the information_schema constraint views.
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     @classmethod
     def from_existing_cursor(cls, cursor: DuckDBPyConnection, name: str) -> DataSourceImpl:

--- a/soda-duckdb/tests/unit/test_duckdb_dialect.py
+++ b/soda-duckdb/tests/unit/test_duckdb_dialect.py
@@ -1,8 +1,8 @@
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
-from soda_duckdb.common.data_sources.duckdb_data_source import (
-    DuckDBMetadataPrimaryKeysQuery,
-    DuckDBSqlDialect,
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
 )
+from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBSqlDialect
 
 
 def test_random():
@@ -11,13 +11,13 @@ def test_random():
     assert sql == 'SELECT RANDOM()\nFROM "a";'
 
 
-def test_primary_keys_query_uses_constraint_column_usage():
-    # DuckDB exposes constraint columns through constraint_column_usage, not the ANSI
-    # key_column_usage view, so the primary-key query must read from constraint_column_usage.
+def test_primary_keys_query_uses_ansi_key_column_usage():
+    # DuckDB's key_column_usage carries ordinal_position (unlike constraint_column_usage), so the
+    # primary-key query uses the ANSI base query to return composite keys in order.
     dialect = DuckDBSqlDialect()
-    query = DuckDBMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
+    query = MetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
     namespace = query._build_namespace(["myschema"])
     sql = dialect.build_select_sql(query.build_sql_statement(namespace, ["orders"]))
     assert '"information_schema"."table_constraints"' in sql
-    assert '"information_schema"."constraint_column_usage"' in sql
-    assert "key_column_usage" not in sql
+    assert '"information_schema"."key_column_usage"' in sql
+    assert "ordinal_position" in sql

--- a/soda-duckdb/tests/unit/test_duckdb_dialect.py
+++ b/soda-duckdb/tests/unit/test_duckdb_dialect.py
@@ -1,8 +1,23 @@
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
-from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBSqlDialect
+from soda_duckdb.common.data_sources.duckdb_data_source import (
+    DuckDBMetadataPrimaryKeysQuery,
+    DuckDBSqlDialect,
+)
 
 
 def test_random():
     sql_dialect: DuckDBSqlDialect = DuckDBSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == 'SELECT RANDOM()\nFROM "a";'
+
+
+def test_primary_keys_query_uses_constraint_column_usage():
+    # DuckDB exposes constraint columns through constraint_column_usage, not the ANSI
+    # key_column_usage view, so the primary-key query must read from constraint_column_usage.
+    dialect = DuckDBSqlDialect()
+    query = DuckDBMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
+    namespace = query._build_namespace(["myschema"])
+    sql = dialect.build_select_sql(query.build_sql_statement(namespace, ["orders"]))
+    assert '"information_schema"."table_constraints"' in sql
+    assert '"information_schema"."constraint_column_usage"' in sql
+    assert "key_column_usage" not in sql

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -40,6 +40,13 @@ class FabricSqlDialect(SqlServerSqlDialect, sqlglot_dialect="fabric"):
         (SodaDataTypeName.TIMESTAMP_TZ, SodaDataTypeName.TIMESTAMP),
     )
 
+    def supports_primary_keys(self) -> bool:
+        # Fabric Warehouse only supports non-enforced primary keys, and only via
+        # ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY NONCLUSTERED (...) NOT ENFORCED —
+        # it rejects an inline PRIMARY KEY clause in CREATE TABLE. Primary-key introspection
+        # stays opt-out here until a post-create ALTER hook exists to declare the key.
+        return False
+
     @classmethod
     def is_same_soda_data_type_with_synonyms(cls, expected: SodaDataTypeName, actual: SodaDataTypeName) -> bool:
         if expected == SodaDataTypeName.TIMESTAMP and actual == SodaDataTypeName.VARCHAR:

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -74,14 +74,11 @@ class PostgresDataSourceImpl(DataSourceImpl, model_class=PostgresDataSourceModel
         )
 
     def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        # Reads pg_catalog, not information_schema: the latter is privilege-filtered and returns
+        # nothing for a read-only user. See PostgresMetadataPrimaryKeysQuery.
         return PostgresMetadataPrimaryKeysQuery(
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
-
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # Reads pg_catalog, not information_schema: the latter is privilege-filtered and returns
-        # nothing for a read-only user. See PostgresMetadataPrimaryKeysQuery.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
 
 class PostgresSqlDataType(SqlDataType):

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -53,7 +53,7 @@ class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         # Redshift exposes primary keys through the standard information_schema constraint views.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -60,14 +60,11 @@ class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel
         )
 
     def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        # Reads pg_catalog, not information_schema: Redshift's Postgres-8-lineage constraint
+        # views only list tables the current user owns. See RedshiftMetadataPrimaryKeysQuery.
         return RedshiftMetadataPrimaryKeysQuery(
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
-
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # Reads pg_catalog, not information_schema: Redshift's Postgres-8-lineage constraint
-        # views only list tables the current user owns. See RedshiftMetadataPrimaryKeysQuery.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
 
 class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -22,7 +22,6 @@ from soda_core.common.statements.metadata_primary_keys_query import (
     MetadataPrimaryKeysQuery,
 )
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
-
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSource as RedshiftDataSourceModel,
 )

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -53,8 +53,17 @@ class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
 
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # Redshift exposes primary keys through the standard information_schema constraint views.
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
+
 
 class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
+    def supports_primary_keys(self) -> bool:
+        # Redshift stores declared primary keys as informational (never enforced) constraints,
+        # surfaced through the standard information_schema constraint views.
+        return True
+
     def supports_percentiles_with_other_distinct_aggregates(self) -> bool:
         # Redshift: "Using LISTAGG/PERCENTILE_CONT/MEDIAN aggregate functions
         # with other distinct aggregate function not supported" — consumers

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -18,12 +18,19 @@ from soda_core.common.sql_ast import (
     VALUES,
 )
 from soda_core.common.sql_dialect import SqlDialect
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
+)
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
+
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSource as RedshiftDataSourceModel,
 )
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSourceConnection,
+)
+from soda_redshift.statements.redshift_metadata_primary_keys_query import (
+    RedshiftMetadataPrimaryKeysQuery,
 )
 from soda_redshift.statements.redshift_metadata_tables_query import (
     RedshiftMetadataTablesQuery,
@@ -53,15 +60,21 @@ class RedshiftDataSourceImpl(DataSourceImpl, model_class=RedshiftDataSourceModel
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
 
+    def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        return RedshiftMetadataPrimaryKeysQuery(
+            sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
+        )
+
     def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # Redshift exposes primary keys through the standard information_schema constraint views.
+        # Reads pg_catalog, not information_schema: Redshift's Postgres-8-lineage constraint
+        # views only list tables the current user owns. See RedshiftMetadataPrimaryKeysQuery.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
 
 class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
     def supports_primary_keys(self) -> bool:
         # Redshift stores declared primary keys as informational (never enforced) constraints,
-        # surfaced through the standard information_schema constraint views.
+        # introspected from pg_catalog.pg_constraint (see RedshiftMetadataPrimaryKeysQuery).
         return True
 
     def supports_percentiles_with_other_distinct_aggregates(self) -> bool:

--- a/soda-redshift/src/soda_redshift/statements/redshift_metadata_primary_keys_query.py
+++ b/soda-redshift/src/soda_redshift/statements/redshift_metadata_primary_keys_query.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from soda_core.common.data_source_results import QueryResult
+from soda_core.common.metadata_types import DataSourceNamespace
+from soda_core.common.sql_ast import (
+    AND,
+    COLUMN,
+    EQ,
+    FROM,
+    IN,
+    JOIN,
+    LITERAL,
+    LOWER,
+    RAW_SQL,
+    SELECT,
+    WHERE,
+)
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
+)
+
+
+class RedshiftMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
+    """Bulk primary-key introspection for Redshift, reading pg_catalog instead of
+    information_schema.
+
+    Redshift's information_schema has Postgres-8 lineage: its constraint views only list
+    tables the current user owns, so a read-only monitoring user silently gets zero primary
+    keys (same reason table_schemata reads SVV_ALL_SCHEMAS — see SCS-1193 — and the tables /
+    columns queries read svv_tables / svv_columns). There is no SVV constraints view, so the
+    primary key is read from pg_catalog.pg_constraint (contype = 'p').
+
+    Redshift has no array_position(), so the postgres pg_catalog query cannot be reused to
+    order the key columns. Instead pg_get_constraintdef(oid) — the same function AWS's
+    v_generate_tbl_ddl admin view uses — renders the constraint as
+    ``PRIMARY KEY (col1, col2, ...)`` in declared key order, and get_results parses the
+    column list out of it.
+    """
+
+    def build_sql_statement(self, table_namespace: DataSourceNamespace, table_names: list[str]) -> list:
+        database_name: str | None = table_namespace.get_database_for_metadata_query()
+        schema_name: str = table_namespace.get_schema_for_metadata_query()
+
+        return [
+            SELECT(
+                [
+                    COLUMN("relname", "tables"),
+                    RAW_SQL("pg_get_constraintdef(constraints.oid)"),
+                ]
+            ),
+            FROM("pg_constraint", table_prefix=["pg_catalog"], alias="constraints"),
+            JOIN(
+                table_name="pg_class",
+                table_prefix=["pg_catalog"],
+                alias="tables",
+                on_condition=EQ(COLUMN("oid", "tables"), COLUMN("conrelid", "constraints")),
+            ),
+            JOIN(
+                table_name="pg_namespace",
+                table_prefix=["pg_catalog"],
+                alias="schemas",
+                on_condition=EQ(COLUMN("oid", "schemas"), COLUMN("relnamespace", "tables")),
+            ),
+            WHERE(
+                AND(
+                    [
+                        EQ(COLUMN("contype", "constraints"), LITERAL("p")),
+                        *(
+                            # Redshift can only introspect the connected database; mirror the
+                            # postgres query's case-insensitive guard.
+                            [EQ(LOWER(RAW_SQL("current_database()")), LITERAL(database_name.lower()))]
+                            if database_name
+                            else []
+                        ),
+                        # Case-insensitive like the postgres query, so a schema spelled in a
+                        # different case doesn't silently match nothing.
+                        EQ(LOWER(COLUMN("nspname", "schemas")), LITERAL(schema_name.lower())),
+                        IN(
+                            COLUMN("relname", "tables"),
+                            [LITERAL(self.sql_dialect.metadata_casify(name)) for name in table_names],
+                        ),
+                    ]
+                )
+            ),
+        ]
+
+    def get_results(self, query_result: QueryResult) -> dict[str, list[str]]:
+        """Groups rows into {table_name: [primary_key_column_names]} in declared key order.
+        Each row is (table_name, constraint_definition); a table has at most one primary key,
+        so one row per table. Rows with a null table name or definition are skipped.
+        """
+        primary_keys_by_table: dict[str, list[str]] = {}
+        for row in query_result.rows:
+            if not row or row[0] is None or row[1] is None:
+                continue
+            table_name, constraint_definition = row[0], row[1]
+            primary_keys_by_table[table_name] = self._parse_primary_key_columns(constraint_definition)
+        return primary_keys_by_table
+
+    @staticmethod
+    def _parse_primary_key_columns(constraint_definition: str) -> list[str]:
+        """Parses the column list out of ``PRIMARY KEY (col1, "Quoted, col", ...)``,
+        preserving order. Splits on commas outside double quotes; strips the quotes and
+        un-doubles embedded ``""`` escapes.
+        """
+        inner: str = constraint_definition[constraint_definition.index("(") + 1 : constraint_definition.rindex(")")]
+        columns: list[str] = []
+        current: list[str] = []
+        in_quotes = False
+        index = 0
+        while index < len(inner):
+            char = inner[index]
+            if char == '"':
+                if in_quotes and index + 1 < len(inner) and inner[index + 1] == '"':
+                    current.append('"')
+                    index += 2
+                    continue
+                in_quotes = not in_quotes
+                index += 1
+                continue
+            if char == "," and not in_quotes:
+                columns.append("".join(current).strip())
+                current = []
+                index += 1
+                continue
+            current.append(char)
+            index += 1
+        if current:
+            columns.append("".join(current).strip())
+        return columns

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -1,5 +1,6 @@
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+
 from soda_redshift.common.data_sources.redshift_data_source import RedshiftSqlDialect
 
 
@@ -83,3 +84,55 @@ def test_percentiles_cannot_share_select_with_other_distinct_aggregates():
     """Redshift refuses PERCENTILE_CONT/DISC/MEDIAN combined with other
     DISTINCT aggregates in one SELECT; consumers batch them separately."""
     assert RedshiftSqlDialect().supports_percentiles_with_other_distinct_aggregates() is False
+
+
+def test_primary_keys_query_reads_pg_catalog_not_information_schema():
+    """The PK query must read pg_catalog.pg_constraint: Redshift's Postgres-8-lineage
+    information_schema constraint views only list tables the current user owns, so a
+    read-only monitoring user silently gets zero primary keys through them (same reason
+    the schemas/tables/columns queries read SVV/pg_catalog views)."""
+    from soda_redshift.statements.redshift_metadata_primary_keys_query import (
+        RedshiftMetadataPrimaryKeysQuery,
+    )
+
+    dialect = RedshiftSqlDialect()
+    query = RedshiftMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
+    namespace = query._build_namespace(["soda_test", "MySchema"])
+    sql = dialect.build_select_sql(query.build_sql_statement(namespace, ["orders"]))
+
+    assert "information_schema" not in sql
+    assert '"pg_catalog"."pg_constraint"' in sql
+    # pg_get_constraintdef carries the key columns in declared order (Redshift has no
+    # array_position to sort a conkey join).
+    assert "pg_get_constraintdef(constraints.oid)" in sql
+    # Schema filter is case-insensitive, so a schema spelled in a different case doesn't
+    # silently match nothing.
+    assert 'LOWER("schemas"."nspname") = \'myschema\'' in sql
+
+
+def test_primary_keys_constraint_definition_parsing_preserves_order():
+    from soda_core.common.data_source_results import QueryResult
+
+    from soda_redshift.statements.redshift_metadata_primary_keys_query import (
+        RedshiftMetadataPrimaryKeysQuery,
+    )
+
+    parse = RedshiftMetadataPrimaryKeysQuery._parse_primary_key_columns
+    assert parse("PRIMARY KEY (id)") == ["id"]
+    assert parse("PRIMARY KEY (tenant_id, id)") == ["tenant_id", "id"]
+    # Quoted identifiers: embedded commas and doubled-quote escapes must survive.
+    assert parse('PRIMARY KEY ("Tenant, Id", id)') == ["Tenant, Id", "id"]
+    assert parse('PRIMARY KEY ("we""ird", other)') == ['we"ird', "other"]
+
+    query = RedshiftMetadataPrimaryKeysQuery(sql_dialect=RedshiftSqlDialect(), data_source_connection=None)
+    query_result = QueryResult(
+        columns=[("table_name",), ("constraint_definition",)],
+        rows=[
+            ("orders", "PRIMARY KEY (tenant_id, id)"),
+            ("customers", "PRIMARY KEY (id)"),
+        ],
+    )
+    assert query.get_results(query_result) == {
+        "orders": ["tenant_id", "id"],
+        "customers": ["id"],
+    }

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -1,6 +1,5 @@
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
-
 from soda_redshift.common.data_sources.redshift_data_source import RedshiftSqlDialect
 
 
@@ -112,7 +111,6 @@ def test_primary_keys_query_reads_pg_catalog_not_information_schema():
 
 def test_primary_keys_constraint_definition_parsing_preserves_order():
     from soda_core.common.data_source_results import QueryResult
-
     from soda_redshift.statements.redshift_metadata_primary_keys_query import (
         RedshiftMetadataPrimaryKeysQuery,
     )

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -8,6 +8,7 @@ from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import (
     ColumnMetadata,
+    DataSourceNamespace,
     SamplerType,
     SodaDataTypeName,
 )
@@ -23,6 +24,9 @@ from soda_core.common.sql_ast import (
     seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
+from soda_core.common.statements.metadata_primary_keys_query import (
+    MetadataPrimaryKeysQuery,
+)
 from soda_core.contracts.impl.contract_verification_impl import ContractImpl
 from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
     SnowflakeDataSource as SnowflakeDataSourceModel,
@@ -41,6 +45,51 @@ TIMESTAMP_WITH_TIME_ZONE = "timestamp with time zone"
 TIMESTAMP_WITH_LOCAL_TIME_ZONE = "timestamp with local time zone"
 
 
+class SnowflakeMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
+    """Primary-key introspection for Snowflake.
+
+    Snowflake exposes primary keys via SHOW PRIMARY KEYS, not
+    information_schema.key_column_usage: its INFORMATION_SCHEMA has a
+    TABLE_CONSTRAINTS view but NO KEY_COLUMN_USAGE view, so the base
+    information_schema JOIN would raise a compilation error. SHOW is not a
+    SELECT, so execute() is overridden directly rather than building an AST
+    statement via build_sql_statement.
+    """
+
+    # SHOW PRIMARY KEYS output columns (0-based positions):
+    # https://docs.snowflake.com/en/sql-reference/sql/show-primary-keys#output
+    _SCHEMA_NAME_COLUMN = 2
+    _TABLE_NAME_COLUMN = 3
+    _COLUMN_NAME_COLUMN = 4
+
+    def execute(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        if not dataset_names:
+            return {}
+        namespace: DataSourceNamespace = self._build_namespace(dataset_prefixes)
+        database_name: str | None = namespace.get_database_for_metadata_query()
+        schema_name: str = namespace.get_schema_for_metadata_query()
+        qualified_schema: str = (
+            f"{self.sql_dialect.quote_default(database_name)}.{self.sql_dialect.quote_default(schema_name)}"
+            if database_name
+            else self.sql_dialect.quote_default(schema_name)
+        )
+        # Bulk: one SHOW returns every table's PK columns for the whole schema.
+        query_result = self.data_source_connection.execute_query(f"SHOW PRIMARY KEYS IN SCHEMA {qualified_schema}")
+
+        # dataset_names arrive in the case Snowflake stores/returns them (SHOW PRIMARY KEYS
+        # returns the same stored casing as the columns metadata the extension keys tables by),
+        # so match exactly rather than re-casing.
+        requested: set[str] = set(dataset_names)
+        primary_keys_by_table: dict[str, set[str]] = {}
+        for row in query_result.rows:
+            table_name = row[self._TABLE_NAME_COLUMN]
+            column_name = row[self._COLUMN_NAME_COLUMN]
+            if table_name not in requested or table_name is None or column_name is None:
+                continue
+            primary_keys_by_table.setdefault(table_name, set()).add(column_name)
+        return primary_keys_by_table
+
+
 class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceModel):
     def __init__(self, data_source_model: SnowflakeDataSourceModel, connection: Optional[DataSourceConnection] = None):
         super().__init__(data_source_model=data_source_model, connection=connection)
@@ -53,8 +102,15 @@ class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
+    def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        return SnowflakeMetadataPrimaryKeysQuery(
+            sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
+        )
+
     def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
-        # Snowflake exposes primary keys through the standard information_schema constraint views.
+        # Snowflake exposes primary keys via SHOW PRIMARY KEYS, not information_schema.key_column_usage
+        # (Snowflake's INFORMATION_SCHEMA has TABLE_CONSTRAINTS but no KEY_COLUMN_USAGE view). See
+        # SnowflakeMetadataPrimaryKeysQuery.
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     def switch_warehouse(self, warehouse: str, contract_impl: ContractImpl) -> None:

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -53,6 +53,10 @@ class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # Snowflake exposes primary keys through the standard information_schema constraint views.
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
+
     def switch_warehouse(self, warehouse: str, contract_impl: ContractImpl) -> None:
         if warehouse and contract_impl.datasource_warehouse != warehouse:
             if contract_impl.datasource_warehouse is None:
@@ -102,6 +106,9 @@ class SnowflakeSqlDialect(SqlDialect, sqlglot_dialect="snowflake"):
         string_literal: str = value.replace("\\", "\\\\")
         string_literal = string_literal.replace("'", "''")
         return string_literal
+
+    def supports_primary_keys(self) -> bool:
+        return True
 
     def default_casify(self, identifier: str) -> str:
         return identifier.upper()

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -61,8 +61,9 @@ class SnowflakeMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
     _SCHEMA_NAME_COLUMN = 2
     _TABLE_NAME_COLUMN = 3
     _COLUMN_NAME_COLUMN = 4
+    _KEY_SEQUENCE_COLUMN = 5  # 1-based position of the column within the primary key
 
-    def execute(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def execute(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         if not dataset_names:
             return {}
         namespace: DataSourceNamespace = self._build_namespace(dataset_prefixes)
@@ -80,14 +81,19 @@ class SnowflakeMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
         # returns the same stored casing as the columns metadata the extension keys tables by),
         # so match exactly rather than re-casing.
         requested: set[str] = set(dataset_names)
-        primary_keys_by_table: dict[str, set[str]] = {}
+        ordered_columns_by_table: dict[str, list[tuple[int, str]]] = {}
         for row in query_result.rows:
             table_name = row[self._TABLE_NAME_COLUMN]
             column_name = row[self._COLUMN_NAME_COLUMN]
             if table_name not in requested or table_name is None or column_name is None:
                 continue
-            primary_keys_by_table.setdefault(table_name, set()).add(column_name)
-        return primary_keys_by_table
+            ordered_columns_by_table.setdefault(table_name, []).append(
+                (int(row[self._KEY_SEQUENCE_COLUMN]), column_name)
+            )
+        return {
+            table_name: [column_name for _, column_name in sorted(ordered_columns)]
+            for table_name, ordered_columns in ordered_columns_by_table.items()
+        }
 
 
 class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceModel):
@@ -107,7 +113,7 @@ class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceMod
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         # Snowflake exposes primary keys via SHOW PRIMARY KEYS, not information_schema.key_column_usage
         # (Snowflake's INFORMATION_SCHEMA has TABLE_CONSTRAINTS but no KEY_COLUMN_USAGE view). See
         # SnowflakeMetadataPrimaryKeysQuery.

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -14,13 +14,20 @@ from soda_core.common.metadata_types import (
 )
 from soda_core.common.sql_ast import (
     ADD_INTERVAL,
+    AND,
     COLUMN,
     COUNT,
     DISTINCT,
+    EQ,
+    FROM,
+    IN,
+    LITERAL,
     RANDOM,
+    SELECT,
     TIME_DELTA,
     TUPLE,
     VALUES,
+    WHERE,
     seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
@@ -48,52 +55,97 @@ TIMESTAMP_WITH_LOCAL_TIME_ZONE = "timestamp with local time zone"
 class SnowflakeMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):
     """Primary-key introspection for Snowflake.
 
-    Snowflake exposes primary keys via SHOW PRIMARY KEYS, not
-    information_schema.key_column_usage: its INFORMATION_SCHEMA has a
-    TABLE_CONSTRAINTS view but NO KEY_COLUMN_USAGE view, so the base
-    information_schema JOIN would raise a compilation error. SHOW is not a
-    SELECT, so execute() is overridden directly rather than building an AST
-    statement via build_sql_statement.
-    """
+    Snowflake's INFORMATION_SCHEMA has a TABLE_CONSTRAINTS view but NO KEY_COLUMN_USAGE view,
+    so the base information_schema JOIN would raise a compilation error. The key columns only
+    come from SHOW PRIMARY KEYS — but SHOW caps its output at ~10K rows, so one schema-wide
+    SHOW silently drops PKs for tables past the cap in a large schema. Two steps instead:
 
-    # SHOW PRIMARY KEYS output columns (0-based positions):
-    # https://docs.snowflake.com/en/sql-reference/sql/show-primary-keys#output
-    _SCHEMA_NAME_COLUMN = 2
-    _TABLE_NAME_COLUMN = 3
-    _COLUMN_NAME_COLUMN = 4
-    _KEY_SEQUENCE_COLUMN = 5  # 1-based position of the column within the primary key
+    1. build_sql_statement queries TABLE_CONSTRAINTS (a real view: filterable, no row cap)
+       for which of the requested tables have a PRIMARY KEY constraint.
+    2. One ``SHOW PRIMARY KEYS IN TABLE`` per such table — its output is that table's key
+       columns only, far below any cap — ordered by key_sequence.
+    """
 
     def execute(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         if not dataset_names:
             return {}
         namespace: DataSourceNamespace = self._build_namespace(dataset_prefixes)
+        select_statement: list = self.build_sql_statement(table_namespace=namespace, table_names=dataset_names)
+        sql: str = self.sql_dialect.build_select_sql(select_statement)
+        # TABLE_CONSTRAINTS returns table names in Snowflake's stored casing; reuse them verbatim
+        # to qualify the SHOW statements and key the result.
+        tables_with_primary_key: list[str] = [
+            row[0] for row in self.data_source_connection.execute_query(sql).rows if row and row[0]
+        ]
+
         database_name: str | None = namespace.get_database_for_metadata_query()
         schema_name: str = namespace.get_schema_for_metadata_query()
-        qualified_schema: str = (
-            f"{self.sql_dialect.quote_default(database_name)}.{self.sql_dialect.quote_default(schema_name)}"
-            if database_name
-            else self.sql_dialect.quote_default(schema_name)
-        )
-        # Bulk: one SHOW returns every table's PK columns for the whole schema.
-        query_result = self.data_source_connection.execute_query(f"SHOW PRIMARY KEYS IN SCHEMA {qualified_schema}")
-
-        # dataset_names arrive in the case Snowflake stores/returns them (SHOW PRIMARY KEYS
-        # returns the same stored casing as the columns metadata the extension keys tables by),
-        # so match exactly rather than re-casing.
-        requested: set[str] = set(dataset_names)
-        ordered_columns_by_table: dict[str, list[tuple[int, str]]] = {}
-        for row in query_result.rows:
-            table_name = row[self._TABLE_NAME_COLUMN]
-            column_name = row[self._COLUMN_NAME_COLUMN]
-            if table_name not in requested or table_name is None or column_name is None:
-                continue
-            ordered_columns_by_table.setdefault(table_name, []).append(
-                (int(row[self._KEY_SEQUENCE_COLUMN]), column_name)
+        primary_keys_by_table: dict[str, list[str]] = {}
+        for table_name in tables_with_primary_key:
+            name_parts: list[str] = ([database_name] if database_name else []) + [schema_name, table_name]
+            qualified_table: str = ".".join(self.sql_dialect.quote_default(part) for part in name_parts)
+            show_result: QueryResult = self.data_source_connection.execute_query(
+                f"SHOW PRIMARY KEYS IN TABLE {qualified_table}"
             )
-        return {
-            table_name: [column_name for _, column_name in sorted(ordered_columns)]
-            for table_name, ordered_columns in ordered_columns_by_table.items()
-        }
+            primary_keys_by_table[table_name] = self._ordered_key_columns(show_result)
+        return primary_keys_by_table
+
+    def build_sql_statement(self, table_namespace: DataSourceNamespace, table_names: list[str]) -> list:
+        """Selects the requested tables that have a PRIMARY KEY constraint from
+        INFORMATION_SCHEMA.TABLE_CONSTRAINTS (which exists on Snowflake; KEY_COLUMN_USAGE does not).
+        """
+        database_name: str | None = table_namespace.get_database_for_metadata_query()
+        schema_name: str = table_namespace.get_schema_for_metadata_query()
+        information_schema = self.sql_dialect.information_schema_namespace_elements(table_namespace)
+
+        return [
+            SELECT([COLUMN(self.sql_dialect.column_table_name())]),
+            FROM(self.table_table_constraints()).IN(information_schema),
+            WHERE(
+                AND(
+                    [
+                        EQ(
+                            COLUMN(self.column_constraint_type()),
+                            LITERAL(self.primary_key_constraint_type_value()),
+                        ),
+                        *(
+                            [
+                                EQ(
+                                    COLUMN(self.sql_dialect.column_table_catalog()),
+                                    LITERAL(self.sql_dialect.metadata_casify(database_name)),
+                                )
+                            ]
+                            if database_name
+                            else []
+                        ),
+                        EQ(
+                            COLUMN(self.sql_dialect.column_table_schema()),
+                            LITERAL(self.sql_dialect.metadata_casify(schema_name)),
+                        ),
+                        IN(
+                            COLUMN(self.sql_dialect.column_table_name()),
+                            [LITERAL(self.sql_dialect.metadata_casify(name)) for name in table_names],
+                        ),
+                    ]
+                )
+            ),
+        ]
+
+    @staticmethod
+    def _ordered_key_columns(show_result: QueryResult) -> list[str]:
+        """Extracts the key column names from one table's SHOW PRIMARY KEYS output, ordered by
+        key_sequence (the 1-based position within the key). Columns are located by name in the
+        cursor description rather than by position, so a change in SHOW's output order fails
+        loud instead of silently mis-parsing."""
+        column_names: list[str] = [str(column[0]).lower() for column in show_result.columns]
+        column_name_index: int = column_names.index("column_name")
+        key_sequence_index: int = column_names.index("key_sequence")
+        ordered_columns: list[tuple[int, str]] = sorted(
+            (int(row[key_sequence_index]), row[column_name_index])
+            for row in show_result.rows
+            if row[column_name_index] is not None
+        )
+        return [column_name for _, column_name in ordered_columns]
 
 
 class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceModel):
@@ -109,15 +161,11 @@ class SnowflakeDataSourceImpl(DataSourceImpl, model_class=SnowflakeDataSourceMod
         )
 
     def create_metadata_primary_keys_query(self) -> MetadataPrimaryKeysQuery:
+        # TABLE_CONSTRAINTS + per-table SHOW PRIMARY KEYS: Snowflake has no KEY_COLUMN_USAGE
+        # view, and a schema-wide SHOW caps at ~10K rows. See SnowflakeMetadataPrimaryKeysQuery.
         return SnowflakeMetadataPrimaryKeysQuery(
             sql_dialect=self.sql_dialect, data_source_connection=self.data_source_connection
         )
-
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # Snowflake exposes primary keys via SHOW PRIMARY KEYS, not information_schema.key_column_usage
-        # (Snowflake's INFORMATION_SCHEMA has TABLE_CONSTRAINTS but no KEY_COLUMN_USAGE view). See
-        # SnowflakeMetadataPrimaryKeysQuery.
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
 
     def switch_warehouse(self, warehouse: str, contract_impl: ContractImpl) -> None:
         if warehouse and contract_impl.datasource_warehouse != warehouse:

--- a/soda-snowflake/tests/unit/test_snowflake_dialect.py
+++ b/soda-snowflake/tests/unit/test_snowflake_dialect.py
@@ -155,3 +155,84 @@ def test_add_interval_renders_timestampadd():
         ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
     )
     assert sql == "TIMESTAMPADD(days, ((soda_partition__ + 1) * 1), '2020-06-20T00:00:00')"
+
+
+class _StubConnection:
+    """Returns canned QueryResults in order and records every SQL statement issued."""
+
+    def __init__(self, results: list[QueryResult]):
+        self._results = list(results)
+        self.executed: list[str] = []
+
+    def execute_query(self, sql: str) -> QueryResult:
+        self.executed.append(sql)
+        return self._results.pop(0)
+
+
+# SHOW PRIMARY KEYS output columns, per
+# https://docs.snowflake.com/en/sql-reference/sql/show-primary-keys#output
+_SHOW_COLUMNS = (
+    ("created_on",),
+    ("database_name",),
+    ("schema_name",),
+    ("table_name",),
+    ("column_name",),
+    ("key_sequence",),
+    ("constraint_name",),
+)
+
+
+def _show_row(table_name: str, column_name: str, key_sequence: int) -> tuple:
+    return ("ts", "MY_DB", "MY_SCHEMA", table_name, column_name, key_sequence, f"{table_name}_pk")
+
+
+def test_primary_keys_queries_table_constraints_then_shows_per_table():
+    """Two-step flow: TABLE_CONSTRAINTS narrows to PK-bearing tables (no SHOW row cap), then one
+    SHOW PRIMARY KEYS IN TABLE per such table. Requested tables without a PK get no SHOW and are
+    absent; composite keys come back ordered by key_sequence even when SHOW rows arrive
+    out of order."""
+    from soda_snowflake.common.data_sources.snowflake_data_source import (
+        SnowflakeMetadataPrimaryKeysQuery,
+    )
+
+    connection = _StubConnection(
+        [
+            # Step 1: TABLE_CONSTRAINTS — NO_PK is requested but has no PK constraint.
+            QueryResult(columns=(("TABLE_NAME",),), rows=[("ORDERS",), ("CUSTOMERS",)]),
+            # Step 2: one SHOW per PK-bearing table; ORDERS rows deliberately out of key order.
+            QueryResult(
+                columns=_SHOW_COLUMNS, rows=[_show_row("ORDERS", "ID", 2), _show_row("ORDERS", "TENANT_ID", 1)]
+            ),
+            QueryResult(columns=_SHOW_COLUMNS, rows=[_show_row("CUSTOMERS", "ID", 1)]),
+        ]
+    )
+    query = SnowflakeMetadataPrimaryKeysQuery(sql_dialect=SnowflakeSqlDialect(), data_source_connection=connection)
+
+    result = query.execute(dataset_prefixes=["MY_DB", "MY_SCHEMA"], dataset_names=["ORDERS", "CUSTOMERS", "NO_PK"])
+
+    assert result == {"ORDERS": ["TENANT_ID", "ID"], "CUSTOMERS": ["ID"]}
+
+    constraints_sql = connection.executed[0]
+    assert "TABLE_CONSTRAINTS" in constraints_sql
+    assert "KEY_COLUMN_USAGE" not in constraints_sql
+    assert "'PRIMARY KEY'" in constraints_sql
+    assert "'ORDERS'" in constraints_sql and "'CUSTOMERS'" in constraints_sql and "'NO_PK'" in constraints_sql
+
+    assert connection.executed[1] == 'SHOW PRIMARY KEYS IN TABLE "MY_DB"."MY_SCHEMA"."ORDERS"'
+    assert connection.executed[2] == 'SHOW PRIMARY KEYS IN TABLE "MY_DB"."MY_SCHEMA"."CUSTOMERS"'
+    assert len(connection.executed) == 3
+
+
+def test_primary_keys_show_parsing_locates_columns_by_name():
+    """SHOW output is parsed by column NAME from the cursor description, not by position — a
+    reordered SHOW output must still parse correctly (and a missing column fails loud)."""
+    from soda_snowflake.common.data_sources.snowflake_data_source import (
+        SnowflakeMetadataPrimaryKeysQuery,
+    )
+
+    reordered_columns = (("key_sequence",), ("column_name",), ("table_name",))
+    show_result = QueryResult(
+        columns=reordered_columns,
+        rows=[(2, "ID", "ORDERS"), (1, "TENANT_ID", "ORDERS")],
+    )
+    assert SnowflakeMetadataPrimaryKeysQuery._ordered_key_columns(show_result) == ["TENANT_ID", "ID"]

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -153,6 +153,13 @@ class SparkDataFrameSqlDialect(DatabricksSqlDialect, sqlglot_dialect="spark"):
         # Instance override — see class-level comment above.
         self.SUPPORTS_DROP_TABLE_CASCADE = use_catalog
 
+    def supports_primary_keys(self) -> bool:
+        # Open-source Spark SQL (the local, Hive-metastore-backed engine this data source runs
+        # against) has no information_schema and cannot declare a PRIMARY KEY in CREATE TABLE,
+        # so primary-key introspection stays opt-out — overriding the Unity Catalog default
+        # inherited from DatabricksSqlDialect.
+        return False
+
     def get_database_prefix_index(self) -> int | None:
         return 0 if self.use_catalog else None
 

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -78,6 +78,11 @@ class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+        # SQL Server exposes primary keys through the standard information_schema constraint views.
+        # Fabric and Synapse inherit this delegate; each dialect opts in via supports_primary_keys().
+        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
+
     def open_connection(self) -> None:
         super().open_connection()
         self._sync_dialect_server_info()
@@ -120,6 +125,11 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         # capability checks then assume the newest engine.
         self.server_major_version: Optional[int] = None
         self.engine_edition: Optional[int] = None
+
+    def supports_primary_keys(self) -> bool:
+        # SQL Server enforces primary keys and reports them through the standard
+        # information_schema constraint views, with the standard PRIMARY KEY (...) DDL.
+        return True
 
     def _build_stddev_samp_sql(self, stddev_samp) -> str:
         # T-SQL names the sample standard deviation aggregate STDEV.

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -78,11 +78,6 @@ class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
-        # SQL Server exposes primary keys through the standard information_schema constraint views.
-        # Fabric and Synapse inherit this delegate; each dialect opts in via supports_primary_keys().
-        return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)
-
     def open_connection(self) -> None:
         super().open_connection()
         self._sync_dialect_server_info()

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -78,7 +78,7 @@ class SqlServerDataSourceImpl(DataSourceImpl, model_class=SqlServerDataSourceMod
             name=self.data_source_model.name, connection_properties=self.data_source_model.connection_properties
         )
 
-    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, set[str]]:
+    def get_primary_keys(self, dataset_prefixes: list[str], dataset_names: list[str]) -> dict[str, list[str]]:
         # SQL Server exposes primary keys through the standard information_schema constraint views.
         # Fabric and Synapse inherit this delegate; each dialect opts in via supports_primary_keys().
         return self.create_metadata_primary_keys_query().execute(dataset_prefixes, dataset_names)

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 from typing import Callable, Optional
 
@@ -83,17 +82,9 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True
     ) -> str:
-        # A NOT ENFORCED primary key still requires its columns to be NOT NULL, so force that
-        # on the participating columns before rendering them. CREATE_TABLE_COLUMN objects are
-        # reused across renders (e.g. cross-source flows render the same source columns on two
-        # dialects), so mutate a deep copy rather than the caller's objects — otherwise
-        # nullable=False leaks onto the shared column list.
-        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
-        if primary_key_column_names:
-            create_table = copy.deepcopy(create_table)
-            for column in create_table.columns:
-                if column.name in primary_key_column_names:
-                    column.nullable = False
+        # This override reimplements the base builder (for the HEAP option below), so apply the
+        # base's NOT NULL-on-primary-key handling explicitly (a NOT ENFORCED key still requires it).
+        create_table = self._create_table_with_primary_key_columns_not_null(create_table)
         create_table_sql = self._build_create_table_statement_sql(create_table)
         column_clauses: list[str] = [self._build_create_table_column(column) for column in create_table.columns]
         primary_key_clause: Optional[str] = self._build_create_table_primary_key(create_table)

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from typing import Callable, Optional
 
@@ -82,13 +83,18 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True
     ) -> str:
-        create_table_sql = self._build_create_table_statement_sql(create_table)
         # A NOT ENFORCED primary key still requires its columns to be NOT NULL, so force that
-        # on the participating columns before rendering them.
-        primary_key_column_names = getattr(create_table, "primary_key_column_names", None) or []
-        for column in create_table.columns:
-            if column.name in primary_key_column_names:
-                column.nullable = False
+        # on the participating columns before rendering them. CREATE_TABLE_COLUMN objects are
+        # reused across renders (e.g. cross-source flows render the same source columns on two
+        # dialects), so mutate a deep copy rather than the caller's objects — otherwise
+        # nullable=False leaks onto the shared column list.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
+        if primary_key_column_names:
+            create_table = copy.deepcopy(create_table)
+            for column in create_table.columns:
+                if column.name in primary_key_column_names:
+                    column.nullable = False
+        create_table_sql = self._build_create_table_statement_sql(create_table)
         column_clauses: list[str] = [self._build_create_table_column(column) for column in create_table.columns]
         primary_key_clause: Optional[str] = self._build_create_table_primary_key(create_table)
         if primary_key_clause is not None:

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -64,16 +64,36 @@ class SynapseSqlDialect(SqlServerSqlDialect, sqlglot_dialect="tsql"):
         # issue a metadata round-trip per page during a paginated scan.
         self._columns_cache: dict[tuple[tuple[str, ...], str], list[str]] = {}
 
+    def supports_primary_keys(self) -> bool:
+        # Synapse dedicated SQL pools store primary keys as non-enforced NONCLUSTERED
+        # constraints, reported through the standard information_schema constraint views.
+        return True
+
+    def _build_create_table_primary_key(self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS) -> Optional[str]:
+        # Synapse only accepts a primary key declared as NONCLUSTERED ... NOT ENFORCED.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None)
+        if not primary_key_column_names:
+            return None
+        quoted_columns: str = ", ".join(
+            self._quote_column_for_create_table(column_name) for column_name in primary_key_column_names
+        )
+        return f"\tPRIMARY KEY NONCLUSTERED ({quoted_columns}) NOT ENFORCED"
+
     def build_create_table_sql(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS, add_semicolon: bool = True
     ) -> str:
         create_table_sql = self._build_create_table_statement_sql(create_table)
-        create_table_sql = (
-            create_table_sql
-            + "(\n"
-            + ",\n".join([self._build_create_table_column(column) for column in create_table.columns])
-            + "\n)"
-        )
+        # A NOT ENFORCED primary key still requires its columns to be NOT NULL, so force that
+        # on the participating columns before rendering them.
+        primary_key_column_names = getattr(create_table, "primary_key_column_names", None) or []
+        for column in create_table.columns:
+            if column.name in primary_key_column_names:
+                column.nullable = False
+        column_clauses: list[str] = [self._build_create_table_column(column) for column in create_table.columns]
+        primary_key_clause: Optional[str] = self._build_create_table_primary_key(create_table)
+        if primary_key_clause is not None:
+            column_clauses.append(primary_key_clause)
+        create_table_sql = create_table_sql + "(\n" + ",\n".join(column_clauses) + "\n)"
         # Synapse uses clustered columnstore indexes by default, which don't support varchar(MAX).
         # Use HEAP to create a heap table instead.
         create_table_sql = create_table_sql + "\nWITH (HEAP)"

--- a/soda-synapse/tests/unit/test_synapse_dialect.py
+++ b/soda-synapse/tests/unit/test_synapse_dialect.py
@@ -1,4 +1,5 @@
-from soda_core.common.sql_ast import COUNT, STAR
+from soda_core.common.metadata_types import SqlDataType
+from soda_core.common.sql_ast import COUNT, CREATE_TABLE, CREATE_TABLE_COLUMN, STAR
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
 from soda_synapse.common.data_sources.synapse_data_source import SynapseSqlDialect
 
@@ -7,6 +8,26 @@ def test_random():
     sql_dialect: SynapseSqlDialect = SynapseSqlDialect()
     sql = sql_dialect.build_select_sql([SELECT(RANDOM()), FROM("a")])
     assert sql == "SELECT ABS(CAST(CHECKSUM(NEWID()) AS FLOAT)) / 2147483648.0\nFROM [a];"
+
+
+def test_primary_key_create_table_is_nonclustered_not_enforced_with_not_null_columns():
+    # Synapse only accepts a NONCLUSTERED ... NOT ENFORCED primary key, and its columns
+    # must be NOT NULL. The custom HEAP create-table builder still emits the PK clause.
+    dialect = SynapseSqlDialect()
+    create_table = CREATE_TABLE(
+        fully_qualified_table_name="db.dbo.orders",
+        columns=[
+            CREATE_TABLE_COLUMN(name="tenant_id", type=SqlDataType("int")),
+            CREATE_TABLE_COLUMN(name="id", type=SqlDataType("int")),
+            CREATE_TABLE_COLUMN(name="label", type=SqlDataType("varchar", character_maximum_length=10)),
+        ],
+        primary_key_column_names=["tenant_id", "id"],
+    )
+    sql = dialect.build_create_table_sql(create_table)
+    assert "[tenant_id] int NOT NULL" in sql
+    assert "[id] int NOT NULL" in sql
+    assert "PRIMARY KEY NONCLUSTERED ([tenant_id], [id]) NOT ENFORCED" in sql
+    assert sql.rstrip(";").endswith("WITH (HEAP)")
 
 
 def test_count_renders_as_count_big():

--- a/soda-tests/tests/integration/test_table_metadata.py
+++ b/soda-tests/tests/integration/test_table_metadata.py
@@ -211,9 +211,13 @@ def test_primary_keys_metadata_do_not_leak_across_schemas(data_source_test_helpe
 
     # Second schema, sharing the database/catalog but a distinct schema name, holding a table with
     # the SAME name (so the auto-generated PK constraint name collides) but a DIFFERENT PK column.
-    database_name = default_prefix[0]
-    other_schema_name = f"{default_prefix[1]}_pkleak"
-    other_prefix = [database_name, other_schema_name]
+    # Derive the schema position from the dialect rather than assuming a [database, schema] prefix:
+    # schema-scoped data sources (e.g. DuckDB) carry a single-element [schema] prefix, so a hard
+    # default_prefix[1] would IndexError. Rebuild the prefix with only the schema element renamed.
+    schema_index = sql_dialect.get_schema_prefix_index()
+    other_schema_name = f"{default_prefix[schema_index]}_pkleak"
+    other_prefix = list(default_prefix)
+    other_prefix[schema_index] = other_schema_name
 
     def _create_table_sql(prefix: list[str]) -> str:
         qualified_name = sql_dialect.qualify_dataset_name(prefix, table_name)

--- a/soda-tests/tests/unit/test_primary_keys_metadata.py
+++ b/soda-tests/tests/unit/test_primary_keys_metadata.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest import mock
-
 import pytest
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
@@ -33,12 +31,51 @@ def test_column_metadata_carries_is_primary_key():
     assert pk_column.is_primary_key is True
 
 
-def test_base_get_primary_keys_returns_empty_dict():
-    # The base implementation must return an empty dict (safe default),
-    # so data sources without an override don't break.
-    data_source_impl = mock.MagicMock(spec=DataSourceImpl)
+class _FakePrimaryKeysDataSource:
+    """DataSourceImpl double for the get_primary_keys gate: a dialect flag, a canned query,
+    and a counter proving whether the query was built at all."""
+
+    class _Dialect:
+        def __init__(self, supports: bool):
+            self._supports = supports
+
+        def supports_primary_keys(self) -> bool:
+            return self._supports
+
+    class _Query:
+        def __init__(self, result: dict):
+            self._result = result
+            self.execute_calls: list[tuple] = []
+
+        def execute(self, dataset_prefixes, dataset_names):
+            self.execute_calls.append((dataset_prefixes, dataset_names))
+            return self._result
+
+    def __init__(self, supports_primary_keys: bool, query_result: dict | None = None):
+        self.sql_dialect = self._Dialect(supports_primary_keys)
+        self.query = self._Query(query_result or {})
+        self.create_query_calls = 0
+
+    def create_metadata_primary_keys_query(self):
+        self.create_query_calls += 1
+        return self.query
+
+
+def test_get_primary_keys_returns_empty_dict_when_dialect_opts_out():
+    # The supports_primary_keys() gate is enforced centrally: a data source whose active
+    # dialect opts out (e.g. Databricks Hive metastore, Fabric) returns {} WITHOUT building
+    # or executing a query — its catalog may not even have the constraint views.
+    data_source_impl = _FakePrimaryKeysDataSource(supports_primary_keys=False)
     result = DataSourceImpl.get_primary_keys(data_source_impl, dataset_prefixes=["public"], dataset_names=["orders"])
     assert result == {}
+    assert data_source_impl.create_query_calls == 0
+
+
+def test_get_primary_keys_delegates_to_query_when_dialect_opts_in():
+    data_source_impl = _FakePrimaryKeysDataSource(supports_primary_keys=True, query_result={"orders": ["id"]})
+    result = DataSourceImpl.get_primary_keys(data_source_impl, dataset_prefixes=["public"], dataset_names=["orders"])
+    assert result == {"orders": ["id"]}
+    assert data_source_impl.query.execute_calls == [(["public"], ["orders"])]
 
 
 def test_get_results_groups_columns_by_table_in_key_order():

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
@@ -81,6 +81,11 @@ class TrinoSqlDialect(SqlDialect, sqlglot_dialect="trino"):
         (SodaDataTypeName.SMALLINT, SodaDataTypeName.INTEGER),
     )
 
+    # Primary-key introspection stays opt-out (supports_primary_keys inherits False from the
+    # base dialect): Trino's information_schema has no table_constraints/key_column_usage views,
+    # its CREATE TABLE grammar has no PRIMARY KEY clause, and no common connector (Hive, Iceberg,
+    # PostgreSQL) surfaces primary keys through the query layer.
+
     def supports_materialized_views(self) -> bool:
         # TODO  this should inherit from the connection
         return True


### PR DESCRIPTION
## Problem

The v4 primary-key primitive (#2811) implemented `get_primary_keys` only for Postgres; every other data source returned an empty result.

## Change

Enables bulk primary-key introspection across the OSS data sources — Snowflake, Redshift, SQL Server, Databricks, BigQuery, DuckDB, Synapse — each opting in via `supports_primary_keys()` + a bulk `get_primary_keys` (delegate to the standard `information_schema` query, or a `MetadataPrimaryKeysQuery` subclass for BigQuery's dataset-qualified namespace and DuckDB's `constraint_column_usage`). BigQuery and Synapse add a create-table `PRIMARY KEY (...) NOT ENFORCED` DDL override so the integration test can create a keyed table. Trino, SparkDF, Fabric, and Athena stay **opt-out** — no `information_schema` constraint views and/or no inline PRIMARY KEY DDL (Fabric is ALTER-only).

Stacked on #2811. Part of OBSL-1043.

## Verification

`test_primary_keys_metadata` (from #2811) runs per data source in the CI matrix, gated on `supports_primary_keys()`. **Locally verified: Postgres and DuckDB** (embedded — DuckDB exercises the subclass path end-to-end). Container-backed sources (Snowflake, BigQuery, Redshift, SQL Server, Databricks, Synapse) are verified by their CI jobs; each assumes its `information_schema` / declared-PK metadata is populated and role-visible.
