### PR TITLE
build(athena): loosen PyAthena to >=2.2.0,<4.0 (remove <3.0 cap, CVE-2026-65321)

### DIFF
--- a/soda-athena/pyproject.toml
+++ b/soda-athena/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "soda-core==4.19.1rc0",
-    "PyAthena>=3.35.4,<4.0",
+    "PyAthena>=2.2.0,<4.0",
     "setuptools>=60",
 ]
 

--- a/soda-athena/pyproject.toml
+++ b/soda-athena/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "soda-core==4.19.1rc0",
-    "PyAthena>=2.2.0,<3.0",
+    "PyAthena>=3.35.4,<4.0",
     "setuptools>=60",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1538,17 +1538,18 @@ wheels = [
 
 [[package]]
 name = "pyathena"
-version = "2.25.2"
+version = "3.35.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "fsspec" },
+    { name = "python-dateutil" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/5c/9ffcae3db22541446ab117eb36d8f539f80cf985294ebf96fe7ed7613182/pyathena-2.25.2.tar.gz", hash = "sha256:aebb8254dd7b2a450841ee3552bf443002a2deaed93fae0ae6f4258b5eb2d367", size = 63531, upload-time = "2023-04-23T05:51:50.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/30/9f4fd9cfd3e0bad8fcdb98a2e27b53bd6e09ff9fab59429d34f4034f807f/pyathena-3.35.4.tar.gz", hash = "sha256:583007b566d1346a4d2486faab0e22858f1942c46064ab71b8e7e93146e2c53d", size = 151680, upload-time = "2026-07-31T12:39:53.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/1a/236386089a297a627ebed13216c9d010ede35b6f809c22569b393fdbcaf4/pyathena-2.25.2-py3-none-any.whl", hash = "sha256:df7855fec5cc675511431d7c72b814346ebd7e51ed32181ec95847154f79210b", size = 68067, upload-time = "2023-04-23T05:51:47.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/73/9ad1a97c6fb96d296b9f8c2a43da9cbae1698c02a422a63355d48489c80a/pyathena-3.35.4-py3-none-any.whl", hash = "sha256:8c5798f33878ce406bdbc0d1c8cd06d9d15181cb10e7e50f6a527f2e2b17a23c", size = 211273, upload-time = "2026-07-31T12:39:51.381Z" },
 ]
 
 [[package]]
@@ -2170,7 +2171,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pyathena", specifier = ">=2.2.0,<3.0" },
+    { name = "pyathena", specifier = ">=3.35.4,<4.0" },
     { name = "setuptools", specifier = ">=60" },
     { name = "soda-core", editable = "soda-core" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pyathena", specifier = ">=3.35.4,<4.0" },
+    { name = "pyathena", specifier = ">=2.2.0,<4.0" },
     { name = "setuptools", specifier = ">=60" },
     { name = "soda-core", editable = "soda-core" },
 ]


### PR DESCRIPTION
## What
Loosen the `soda-athena` PyAthena constraint from `>=2.2.0,<3.0` to **`>=2.2.0,<4.0`** — i.e. remove the `<3.0` cap so PyAthena **3.x** (which contains the fix for **CVE-2026-65321**) can resolve, while keeping 2.x installable and guarding against a future 4.x major.

## Why this shape
Mirrors `soda-snowflake`'s uncapped `snowflake-connector-python>=3.0`: keep the library constraint thin, and let the **deployable launchers pin the fixed floor** (`pyathena>=3.35.4`, following the Snowflake bump precedent). This avoids forcing 3.x onto every downstream `soda-athena` consumer.

## Verification
Resolves to PyAthena **3.35.4** today (latest `<4.0`) — the exact version already validated against **real Athena** on this PR (v4: `[REPLAY=OFF]` matrix; v3: the `athena` job). Environment is unchanged, so that verification still holds.

## Security context
Soda is **not exploitable** by CVE-2026-65321 on any PyAthena version — it always builds fully-rendered SQL and calls single-arg `cursor.execute(sql)`, never passing a `parameters` dict, so the vulnerable `DefaultParameterFormatter` branch is unreachable. This change is dependency hygiene + unblocking the launcher floor-pin, not an exploit fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)