### PR TITLE
refactor(cli): single mark-scan-failed site at the CLI failure boundary

### DIFF
--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -201,7 +201,9 @@ def execute_check_collections(
             constructed.append((impl, impl_class, None, yaml_source))
         except Exception as exc:
             if abort_on_first_error:
-                _report_runner_scan_failed_before_reraise(soda_cloud_impl, publish_results, logs, exc)
+                # Re-raise verbatim, without touching Cloud: the CLI failure boundary
+                # (``run_with_failure_reporting``) owns the single mark-scan-failed —
+                # a session-level mark here would duplicate it.
                 raise
             constructed.append((None, impl_class, exc, yaml_source))
 
@@ -239,7 +241,7 @@ def execute_check_collections(
                 results.append(impl.verify())
             except Exception as exc:
                 if abort_on_first_error:
-                    _report_runner_scan_failed_before_reraise(soda_cloud_impl, publish_results, logs, exc)
+                    # Re-raise verbatim, without touching Cloud (see the phase-1 abort above).
                     raise
                 results.append(impl_class.build_error_result(yaml_source, exc))
 
@@ -403,46 +405,6 @@ def execute_check_collections(
                     )
 
     return CheckCollectionSessionResult(results)
-
-
-def _report_runner_scan_failed_before_reraise(
-    soda_cloud_impl: Optional[SodaCloud],
-    publish_results: bool,
-    logs: Optional[Logs],
-    exc: BaseException,
-) -> None:
-    """Best-effort: mark the runner's (still-PENDING) Cloud scan FAILED with the captured logs
-    just before an ``abort_on_first_error`` re-raise.
-
-    A single-contract (runner) scan aborts on the first construction/verify exception, which
-    re-raises out of ``execute_check_collections`` before phase 3's combined upload runs — the only
-    place that otherwise ships logs / marks the scan FAILED. Without this the exception propagates to
-    the CLI (exit 3) and the launcher only writes it to pod logs, so the Cloud scan record shows
-    FAILED with no logs and the failure is undiagnosable (SAS-13001). Reporting here keeps the
-    historical re-raise contract intact while making the failure visible in Cloud.
-
-    No-op when there is no cloud client, no publish opt-in, or no runner scan id (ad-hoc runs).
-    Never masks the original exception: any error while reporting is swallowed so the caller still
-    sees the real failure. The shared ``logs`` gatherer holds every construction/verify record (each
-    impl is built with ``logs=logs``), so its records are exactly what should reach Cloud.
-    """
-    if soda_cloud_impl is None or not publish_results:
-        return
-    soda_scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
-    if not soda_scan_id:
-        return
-    try:
-        log_records = logs.get_log_records() if logs is not None else None
-        soda_cloud_impl.mark_scan_as_failed(
-            scan_id=soda_scan_id,
-            logs=log_records,
-            exc=exc if isinstance(exc, Exception) else None,
-        )
-    except Exception:
-        # Warning, not debug: if this best-effort report fails the scan stays FAILED-with-no-logs in
-        # Cloud — the exact state this helper exists to avoid — so it must be visible in the pod logs
-        # / Datadog rather than silently swallowed. (The original exception is still re-raised.)
-        logger.warning("Could not report runner scan as failed before re-raising", exc_info=True)
 
 
 def _parse_data_timestamp(value: Optional[Union[str, datetime]]) -> Optional[datetime]:

--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -25,6 +25,7 @@ from soda_core.cli.handlers.dependencies import (
     resolve_data_source,
     resolve_scan_definition_name,
     resolve_soda_cloud,
+    resolve_soda_cloud_for_failure_report,
     run_with_failure_reporting,
 )
 from soda_core.cli.handlers.failure_reporting import ScanExecutionFailedException
@@ -272,20 +273,31 @@ def _setup_contract_verify_command(contract_parsers) -> None:
             soda_logger.error(str(e))
             exit_with_code(ExitCode.LOG_ERRORS)
 
-        exit_code = handle_verify_contract(
-            contract_file_path,
-            dataset_identifier,
-            data_source_file_paths,
-            soda_cloud_file_path,
-            variables,
-            publish,
-            verbose,
-            use_runner,
-            blocking_timeout_in_minutes,
-            args.check_paths,
-            check_selectors,
-            diagnostics_warehouse_file_path,
-            metadata_dwh_file_path,
+        # The reporting channel resolves first, outside the wrapped command; the wrapper
+        # is the single Cloud-marking site for escaped failures (exit 3 delivered or
+        # ad-hoc, 4 undelivered so the launcher's fallback reports). A broken Cloud
+        # config resolves to None here; the command re-raises the real config error
+        # (verify_contract builds its own client) and the boundary reports it through
+        # the None channel.
+        soda_cloud = resolve_soda_cloud_for_failure_report(soda_cloud_file_path, variables)
+        exit_code = run_with_failure_reporting(
+            soda_cloud,
+            lambda logs: handle_verify_contract(
+                contract_file_path,
+                dataset_identifier,
+                data_source_file_paths,
+                soda_cloud_file_path,
+                variables,
+                publish,
+                verbose,
+                use_runner,
+                blocking_timeout_in_minutes,
+                args.check_paths,
+                check_selectors,
+                diagnostics_warehouse_file_path,
+                metadata_dwh_file_path,
+                logs=logs,
+            ),
         )
 
         exit_with_code(exit_code)

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -10,7 +10,6 @@ from soda_core.common._deprecation import deprecated_kwarg
 from soda_core.common.exceptions import (
     ContractParserException,
     InvalidArgumentException,
-    InvalidDataSourceConfigurationException,
 )
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.yaml import ContractYamlSource
@@ -46,7 +45,20 @@ def handle_verify_contract(
         use_runner = False
     if check_selectors is None:
         check_selectors = []
-    try:
+
+    # Local import avoids a soda_cloud <-> contracts.api cycle.
+    from soda_core.cli.handlers.dependencies import run_with_failure_reporting
+    from soda_core.common.logs import Logs
+
+    # The reporting channel resolves first, outside the wrapped command — it is the single
+    # Cloud-marking site for failures (delivery-aware, as discover/monitor: exit 3 when Cloud
+    # has the failure or the run is ad-hoc, 4 when a managed run's failure couldn't reach
+    # Cloud so the launcher's fallback reports). A broken Cloud config resolves to None here;
+    # the command re-raises the real config error (verify_contract builds its own client) and
+    # the boundary reports it through the None channel.
+    soda_cloud = _resolve_soda_cloud_for_failure_report(soda_cloud_file_path, variables)
+
+    def verify_and_interpret(logs: Logs) -> ExitCode:
         dwh_files: Optional[DiagnosticsWarehouseFiles] = None
         if diagnostics_warehouse_file_path or metadata_dwh_file_path:
             dwh_files = DiagnosticsWarehouseFiles(
@@ -68,21 +80,14 @@ def handle_verify_contract(
             check_paths=check_paths,
             check_selectors=check_selectors,
             dwh_data_source_file_path=dwh_files,
+            # The wrapper's collector, threaded into the session so every construction/
+            # verify record lands in the collector the failure report captures from.
+            logs=logs,
         )
 
         return interpret_contract_verification_result(contract_verification_result)
 
-    except (InvalidArgumentException, InvalidDataSourceConfigurationException, Exception) as exc:
-        # Shared delivery-aware reporting (as discover/monitor do): marks the managed scan failed and
-        # returns 3 when Cloud has the failure (or ad-hoc), 4 when it doesn't so the launcher reports.
-        # Local import avoids a soda_cloud <-> contracts.api cycle.
-        from soda_core.cli.handlers.failure_reporting import (
-            report_scan_execution_failure,
-        )
-
-        soda_logger.exception(f"An unexpected exception occurred: {exc}")
-        soda_cloud = _resolve_soda_cloud_for_failure_report(soda_cloud_file_path, variables)
-        return report_scan_execution_failure(soda_cloud, log_records=None)
+    return run_with_failure_reporting(soda_cloud, verify_and_interpret)
 
 
 def _resolve_soda_cloud_for_failure_report(

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -1,6 +1,9 @@
 from os.path import dirname, exists
 from pathlib import Path
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
+
+if TYPE_CHECKING:
+    from soda_core.common.soda_cloud import SodaCloud
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common._deprecation import deprecated_kwarg
@@ -70,8 +73,31 @@ def handle_verify_contract(
         return interpret_contract_verification_result(contract_verification_result)
 
     except (InvalidArgumentException, InvalidDataSourceConfigurationException, Exception) as exc:
+        # Shared delivery-aware reporting (as discover/monitor do): marks the managed scan failed and
+        # returns 3 when Cloud has the failure (or ad-hoc), 4 when it doesn't so the launcher reports.
+        # Local import avoids a soda_cloud <-> contracts.api cycle.
+        from soda_core.cli.handlers.failure_reporting import (
+            report_scan_execution_failure,
+        )
+
         soda_logger.exception(f"An unexpected exception occurred: {exc}")
-        return ExitCode.LOG_ERRORS
+        soda_cloud = _resolve_soda_cloud_for_failure_report(soda_cloud_file_path, variables)
+        return report_scan_execution_failure(soda_cloud, log_records=None)
+
+
+def _resolve_soda_cloud_for_failure_report(
+    soda_cloud_file_path: Optional[str], variables: Optional[Dict[str, str]]
+) -> "Optional[SodaCloud]":
+    """Soda Cloud channel for reporting an early verify failure, or None when Cloud isn't configured
+    or can't be built (report_scan_execution_failure then returns 3 for ad-hoc, 4 for a managed run)."""
+    from soda_core.common.soda_cloud import SodaCloud
+
+    if not soda_cloud_file_path:
+        return None
+    try:
+        return SodaCloud.from_config(soda_cloud_file_path, variables)
+    except Exception:
+        return None
 
 
 def contract_verification_is_not_sent_to_cloud(

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -1,9 +1,6 @@
 from os.path import dirname, exists
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional
-
-if TYPE_CHECKING:
-    from soda_core.common.soda_cloud import SodaCloud
+from typing import Dict, Optional
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common._deprecation import deprecated_kwarg
@@ -12,6 +9,7 @@ from soda_core.common.exceptions import (
     InvalidArgumentException,
 )
 from soda_core.common.logging_constants import Emoticons, soda_logger
+from soda_core.common.logs import Logs
 from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.api import test_contract, verify_contract
 from soda_core.contracts.api.publish_api import publish_contract
@@ -36,8 +34,21 @@ def handle_verify_contract(
     check_selectors: Optional[list[CheckSelector]] = None,
     diagnostics_warehouse_file_path: Optional[str] = None,
     metadata_dwh_file_path: Optional[str] = None,
+    logs: Optional[Logs] = None,
     **kwargs,
 ) -> ExitCode:
+    """Run a contract verification and map its result to an exit code.
+
+    Failures propagate raw without logging or Cloud reporting here: the CLI
+    wiring wraps this command in ``run_with_failure_reporting`` — the single
+    Cloud-marking site for escaped exceptions (delivery-aware: exit 3 when
+    Cloud has the failure or the run is ad-hoc, 4 when a managed run's failure
+    couldn't reach Cloud so the launcher's fallback reports).
+
+    ``logs`` is the wrapper's collector, threaded into the session so every
+    construction/verify record lands in the collector the failure report
+    captures from.
+    """
     use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
     if kwargs:
         raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
@@ -46,63 +57,31 @@ def handle_verify_contract(
     if check_selectors is None:
         check_selectors = []
 
-    # Local import avoids a soda_cloud <-> contracts.api cycle.
-    from soda_core.cli.handlers.dependencies import run_with_failure_reporting
-    from soda_core.common.logs import Logs
-
-    # The reporting channel resolves first, outside the wrapped command — it is the single
-    # Cloud-marking site for failures (delivery-aware, as discover/monitor: exit 3 when Cloud
-    # has the failure or the run is ad-hoc, 4 when a managed run's failure couldn't reach
-    # Cloud so the launcher's fallback reports). A broken Cloud config resolves to None here;
-    # the command re-raises the real config error (verify_contract builds its own client) and
-    # the boundary reports it through the None channel.
-    soda_cloud = _resolve_soda_cloud_for_failure_report(soda_cloud_file_path, variables)
-
-    def verify_and_interpret(logs: Logs) -> ExitCode:
-        dwh_files: Optional[DiagnosticsWarehouseFiles] = None
-        if diagnostics_warehouse_file_path or metadata_dwh_file_path:
-            dwh_files = DiagnosticsWarehouseFiles(
-                primary_path=diagnostics_warehouse_file_path,
-                metadata_dwh_file_path=metadata_dwh_file_path,
-            )
-
-        contract_verification_result = verify_contract(
-            contract_file_path=contract_file_path,
-            dataset_identifier=dataset_identifier,
-            data_source_file_path=None,
-            data_source_file_paths=data_source_file_paths,
-            soda_cloud_file_path=soda_cloud_file_path,
-            variables=variables,
-            publish=publish,
-            verbose=verbose,
-            use_runner=use_runner,
-            blocking_timeout_in_minutes=blocking_timeout_in_minutes,
-            check_paths=check_paths,
-            check_selectors=check_selectors,
-            dwh_data_source_file_path=dwh_files,
-            # The wrapper's collector, threaded into the session so every construction/
-            # verify record lands in the collector the failure report captures from.
-            logs=logs,
+    dwh_files: Optional[DiagnosticsWarehouseFiles] = None
+    if diagnostics_warehouse_file_path or metadata_dwh_file_path:
+        dwh_files = DiagnosticsWarehouseFiles(
+            primary_path=diagnostics_warehouse_file_path,
+            metadata_dwh_file_path=metadata_dwh_file_path,
         )
 
-        return interpret_contract_verification_result(contract_verification_result)
+    contract_verification_result = verify_contract(
+        contract_file_path=contract_file_path,
+        dataset_identifier=dataset_identifier,
+        data_source_file_path=None,
+        data_source_file_paths=data_source_file_paths,
+        soda_cloud_file_path=soda_cloud_file_path,
+        variables=variables,
+        publish=publish,
+        verbose=verbose,
+        use_runner=use_runner,
+        blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+        check_paths=check_paths,
+        check_selectors=check_selectors,
+        dwh_data_source_file_path=dwh_files,
+        logs=logs,
+    )
 
-    return run_with_failure_reporting(soda_cloud, verify_and_interpret)
-
-
-def _resolve_soda_cloud_for_failure_report(
-    soda_cloud_file_path: Optional[str], variables: Optional[Dict[str, str]]
-) -> "Optional[SodaCloud]":
-    """Soda Cloud channel for reporting an early verify failure, or None when Cloud isn't configured
-    or can't be built (report_scan_execution_failure then returns 3 for ad-hoc, 4 for a managed run)."""
-    from soda_core.common.soda_cloud import SodaCloud
-
-    if not soda_cloud_file_path:
-        return None
-    try:
-        return SodaCloud.from_config(soda_cloud_file_path, variables)
-    except Exception:
-        return None
+    return interpret_contract_verification_result(contract_verification_result)
 
 
 def contract_verification_is_not_sent_to_cloud(

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -109,17 +109,22 @@ def resolve_scan_definition_name(scan_definition_name: Optional[str]) -> str:
 
 
 def run_with_failure_reporting(
-    soda_cloud: SodaCloud,
+    soda_cloud: Optional[SodaCloud],
     command: Callable[[Logs], ExitCode],
 ) -> ExitCode:
     """Run a command with every failure mapped to an exit code and reported to
     Soda Cloud in one place.
 
-    Receives the already-constructed reporting channel (``soda_cloud``);
-    dependency construction lives at the wiring layer, which decides what
-    resolves inside the command. Owns the ``Logs`` lifecycle — the collector
-    starts before the command, so in-command resolution failures are captured
-    too. The wrapper's own ``logs`` collector is handed to the command so a
+    This is the single Cloud-marking site for exceptions escaping a command:
+    the engine layers underneath re-raise without touching Cloud, so exactly
+    one ``sodaCoreMarkScanFailed`` reaches the backend per failed run.
+
+    Receives the already-constructed reporting channel (``soda_cloud``;
+    ``None`` when the command can run without Cloud — an escaped failure then
+    exits 4 for a managed run, 3 ad-hoc); dependency construction lives at the
+    wiring layer, which decides what resolves inside the command. Owns the
+    ``Logs`` lifecycle — the collector starts before the command, so
+    in-command resolution failures are captured too. The wrapper's own ``logs`` collector is handed to the command so a
     command that runs a check-collection session can thread it through (each
     impl built with ``logs=logs``); without this a command constructing its own
     inner ``Logs`` would displace the wrapper's collector and its downstream

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -77,6 +77,13 @@ def resolve_soda_cloud_for_failure_report(
     try:
         return SodaCloud.from_config(soda_cloud_file_path, variables)
     except Exception:
+        # Deliberately broad: this runs outside the failure boundary, where an escaped
+        # exception would crash the CLI instead of mapping to a delivery-aware exit code.
+        soda_logger.debug(
+            f"Could not build the Soda Cloud failure-report channel from '{soda_cloud_file_path}'; "
+            f"failures will be reported by exit code only.",
+            exc_info=True,
+        )
         return None
 
 

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -60,6 +60,26 @@ def resolve_soda_cloud(soda_cloud_file_path: Optional[str]) -> SodaCloud:
     return soda_cloud
 
 
+def resolve_soda_cloud_for_failure_report(
+    soda_cloud_file_path: Optional[str], variables: Optional[dict[str, str]] = None
+) -> Optional[SodaCloud]:
+    """Soda Cloud channel for ``run_with_failure_reporting``, or None when Cloud isn't
+    configured or can't be built (``report_scan_execution_failure`` then returns 3 for an
+    ad-hoc run, 4 for a managed one).
+
+    The swallow-to-None variant of ``resolve_soda_cloud``, for commands where running
+    without Cloud is legal (e.g. a local contract verify). A broken config is not lost:
+    the wrapped command re-raises the real config error (it builds its own client from
+    the same file) and the boundary reports it through the None channel.
+    """
+    if not soda_cloud_file_path:
+        return None
+    try:
+        return SodaCloud.from_config(soda_cloud_file_path, variables)
+    except Exception:
+        return None
+
+
 def resolve_data_source(data_source_file_path: Optional[str]) -> DataSourceImpl:
     """Parse a data source configuration file into a ``DataSourceImpl``.
 

--- a/soda-core/src/soda_core/contracts/api/verify_api.py
+++ b/soda-core/src/soda_core/contracts/api/verify_api.py
@@ -5,6 +5,7 @@ from soda_core.common._deprecation import deprecated_kwarg, warn_deprecated
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import InvalidArgumentException, SodaCloudException
 from soda_core.common.logging_constants import soda_logger
+from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import (
     ContractYamlSource,
@@ -263,6 +264,7 @@ def verify_contract(
     check_paths: Optional[list[str]] = None,
     dwh_data_source_file_path: Optional[Union[str, DiagnosticsWarehouseFiles]] = None,
     check_selectors: Optional[list[CheckSelector]] = None,
+    logs: Optional[Logs] = None,
     **kwargs,
 ) -> ContractVerificationSessionResult:
     use_runner = deprecated_kwarg(kwargs, "use_agent", "use_runner", use_runner)
@@ -290,61 +292,58 @@ def verify_contract(
     else:
         contract_file_paths = None
 
+    # Failures propagate raw, without touching Cloud: the CLI failure boundary
+    # (``run_with_failure_reporting``) owns the single mark-scan-failed, and a
+    # mark here would duplicate it (double backend scan-ended events).
+    # Programmatic callers get the exception and own the reporting decision.
     soda_cloud_client: Optional[SodaCloud] = None
-    try:
-        if soda_cloud_file_path:
-            soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path, variables)
+    if soda_cloud_file_path:
+        soda_cloud_client = SodaCloud.from_config(soda_cloud_file_path, variables)
 
-        # TODO: verify the path where connection is provided
-        validate_verify_arguments(
-            contract_file_paths,
-            dataset_identifiers,
-            data_source_file_paths,
-            data_sources,
-            publish,
-            use_runner,
-            soda_cloud_client,
-        )
+    # TODO: verify the path where connection is provided
+    validate_verify_arguments(
+        contract_file_paths,
+        dataset_identifiers,
+        data_source_file_paths,
+        data_sources,
+        publish,
+        use_runner,
+        soda_cloud_client,
+    )
 
-        contract_yaml_sources = _create_contract_yamls(contract_file_paths, dataset_identifiers, soda_cloud_client)
+    contract_yaml_sources = _create_contract_yamls(contract_file_paths, dataset_identifiers, soda_cloud_client)
 
-        if len(contract_yaml_sources) == 0:
-            soda_logger.debug("No contracts given. Exiting.")
-            return ContractVerificationSessionResult(contract_verification_results=[])
+    if len(contract_yaml_sources) == 0:
+        soda_logger.debug("No contracts given. Exiting.")
+        return ContractVerificationSessionResult(contract_verification_results=[])
 
-        data_source_yaml_sources: list[DataSourceYamlSource] = []
-        if data_source_file_paths:
-            data_source_yaml_sources.extend(
-                build_data_source_yaml_sources(data_source_file_paths, use_runner=use_runner)
-            )
+    data_source_yaml_sources: list[DataSourceYamlSource] = []
+    if data_source_file_paths:
+        data_source_yaml_sources.extend(build_data_source_yaml_sources(data_source_file_paths, use_runner=use_runner))
 
-        contract_verification_result = ContractVerificationSession.execute(
-            contract_yaml_sources=contract_yaml_sources,
-            data_source_yaml_sources=data_source_yaml_sources,
-            data_source_impls=data_sources,
-            soda_cloud_impl=soda_cloud_client,
-            variables=variables,
-            data_timestamp=data_timestamp,
-            only_validate_without_execute=False,
-            soda_cloud_publish_results=publish,
-            soda_cloud_use_runner=use_runner,
-            soda_cloud_verbose=verbose,
-            soda_cloud_use_runner_blocking_timeout_in_minutes=blocking_timeout_in_minutes,
-            check_paths=check_paths,
-            check_selectors=check_selectors,
-            dwh_data_source_file_path=dwh_data_source_file_path,
-        )
+    contract_verification_result = ContractVerificationSession.execute(
+        contract_yaml_sources=contract_yaml_sources,
+        data_source_yaml_sources=data_source_yaml_sources,
+        data_source_impls=data_sources,
+        soda_cloud_impl=soda_cloud_client,
+        variables=variables,
+        data_timestamp=data_timestamp,
+        only_validate_without_execute=False,
+        soda_cloud_publish_results=publish,
+        soda_cloud_use_runner=use_runner,
+        soda_cloud_verbose=verbose,
+        soda_cloud_use_runner_blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+        check_paths=check_paths,
+        check_selectors=check_selectors,
+        dwh_data_source_file_path=dwh_data_source_file_path,
+        logs=logs,
+    )
 
-        soda_telemetry.ingest_contract_verification_session_result(
-            contract_verification_session_result=contract_verification_result
-        )
+    soda_telemetry.ingest_contract_verification_session_result(
+        contract_verification_session_result=contract_verification_result
+    )
 
-        return contract_verification_result
-    except Exception as exc:
-        soda_logger.error(exc)
-        if soda_cloud_client:
-            soda_cloud_client.mark_scan_as_failed(exc=exc)
-        raise exc
+    return contract_verification_result
 
 
 def validate_verify_arguments(

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union
 
 from soda_core import is_verbose
 from soda_core.common.logging_constants import Emoticons, soda_logger
-from soda_core.common.logs import Location
+from soda_core.common.logs import Location, Logs
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
 from soda_core.contracts.contract_interfaces import Loggable
 from soda_core.contracts.impl.diagnostics_warehouse_files import (
@@ -52,6 +52,7 @@ class ContractVerificationSession:
         check_paths: Optional[list[str]] = None,
         dwh_data_source_file_path: Optional[Union[str, DiagnosticsWarehouseFiles]] = None,
         check_selectors: Optional[list["CheckSelector"]] = None,
+        logs: Optional["Logs"] = None,
         **kwargs,
     ) -> ContractVerificationSessionResult:
         from soda_core.common._deprecation import deprecated_kwarg
@@ -99,6 +100,7 @@ class ContractVerificationSession:
             soda_cloud_use_runner_blocking_timeout_in_minutes=soda_cloud_use_runner_blocking_timeout_in_minutes,
             check_selectors=merged_selectors,
             dwh_files=dwh_files,
+            logs=logs,
         )
 
 

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -194,6 +194,7 @@ class ContractVerificationSessionImpl:
         soda_cloud_use_runner_blocking_timeout_in_minutes: Optional[int] = None,
         check_selectors: Optional[list[CheckSelector]] = None,
         dwh_files: Optional[DiagnosticsWarehouseFiles] = None,
+        logs: Optional[Logs] = None,
         **kwargs,
     ):
         # Backwards-compat: accept the legacy "agent" kwarg names. Optional[T] = None +
@@ -215,7 +216,10 @@ class ContractVerificationSessionImpl:
         if soda_cloud_use_runner_blocking_timeout_in_minutes is None:
             soda_cloud_use_runner_blocking_timeout_in_minutes = 60
 
-        logs: Logs = Logs()
+        # A caller-supplied collector (the CLI failure-reporting wrapper's) is reused so
+        # every session record reaches its failure report; constructing an inner Logs
+        # here would displace the caller's active collector.
+        logs: Logs = logs if logs is not None else Logs()
 
         # Validate input contract_yaml_sources
         assert isinstance(contract_yaml_sources, list)

--- a/soda-tests/tests/unit/test_cli.py
+++ b/soda-tests/tests/unit/test_cli.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from soda_core.cli.cli import create_cli_parser, execute
@@ -208,7 +208,9 @@ def test_cli_argument_mapping_for_contract_verify_command(mock_handler, args, ex
 
     assert e.value.code == 0
 
-    mock_handler.assert_called_once_with(*expected)
+    # The verify wiring wraps the handler in run_with_failure_reporting and threads
+    # the wrapper's Logs collector; the argument mapping under test is positional.
+    mock_handler.assert_called_once_with(*expected, logs=ANY)
 
 
 def test_verify_command_raises_exception_when_none_of_contract_or_dataset_specified():

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -154,6 +154,19 @@ def test_handle_verify_contract_early_failure_marks_scan_failed_exactly_once_wit
     assert kwargs.get("logs"), "the single mark must carry the captured log records"
 
 
+@patch("soda_core.common.soda_cloud.SodaCloud.from_config")
+def test_handle_verify_contract_broken_cloud_config_managed_exits_results_not_sent(mock_from_config, monkeypatch):
+    """A managed run whose Cloud config can't even build a client has no reporting
+    channel at all (resolve_soda_cloud_for_failure_report swallows to None): nothing
+    can reach Cloud, so exit RESULTS_NOT_SENT_TO_CLOUD (4) and the launcher's
+    fallback marks the scan failed. The real config error still surfaces through the
+    boundary because verify_contract re-raises it building its own client."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    mock_from_config.side_effect = Exception("broken cloud config")
+
+    assert _run_handle_verify_contract() == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
 @patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
 @patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
 def test_handle_verify_contract_use_agent_kwarg_deprecated(mock_execute, mock_cloud_client):

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -7,6 +7,10 @@ from soda_core.cli.handlers.contract import (
     handle_test_contract,
     handle_verify_contract,
 )
+from soda_core.cli.handlers.dependencies import (
+    resolve_soda_cloud_for_failure_report,
+    run_with_failure_reporting,
+)
 from soda_core.common.logs import Logs
 from soda_core.contracts.contract_publication import (
     ContractPublication,
@@ -64,19 +68,26 @@ def test_handle_verify_contract_exit_codes(
 
 
 def _run_handle_verify_contract():
-    return handle_verify_contract(
-        contract_file_path="contract.yaml",
-        dataset_identifier=None,
-        data_source_file_paths=["ds.yaml"],
-        soda_cloud_file_path="sc.yaml",
-        variables={},
-        publish=True,
-        verbose=False,
-        use_runner=True,
-        blocking_timeout_in_minutes=10,
-        check_paths=None,
-        check_selectors=[],
-        diagnostics_warehouse_file_path=None,
+    # Mirrors the cli.py verify wiring: resolve the reporting channel first, then wrap
+    # the bare command in run_with_failure_reporting (the single Cloud-marking site).
+    soda_cloud = resolve_soda_cloud_for_failure_report("sc.yaml", {})
+    return run_with_failure_reporting(
+        soda_cloud,
+        lambda logs: handle_verify_contract(
+            contract_file_path="contract.yaml",
+            dataset_identifier=None,
+            data_source_file_paths=["ds.yaml"],
+            soda_cloud_file_path="sc.yaml",
+            variables={},
+            publish=True,
+            verbose=False,
+            use_runner=True,
+            blocking_timeout_in_minutes=10,
+            check_paths=None,
+            check_selectors=[],
+            diagnostics_warehouse_file_path=None,
+            logs=logs,
+        ),
     )
 
 

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -63,6 +63,65 @@ def test_handle_verify_contract_exit_codes(
     assert exit_code == expected_exit_code
 
 
+def _run_handle_verify_contract():
+    return handle_verify_contract(
+        contract_file_path="contract.yaml",
+        dataset_identifier=None,
+        data_source_file_paths=["ds.yaml"],
+        soda_cloud_file_path="sc.yaml",
+        variables={},
+        publish=True,
+        verbose=False,
+        use_runner=True,
+        blocking_timeout_in_minutes=10,
+        check_paths=None,
+        check_selectors=[],
+        diagnostics_warehouse_file_path=None,
+    )
+
+
+# Exception-path exit codes: the mocked mark_scan_as_failed return value is the Cloud delivery
+# signal that decides exit 3 vs 4. Patching SodaCloud.from_config at its source covers both the
+# handler's report client and verify_contract's own.
+@patch("soda_core.common.soda_cloud.SodaCloud.from_config")
+@patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
+def test_handle_verify_contract_early_failure_undelivered_exits_results_not_sent(
+    mock_execute, mock_from_config, monkeypatch
+):
+    """A managed scan whose early failure could NOT be reported to Cloud must exit
+    RESULTS_NOT_SENT_TO_CLOUD (4) so the launcher marks the scan failed itself,
+    instead of the old LOG_ERRORS (3) that made the job look succeeded."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    mock_execute.side_effect = Exception("parse error: invalid YAML")
+    mock_from_config.return_value.mark_scan_as_failed.return_value = False
+
+    assert _run_handle_verify_contract() == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+@patch("soda_core.common.soda_cloud.SodaCloud.from_config")
+@patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
+def test_handle_verify_contract_early_failure_delivered_exits_log_errors(mock_execute, mock_from_config, monkeypatch):
+    """A managed scan whose early failure WAS reported to Cloud stays LOG_ERRORS (3):
+    Cloud already shows the failure with logs, so the job legitimately completed."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    mock_execute.side_effect = Exception("parse error: invalid YAML")
+    mock_from_config.return_value.mark_scan_as_failed.return_value = True
+
+    assert _run_handle_verify_contract() == ExitCode.LOG_ERRORS
+
+
+@patch("soda_core.common.soda_cloud.SodaCloud.from_config")
+@patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
+def test_handle_verify_contract_early_failure_adhoc_exits_log_errors(mock_execute, mock_from_config, monkeypatch):
+    """An ad-hoc run (no SODA_SCAN_ID) has no Cloud scan to update, so an early
+    failure exits LOG_ERRORS (3) regardless of Cloud delivery."""
+    monkeypatch.delenv("SODA_SCAN_ID", raising=False)
+    mock_execute.side_effect = Exception("parse error: invalid YAML")
+    mock_from_config.return_value.mark_scan_as_failed.return_value = False
+
+    assert _run_handle_verify_contract() == ExitCode.LOG_ERRORS
+
+
 @patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
 @patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
 def test_handle_verify_contract_use_agent_kwarg_deprecated(mock_execute, mock_cloud_client):

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -122,6 +122,27 @@ def test_handle_verify_contract_early_failure_adhoc_exits_log_errors(mock_execut
     assert _run_handle_verify_contract() == ExitCode.LOG_ERRORS
 
 
+@patch("soda_core.common.soda_cloud.SodaCloud.from_config")
+@patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
+def test_handle_verify_contract_early_failure_marks_scan_failed_exactly_once_with_logs(
+    mock_execute, mock_from_config, monkeypatch
+):
+    """The CLI failure boundary is the single Cloud-marking site for escaped exceptions.
+    A second sodaCoreMarkScanFailed (historically sent from the session's pre-reraise
+    hook and verify_contract's except arm) re-dispatches the backend's scan-ended
+    events — duplicate failed-scan notifications — and re-promotes the scan logs."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    mock_execute.side_effect = Exception("parse error: invalid YAML")
+    mock_cloud = mock_from_config.return_value
+    mock_cloud.mark_scan_as_failed.return_value = True
+
+    assert _run_handle_verify_contract() == ExitCode.LOG_ERRORS
+
+    assert mock_cloud.mark_scan_as_failed.call_count == 1
+    _, kwargs = mock_cloud.mark_scan_as_failed.call_args
+    assert kwargs.get("logs"), "the single mark must carry the captured log records"
+
+
 @patch("soda_core.contracts.api.verify_api.SodaCloud.from_config")
 @patch("soda_core.contracts.api.verify_api.ContractVerificationSession.execute")
 def test_handle_verify_contract_use_agent_kwarg_deprecated(mock_execute, mock_cloud_client):

--- a/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
+++ b/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
@@ -288,7 +288,7 @@ def test_uncaught_exception_during_construction_reraises_without_marking_scan_fa
     )
 
 
-def _handle_verify_contract_with_files(tmp_path, mock_cloud: MockSodaCloud) -> ExitCode:
+def _handle_verify_contract_with_files(tmp_path, mock_cloud: MockSodaCloud, data_source_yaml: str = None) -> ExitCode:
     """Run the real CLI flow end-to-end (real session, real duckdb data source),
     with ``SodaCloud.from_config`` pinned to the given mock. Mirrors the cli.py
     verify wiring: channel resolution first, then the bare command wrapped in
@@ -296,7 +296,7 @@ def _handle_verify_contract_with_files(tmp_path, mock_cloud: MockSodaCloud) -> E
     contract_path = tmp_path / "contract.yaml"
     contract_path.write_text(_CONTRACT_YAML)
     data_source_path = tmp_path / "ds.yaml"
-    data_source_path.write_text(_DATA_SOURCE_YAML)
+    data_source_path.write_text(data_source_yaml if data_source_yaml is not None else _DATA_SOURCE_YAML)
 
     with patch("soda_core.common.soda_cloud.SodaCloud.from_config", return_value=mock_cloud):
         soda_cloud = resolve_soda_cloud_for_failure_report("sc.yaml", {})
@@ -369,3 +369,58 @@ def test_cli_boundary_rejected_mark_exits_results_not_sent(monkeypatch, tmp_path
 
     assert exit_code == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
     assert len(_mark_requests(mock_cloud)) == 1
+
+
+def test_cli_boundary_construction_abort_marks_scan_failed_exactly_once_with_engine_logs(monkeypatch, tmp_path):
+    """The construction-phase counterpart of the verify-abort E2E above: a phase-1
+    construction exception escapes the session unmarked and reaches Cloud as exactly
+    ONE boundary mark carrying the captured engine logs."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+
+    def _boom_init(self, *args, **kwargs):
+        soda_logger.error("Boom: could not construct contract")
+        raise RuntimeError("construction exploded")
+
+    monkeypatch.setattr(ContractImpl, "__init__", _boom_init)
+
+    mock_cloud = MockSodaCloud()
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    exit_code = _handle_verify_contract_with_files(tmp_path, mock_cloud)
+
+    assert exit_code == ExitCode.LOG_ERRORS
+    mark_requests = _mark_requests(mock_cloud)
+    assert len(mark_requests) == 1
+    assert mark_requests[0].get("scanId") == "scan-under-test"
+    assert "Boom: could not construct contract" in str(mark_requests[0].get("logs"))
+
+
+def test_cli_boundary_success_path_uploads_results_without_marking(monkeypatch, tmp_path):
+    """The normal path through the boundary: a managed run that verifies cleanly
+    uploads its results and never touches mark-scan-failed — exercising the shared
+    Logs collector (wrapper -> session) on the success path."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+
+    import duckdb
+
+    db_path = tmp_path / "test.duckdb"
+    connection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE my_table (id VARCHAR)")
+    connection.execute("INSERT INTO my_table VALUES ('a')")
+    connection.close()
+
+    data_source_yaml = (
+        "type: duckdb\n" "name: test_ds\n" "connection:\n" f'    database: "{db_path}"\n' "    schema: main\n"
+    )
+
+    # The insert response must carry the shared scanId — a 200 without it is
+    # deliberately marked failed-to-send (exit 4).
+    mock_cloud = MockSodaCloud(responses=[MockResponse(status_code=200, json_object={"scanId": "scan-under-test"})])
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    exit_code = _handle_verify_contract_with_files(tmp_path, mock_cloud, data_source_yaml=data_source_yaml)
+
+    assert exit_code == ExitCode.OK
+    assert _mark_requests(mock_cloud) == []
+    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
+    assert "sodaCoreInsertScanResults" in request_types

--- a/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
+++ b/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
@@ -26,6 +26,10 @@ import pytest
 from helpers.mock_soda_cloud import MockResponse, MockSodaCloud
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.contract import handle_verify_contract
+from soda_core.cli.handlers.dependencies import (
+    resolve_soda_cloud_for_failure_report,
+    run_with_failure_reporting,
+)
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
@@ -285,27 +289,34 @@ def test_uncaught_exception_during_construction_reraises_without_marking_scan_fa
 
 
 def _handle_verify_contract_with_files(tmp_path, mock_cloud: MockSodaCloud) -> ExitCode:
-    """Run the real CLI handler end-to-end (real session, real duckdb data source),
-    with ``SodaCloud.from_config`` pinned to the given mock."""
+    """Run the real CLI flow end-to-end (real session, real duckdb data source),
+    with ``SodaCloud.from_config`` pinned to the given mock. Mirrors the cli.py
+    verify wiring: channel resolution first, then the bare command wrapped in
+    ``run_with_failure_reporting`` (the single Cloud-marking site)."""
     contract_path = tmp_path / "contract.yaml"
     contract_path.write_text(_CONTRACT_YAML)
     data_source_path = tmp_path / "ds.yaml"
     data_source_path.write_text(_DATA_SOURCE_YAML)
 
     with patch("soda_core.common.soda_cloud.SodaCloud.from_config", return_value=mock_cloud):
-        return handle_verify_contract(
-            contract_file_path=str(contract_path),
-            dataset_identifier=None,
-            data_source_file_paths=[str(data_source_path)],
-            soda_cloud_file_path="sc.yaml",
-            variables={},
-            publish=True,
-            verbose=False,
-            use_runner=False,
-            blocking_timeout_in_minutes=10,
-            check_paths=None,
-            check_selectors=[],
-            diagnostics_warehouse_file_path=None,
+        soda_cloud = resolve_soda_cloud_for_failure_report("sc.yaml", {})
+        return run_with_failure_reporting(
+            soda_cloud,
+            lambda logs: handle_verify_contract(
+                contract_file_path=str(contract_path),
+                dataset_identifier=None,
+                data_source_file_paths=[str(data_source_path)],
+                soda_cloud_file_path="sc.yaml",
+                variables={},
+                publish=True,
+                verbose=False,
+                use_runner=False,
+                blocking_timeout_in_minutes=10,
+                check_paths=None,
+                check_selectors=[],
+                diagnostics_warehouse_file_path=None,
+                logs=logs,
+            ),
         )
 
 

--- a/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
+++ b/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
@@ -8,12 +8,24 @@ A managed/agent scan is still in PENDING at this point, and the Cloud state mach
 forbids PENDING -> COMPLETED_WITH_ERRORS (only PENDING -> FAILED is allowed), so the
 result upload 400s with ``invalid_scan_state`` -> exit code 4. Reporting FAILED keeps
 the send valid.
+
+Cloud marking has exactly two sites, and they never overlap:
+- the send-results site substitutes a mark for the upload when the run *returned*
+  an errored result without check results (the tests above the SAS-13001 section);
+- the CLI failure boundary (``run_with_failure_reporting`` /
+  ``report_scan_execution_failure``) marks for exceptions that *escape* the run
+  (the SAS-13001 tests below). The engine layers underneath — the session's abort
+  re-raise and ``verify_contract`` — must NOT mark: a second
+  ``sodaCoreMarkScanFailed`` re-dispatches the backend's scan-ended events
+  (duplicate failed-scan notifications) and re-promotes the scan logs.
 """
 
 from unittest.mock import patch
 
 import pytest
 from helpers.mock_soda_cloud import MockResponse, MockSodaCloud
+from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.contract import handle_verify_contract
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
@@ -201,11 +213,20 @@ def test_combine_uploads_path_rejected_mark_surfaces_as_send_failure(monkeypatch
     assert result.sending_results_to_soda_cloud_failed is True
 
 
-def test_uncaught_exception_during_verify_marks_scan_failed_with_logs(monkeypatch):
+def _mark_requests(mock_cloud: MockSodaCloud) -> list[dict]:
+    return [
+        r.json
+        for r in mock_cloud.requests
+        if isinstance(r.json, dict) and r.json.get("type") == "sodaCoreMarkScanFailed"
+    ]
+
+
+def test_uncaught_exception_during_verify_reraises_without_marking_scan_failed(monkeypatch):
     """A single-contract (runner) scan that raises an *uncaught* exception during verify aborts
-    and re-raises before phase 3's combined upload runs. The engine must still report the runner
-    scan as FAILED with the captured logs, otherwise the Cloud scan record shows no logs and the
-    failure is undiagnosable (SAS-13001)."""
+    and re-raises verbatim. The session must NOT mark the scan failed on the way out: the CLI
+    failure boundary owns that mark, and a session-level mark would make it a duplicate
+    (double backend scan-ended events). See the CLI-boundary tests below for where the mark
+    (with the captured logs, SAS-13001) now happens."""
     monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
 
     def _boom(self, *args, **kwargs):
@@ -227,25 +248,15 @@ def test_uncaught_exception_during_verify_marks_scan_failed_with_logs(monkeypatc
             soda_cloud_publish_results=True,
         )
 
-    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
-    mark_requests = [
-        r.json
-        for r in mock_cloud.requests
-        if isinstance(r.json, dict) and r.json.get("type") == "sodaCoreMarkScanFailed"
-    ]
-    assert mark_requests, (
-        "A scan that raised an uncaught exception during verify must be marked FAILED so the "
-        f"failure is visible in Cloud. Requests seen: {request_types}"
+    assert not _mark_requests(mock_cloud), (
+        "An exception escaping the session must leave the Cloud scan untouched — the CLI "
+        "failure boundary owns the single mark-scan-failed."
     )
-    assert mark_requests[0].get("scanId") == "scan-under-test"
-    # The captured engine logs must be shipped, not an empty payload — that is the whole point.
-    assert mark_requests[0].get("logs"), "mark-scan-failed must carry the captured engine logs, not an empty payload"
 
 
-def test_uncaught_exception_during_construction_marks_scan_failed_with_logs(monkeypatch):
-    """The other abort pathway: an uncaught exception during contract *construction* (phase 1, before
-    verify) must likewise mark the runner scan FAILED with the captured logs before re-raising. Both
-    the construction and verify abort points call the same reporting helper (SAS-13001)."""
+def test_uncaught_exception_during_construction_reraises_without_marking_scan_failed(monkeypatch):
+    """The other abort pathway: an uncaught exception during contract *construction* (phase 1,
+    before verify) likewise re-raises without a session-level mark."""
     monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
 
     def _boom_init(self, *args, **kwargs):
@@ -267,15 +278,83 @@ def test_uncaught_exception_during_construction_marks_scan_failed_with_logs(monk
             soda_cloud_publish_results=True,
         )
 
-    request_types = [r.json.get("type") for r in mock_cloud.requests if isinstance(r.json, dict)]
-    mark_requests = [
-        r.json
-        for r in mock_cloud.requests
-        if isinstance(r.json, dict) and r.json.get("type") == "sodaCoreMarkScanFailed"
-    ]
-    assert mark_requests, (
-        "A scan that raised an uncaught exception during construction must be marked FAILED. "
-        f"Requests seen: {request_types}"
+    assert not _mark_requests(mock_cloud), (
+        "An exception escaping phase-1 construction must leave the Cloud scan untouched — the "
+        "CLI failure boundary owns the single mark-scan-failed."
+    )
+
+
+def _handle_verify_contract_with_files(tmp_path, mock_cloud: MockSodaCloud) -> ExitCode:
+    """Run the real CLI handler end-to-end (real session, real duckdb data source),
+    with ``SodaCloud.from_config`` pinned to the given mock."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_CONTRACT_YAML)
+    data_source_path = tmp_path / "ds.yaml"
+    data_source_path.write_text(_DATA_SOURCE_YAML)
+
+    with patch("soda_core.common.soda_cloud.SodaCloud.from_config", return_value=mock_cloud):
+        return handle_verify_contract(
+            contract_file_path=str(contract_path),
+            dataset_identifier=None,
+            data_source_file_paths=[str(data_source_path)],
+            soda_cloud_file_path="sc.yaml",
+            variables={},
+            publish=True,
+            verbose=False,
+            use_runner=False,
+            blocking_timeout_in_minutes=10,
+            check_paths=None,
+            check_selectors=[],
+            diagnostics_warehouse_file_path=None,
+        )
+
+
+def test_cli_boundary_marks_scan_failed_exactly_once_with_engine_logs(monkeypatch, tmp_path):
+    """SAS-13001, relocated: an uncaught verify exception reaches Cloud as exactly ONE
+    mark-scan-failed — sent by the CLI failure boundary — carrying the captured engine logs.
+    Exit code 3: the failure is visible in Cloud, the run is delivered."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+
+    def _boom(self, *args, **kwargs):
+        soda_logger.error("Boom: could not build check collection")
+        raise RuntimeError("verify exploded")
+
+    monkeypatch.setattr(ContractImpl, "verify", _boom)
+
+    mock_cloud = MockSodaCloud()
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    exit_code = _handle_verify_contract_with_files(tmp_path, mock_cloud)
+
+    assert exit_code == ExitCode.LOG_ERRORS
+    mark_requests = _mark_requests(mock_cloud)
+    assert len(mark_requests) == 1, (
+        f"Exactly one mark-scan-failed must reach Cloud; got {len(mark_requests)}. "
+        "A duplicate re-dispatches the backend's scan-ended events (duplicate notifications)."
     )
     assert mark_requests[0].get("scanId") == "scan-under-test"
-    assert mark_requests[0].get("logs"), "mark-scan-failed must carry the captured engine logs, not an empty payload"
+    # The captured engine logs must be shipped, not an empty payload — that is the whole point.
+    payload = str(mark_requests[0].get("logs"))
+    assert (
+        "Boom: could not build check collection" in payload
+    ), "mark-scan-failed must carry the captured engine logs, not an empty payload"
+
+
+def test_cli_boundary_rejected_mark_exits_results_not_sent(monkeypatch, tmp_path):
+    """When Cloud rejects the boundary's single mark, nothing reached Cloud: exit
+    RESULTS_NOT_SENT_TO_CLOUD (4) so the launcher's fallback marks the scan failed itself."""
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-under-test")
+
+    def _boom(self, *args, **kwargs):
+        raise RuntimeError("verify exploded")
+
+    monkeypatch.setattr(ContractImpl, "verify", _boom)
+
+    # The only HTTP request in this flow is the boundary's mark command; make it fail.
+    mock_cloud = MockSodaCloud(responses=[MockResponse(status_code=500, json_object={})])
+    mock_cloud._upload_contract_yaml_file = lambda *args, **kwargs: "contract-file-id"
+
+    exit_code = _handle_verify_contract_with_files(tmp_path, mock_cloud)
+
+    assert exit_code == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+    assert len(_mark_requests(mock_cloud)) == 1


### PR DESCRIPTION
## Problem

Two related defects in how early scan failures (before any results exist) reach Soda Cloud:

**1. Silent success on undelivered failures.** The exit code is a delivery signal the launcher relies on:

| exit | meaning | launcher action |
|---|---|---|
| `LOG_ERRORS` (3) | the engine already marked the scan FAILED on Cloud | trust it, container exits 0 |
| `RESULTS_NOT_SENT_TO_CLOUD` (4) | nothing reached Cloud | launcher marks the scan failed itself |

`handle_verify_contract` returned `LOG_ERRORS` (3) for **every** exception out of `verify_contract`, including failures whose Cloud report never landed — the launcher trusts exit ≤3, k8s marks the Job Succeeded, and a failed scan shows up as success with an empty Cloud record.

**2. Multiple `sodaCoreMarkScanFailed` per failure.** A failed managed scan marked the Cloud scan FAILED up to **three times**: the session's abort-on-first-error pre-reraise hook, `verify_contract`'s except arm, and the handler's failure report. Verified against the backend: the repeats are *accepted* (`markScanFailed` skips the scan-state check, and the instruction transition short-circuits on final states) — but each mark re-dispatches `FullScanEndedEvent` / `SodaCoreScanSuccessfulEvent` / `ManagedScanStateChangedEvent`, and `ManagedScanNotificationModule` sends failed-scan notifications per event **with no dedupe**, plus `promoteOngoingScanLogsToParquet` runs again per mark.

## Fix

Make the CLI failure boundary (`run_with_failure_reporting` → `report_scan_execution_failure`) the **only** Cloud-marking site for escaped exceptions:

- **`session.py`**: the abort-on-first-error paths re-raise verbatim; `_report_runner_scan_failed_before_reraise` is deleted.
- **`verify_api.py`**: `verify_contract`'s `except: mark + re-raise` arm is deleted. Failures propagate raw. This is invisible to programmatic callers: they run without a launcher-created scan (no `SODA_SCAN_ID`), where `mark_scan_as_failed` already returned without sending anything. One narrow exception: an out-of-tree caller that sets `SODA_SCAN_ID` itself (emulating a managed run outside the launcher) previously got a Cloud mark from this arm via the env fallback and now gets only the raised exception.
- **`contract.py` / `cli.py`**: `handle_verify_contract` is a bare command like `handle_monitor` (takes the wrapper's `Logs`, propagates failures raw); the `cli.py` verify wiring resolves the reporting channel (`resolve_soda_cloud_for_failure_report`, now in `dependencies.py`, swallow-to-None with a debug log) and wraps the command in `run_with_failure_reporting` — the same shape discover/monitor use. The reporter returns 3 when Cloud accepted the mark (or ad-hoc), 4 when it didn't so the launcher's fallback runs.
- **Logs threading**: `verify_contract` → `ContractVerificationSession.execute` → the session impl accept an optional `Logs` collector (the impl previously always constructed its own, displacing the wrapper's). The single mark therefore carries the **full engine log records** — fixing the earlier iteration's `log_records=None` report, which was the exact FAILED-with-no-logs Cloud record SAS-13001 is about.

Every managed scan enters through the CLI (the launcher builds `soda contract verify` / `soda monitor run` / `soda discover` command lines), so the boundary covers all of them. The invariant after this PR: **Cloud marking happens either at the send-results site as an upload substitution recorded on the result (which never raises), or at the CLI boundary for escaped exceptions — never both.**

## Tests

TDD'd — the new invariants were written first and failed for the right reasons (2 marks at handler level, 3 end-to-end):

- session abort paths (construction + verify) re-raise **without** any `sodaCoreMarkScanFailed`;
- end-to-end through the verify wiring shape (real session, duckdb): **exactly one** mark carrying the engine logs + exit 3, for **both** the verify abort and the phase-1 construction abort; rejected mark → exit 4 (SAS-13001 regression tests, relocated from session-level to boundary-level);
- success-path E2E: a clean managed run uploads results and never touches mark-scan-failed (exercises the shared wrapper→session `Logs` collector on the normal path);
- exception-path exit codes: managed + undelivered (rejected mark) → 4, managed + no channel (broken Cloud config) → 4, managed + delivered → 3, ad-hoc → 3.

Full suites green: unit 1178, feature 13, integration 165 (+ skips).

## Related

- Motivated by review on sodadata/soda-extensions#543 (monitor's `abort_on_first_error=True` double-marks until this ships): once the soda-core floor bumps, monitor single-marks with no soda-extensions change.
- Launcher follow-up (from review): the launcher's exit-4 mark-failed fallback is wired for discover/profile/monitor and batched scans but not for `verify` — verify's undelivered failures are now visible (non-zero exit) but rely on the orchestrator marking on non-zero exit until the launcher wires the >3 fallback for verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)