### PR TITLE
fix(cli): generate --check-filter help from SUPPORTED_FIELDS

### DIFF
--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -223,7 +223,10 @@ def _setup_contract_verify_command(contract_parsers) -> None:
         action="append",
         type=str,
         help="Filter checks by attributes. Format: key=value. "
-        "Supported keys: type, name, column, path, qualifier, attributes.<key>. "
+        # Generated from the parser's own field set so help, error message and
+        # docs cannot drift apart again.
+        f"Supported keys: {', '.join(sorted(CheckSelector.SUPPORTED_FIELDS))}, "
+        f"{CheckSelector.ATTRIBUTES_PREFIX}<key>. "
         "Multiple filters: AND across fields, OR within same field. "
         "Wildcards (* and ?) supported in values. "
         "For list attributes: key=value for member match, key=[a,b] for exact list match. "

--- a/soda-tests/tests/unit/test_cli.py
+++ b/soda-tests/tests/unit/test_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 from soda_core.cli.cli import create_cli_parser, execute
+from soda_core.contracts.impl.check_selector import CheckSelector
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.logs import Logs
 
@@ -489,3 +490,35 @@ def test_cli_v3_legacy_commands(legacy_command):
         execute()
 
     assert e.value.code == 3
+
+
+def test_check_filter_help_lists_every_supported_field():
+    """The -cf help text must name every field the selector actually accepts.
+
+    These drifted apart: help documented 6 of the 10 supported fields, so
+    relative_path, check_path, source, collection and standard all worked but
+    were undiscoverable. A filter naming a field a user believes unsupported
+    silently matches nothing, and a check selection that matches nothing still
+    exits 0.
+    """
+    verify_parser = (
+        create_cli_parser()
+        ._subparsers._group_actions[0]
+        .choices["contract"]
+        ._subparsers._group_actions[0]
+        .choices["verify"]
+    )
+    check_filter_action = next(
+        action
+        for action in verify_parser._actions
+        if "--check-filter" in action.option_strings
+    )
+
+    undocumented = sorted(
+        field
+        for field in CheckSelector.SUPPORTED_FIELDS
+        if field not in check_filter_action.help
+    )
+    assert not undocumented, (
+        f"--check-filter accepts {undocumented} but --help does not mention them"
+    )

--- a/soda-tests/tests/unit/test_cli.py
+++ b/soda-tests/tests/unit/test_cli.py
@@ -3,9 +3,9 @@ from unittest.mock import ANY, patch
 
 import pytest
 from soda_core.cli.cli import create_cli_parser, execute
-from soda_core.contracts.impl.check_selector import CheckSelector
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common.logs import Logs
+from soda_core.contracts.impl.check_selector import CheckSelector
 
 # from soda_core.cli.soda import CLI
 

--- a/soda-tests/tests/unit/test_cli.py
+++ b/soda-tests/tests/unit/test_cli.py
@@ -508,17 +508,7 @@ def test_check_filter_help_lists_every_supported_field():
         ._subparsers._group_actions[0]
         .choices["verify"]
     )
-    check_filter_action = next(
-        action
-        for action in verify_parser._actions
-        if "--check-filter" in action.option_strings
-    )
+    check_filter_action = next(action for action in verify_parser._actions if "--check-filter" in action.option_strings)
 
-    undocumented = sorted(
-        field
-        for field in CheckSelector.SUPPORTED_FIELDS
-        if field not in check_filter_action.help
-    )
-    assert not undocumented, (
-        f"--check-filter accepts {undocumented} but --help does not mention them"
-    )
+    undocumented = sorted(field for field in CheckSelector.SUPPORTED_FIELDS if field not in check_filter_action.help)
+    assert not undocumented, f"--check-filter accepts {undocumented} but --help does not mention them"


### PR DESCRIPTION
`-cf` help was hand-maintained and had drifted from `CheckSelector.SUPPORTED_FIELDS`.

| | fields |
|---|---|
| `--help` documented | `type, name, column, path, qualifier, attributes.<key>` |
| `SUPPORTED_FIELDS` accepts | the above **plus** `relative_path`, `check_path`, `source`, `collection`, `standard` |

So five working selectors were undiscoverable from the CLI. `source` is one a customer relies on today, and the docs give a third variant again — three lists, all disagreeing.

### Why this is more than a help string

A filter naming a field the user believes is unsupported matches nothing — and a check selection that matches nothing currently **runs zero checks and exits 0**. So the discovery surface for `-cf` is load-bearing for whether a CI gate gates anything. (The exit-0-on-empty-selection behaviour is a separate issue, tracked as ADO-148.)

### The change

Build the help string from the parser's own field set, so the two cannot drift again when a selector is added.

```python
f"Supported keys: {', '.join(sorted(CheckSelector.SUPPORTED_FIELDS))}, "
f"{CheckSelector.ATTRIBUTES_PREFIX}<key>. "
```

Renders as:

```
Supported keys: check_path, collection, column, name, path, qualifier,
relative_path, source, standard, type, attributes.<key>.
```

### Test

`test_check_filter_help_lists_every_supported_field` asserts every supported field appears in the help text. Verified it fails on the previous text, naming exactly the five that were missing:

```
E  assert not ['check_path', 'collection', 'relative_path', 'source', 'standard']
```

`soda-tests/tests/unit/test_cli.py` — 22 passed.

### Not covered here

The docs are the third disagreeing source and still need updating separately, and the accepted `source` values (the `TestSource` vocabulary) are documented nowhere.

Linear: ADO-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXB2EoUCNDuwoaLizbiPb5