### PR TITLE
fix(databricks): refuse to connect without credentials instead of hanging in interactive OAuth

### DIFF
--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -50,8 +50,7 @@ class DatabricksDataSourceConnection(DataSourceConnection):
             raise ValueError(
                 "Databricks connection has no credentials: 'access_token' is missing or empty and no OAuth "
                 "auth_type is configured. Refusing to connect, because the Databricks SQL connector would "
-                "otherwise start an interactive browser login that cannot complete in a non-interactive run. "
-                "If the token is provided through ${env.VAR}, make sure VAR is set where the verification runs."
+                "otherwise start an interactive browser login that cannot complete in a non-interactive run."
             )
         return sql.connect(
             user_agent_entry="Soda Core",

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -42,7 +42,17 @@ class DatabricksDataSourceConnection(DataSourceConnection):
                 **connection_kwargs,
             )
 
-        # Token (PAT) auth: access_token flows through connection_kwargs unchanged.
+        # Token (PAT) auth: access_token flows through connection_kwargs unchanged. Never hand
+        # the connector a credential-less connect(): with no credentials_provider and a falsy
+        # access_token it falls back to its interactive browser OAuth (U2M) flow, which opens a
+        # browser URL and blocks on localhost:8020 — an infinite hang in a headless run.
+        if not connection_kwargs.get("access_token"):
+            raise ValueError(
+                "Databricks connection has no credentials: 'access_token' is missing or empty and no OAuth "
+                "auth_type is configured. Refusing to connect, because the Databricks SQL connector would "
+                "otherwise start an interactive browser login that cannot complete in a non-interactive run. "
+                "If the token is provided through ${env.VAR}, make sure VAR is set where the verification runs."
+            )
         return sql.connect(
             user_agent_entry="Soda Core",
             **connection_kwargs,

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -38,7 +38,10 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
 
 class DatabricksTokenAuth(DatabricksSharedConnectionProperties):
-    access_token: SecretStr = Field(..., description="Personal access token")
+    # min_length: an empty token (e.g. an unresolved variable reference) must be rejected here —
+    # the connector treats a falsy access_token as "no auth" and falls back to an interactive
+    # browser login (see DatabricksDataSourceConnection._create_connection).
+    access_token: SecretStr = Field(..., min_length=1, description="Personal access token")
 
 
 class DatabricksOAuthM2M(DatabricksSharedConnectionProperties):

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -1,10 +1,16 @@
 from abc import ABC
-from typing import ClassVar, Dict, Optional
+from typing import Annotated, Any, ClassVar, Dict, Literal, Optional, Union
 
-from pydantic import Field, SecretStr
+from pydantic import Discriminator, Field, SecretStr, Tag
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
 )
+
+# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
+# are the cross-repo contract: they match soda-library#759 and the Cloud connection form.
+AUTH_TYPE_TOKEN = "personal-access-token"
+AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
+AUTH_TYPE_AZURE_SP = "azure-service-principal"
 
 
 class DatabricksConnectionProperties(DataSourceConnectionProperties, ABC):
@@ -26,6 +32,9 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
     def to_connection_kwargs(self) -> dict:
         connection_kwargs = super().to_connection_kwargs()
+        # The auth mode discriminator is ours, never a sql.connect kwarg (the connector has its
+        # own, differently-valued `auth_type` argument).
+        connection_kwargs.pop("auth_type", None)
         server_hostname: str = connection_kwargs["server_hostname"]
         # Check if the server_hostname starts with https:// or http:// and remove it
         prefixes = ["https://", "http://"]
@@ -38,6 +47,8 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
 
 class DatabricksTokenAuth(DatabricksSharedConnectionProperties):
+    # Backward compatibility: PAT is the mode when auth_type is omitted.
+    auth_type: Optional[Literal["personal-access-token"]] = Field(None, description="Auth mode discriminator")
     # min_length: an empty token (e.g. an unresolved variable reference) must be rejected here —
     # the connector treats a falsy access_token as "no auth" and falls back to an interactive
     # browser login (see DatabricksDataSourceConnection._create_connection).
@@ -53,6 +64,7 @@ class DatabricksOAuthM2M(DatabricksSharedConnectionProperties):
     plain ``sql.connect`` kwargs, hence the ``to_connection_kwargs`` override below.
     """
 
+    auth_type: Literal["databricks-oauth-m2m"] = Field(..., description="Auth mode discriminator")
     client_id: str = Field(..., description="Databricks OAuth service-principal client ID")
     client_secret: SecretStr = Field(..., description="Databricks OAuth service-principal client secret")
 
@@ -75,6 +87,7 @@ class DatabricksAzureServicePrincipal(DatabricksSharedConnectionProperties):
     fields; they must NOT be emitted as plain ``sql.connect`` kwargs.
     """
 
+    auth_type: Literal["azure-service-principal"] = Field(..., description="Auth mode discriminator")
     azure_client_id: str = Field(..., description="Entra ID (Azure AD) service-principal application/client ID")
     azure_client_secret: SecretStr = Field(..., description="Entra ID (Azure AD) service-principal client secret")
     azure_tenant_id: str = Field(..., description="Entra ID (Azure AD) directory/tenant ID")
@@ -86,3 +99,28 @@ class DatabricksAzureServicePrincipal(DatabricksSharedConnectionProperties):
         for field_name in self._credential_fields:
             connection_kwargs.pop(field_name, None)
         return connection_kwargs
+
+
+def _discriminate_auth_type(value: Any) -> Optional[str]:
+    """Pick the auth mode from the raw ``connection`` mapping (or an already-built model).
+
+    An omitted ``auth_type`` means PAT, the only mode that existed before the discriminator.
+    Returning an unknown tag makes pydantic report it against the expected tags.
+    """
+    if isinstance(value, dict):
+        auth_type = value.get("auth_type")
+    else:
+        auth_type = getattr(value, "auth_type", None)
+    return auth_type or AUTH_TYPE_TOKEN
+
+
+DatabricksConnection = Annotated[
+    Union[
+        Annotated[DatabricksTokenAuth, Tag(AUTH_TYPE_TOKEN)],
+        Annotated[DatabricksOAuthM2M, Tag(AUTH_TYPE_OAUTH_M2M)],
+        Annotated[DatabricksAzureServicePrincipal, Tag(AUTH_TYPE_AZURE_SP)],
+    ],
+    Discriminator(_discriminate_auth_type),
+]
+"""The ``connection`` block of a Databricks data source: one of the auth modes, selected by
+``auth_type`` (PAT when omitted). Validation errors are scoped to the selected mode only."""

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -48,27 +48,12 @@ class DatabricksDataSource(DataSourceBase, abc.ABC):
             if properties_class is None:
                 supported = ", ".join(sorted(_AUTH_TYPE_TO_PROPERTIES))
                 raise ValueError(f"Unknown Databricks auth_type '{auth_type}'. Supported: {supported}")
-            if properties_class is DatabricksTokenAuth:
-                cls._require_non_empty_access_token(value)
             return properties_class(**value)
 
         # Backward compatibility: no explicit auth_type → infer PAT from field presence.
         if "access_token" in value:
-            cls._require_non_empty_access_token(value)
             return DatabricksTokenAuth(**value)
         raise ValueError(
             "Could not infer Databricks connection type: provide 'auth_type' "
             f"(one of {', '.join(sorted(_AUTH_TYPE_TO_PROPERTIES))}) or 'access_token'."
         )
-
-    @staticmethod
-    def _require_non_empty_access_token(value: dict) -> None:
-        # An unresolved ${env.VAR} reference typically arrives as None or an empty string. An
-        # empty token must not reach the connector: with no credentials it falls back to an
-        # interactive browser login (see DatabricksDataSourceConnection._create_connection).
-        access_token = value.get("access_token")
-        if access_token is None or access_token == "":
-            raise ValueError(
-                "Databricks 'access_token' is missing or empty. If it is provided through ${env.VAR}, "
-                "make sure VAR is set where the contract verification runs."
-            )

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -1,59 +1,20 @@
 import abc
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_databricks.model.data_source.databricks_connection_properties import (
-    DatabricksAzureServicePrincipal,
-    DatabricksConnectionProperties,
-    DatabricksOAuthM2M,
-    DatabricksTokenAuth,
+from soda_databricks.model.data_source.databricks_connection_properties import (  # noqa: F401 — re-exported
+    AUTH_TYPE_AZURE_SP,
+    AUTH_TYPE_OAUTH_M2M,
+    AUTH_TYPE_TOKEN,
+    DatabricksConnection,
 )
-
-# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
-# are the cross-repo contract: they match soda-library#759 and the Cloud connection form.
-AUTH_TYPE_TOKEN = "personal-access-token"
-AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
-AUTH_TYPE_AZURE_SP = "azure-service-principal"
-
-_AUTH_TYPE_TO_PROPERTIES = {
-    AUTH_TYPE_TOKEN: DatabricksTokenAuth,
-    AUTH_TYPE_OAUTH_M2M: DatabricksOAuthM2M,
-    AUTH_TYPE_AZURE_SP: DatabricksAzureServicePrincipal,
-}
 
 
 class DatabricksDataSource(DataSourceBase, abc.ABC):
     type: Literal["databricks"] = Field("databricks")
-    connection_properties: DatabricksConnectionProperties = Field(
+    # Auth mode is picked by the `auth_type` discriminator on DatabricksConnection (PAT when
+    # omitted, for backward compatibility), so validation errors name the selected mode only.
+    connection_properties: DatabricksConnection = Field(
         ..., alias="connection", description="Databricks connection configuration"
     )
-
-    @field_validator("connection_properties", mode="before")
-    @classmethod
-    def infer_connection_type(cls, value):
-        # Already a resolved properties object (e.g. constructed in code) — pass through.
-        if isinstance(value, DatabricksConnectionProperties):
-            return value
-        if not isinstance(value, dict):
-            raise ValueError("Could not infer Databricks connection type from input")
-
-        # Copy so the discriminator can be stripped without mutating caller input; also
-        # prevents auth_type leaking into sql.connect kwargs (base model has extra='allow').
-        value = dict(value)
-        auth_type = value.pop("auth_type", None)
-
-        if auth_type is not None:
-            properties_class = _AUTH_TYPE_TO_PROPERTIES.get(auth_type)
-            if properties_class is None:
-                supported = ", ".join(sorted(_AUTH_TYPE_TO_PROPERTIES))
-                raise ValueError(f"Unknown Databricks auth_type '{auth_type}'. Supported: {supported}")
-            return properties_class(**value)
-
-        # Backward compatibility: no explicit auth_type → infer PAT from field presence.
-        if "access_token" in value:
-            return DatabricksTokenAuth(**value)
-        raise ValueError(
-            "Could not infer Databricks connection type: provide 'auth_type' "
-            f"(one of {', '.join(sorted(_AUTH_TYPE_TO_PROPERTIES))}) or 'access_token'."
-        )

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -48,12 +48,27 @@ class DatabricksDataSource(DataSourceBase, abc.ABC):
             if properties_class is None:
                 supported = ", ".join(sorted(_AUTH_TYPE_TO_PROPERTIES))
                 raise ValueError(f"Unknown Databricks auth_type '{auth_type}'. Supported: {supported}")
+            if properties_class is DatabricksTokenAuth:
+                cls._require_non_empty_access_token(value)
             return properties_class(**value)
 
         # Backward compatibility: no explicit auth_type → infer PAT from field presence.
         if "access_token" in value:
+            cls._require_non_empty_access_token(value)
             return DatabricksTokenAuth(**value)
         raise ValueError(
             "Could not infer Databricks connection type: provide 'auth_type' "
             f"(one of {', '.join(sorted(_AUTH_TYPE_TO_PROPERTIES))}) or 'access_token'."
         )
+
+    @staticmethod
+    def _require_non_empty_access_token(value: dict) -> None:
+        # An unresolved ${env.VAR} reference typically arrives as None or an empty string. An
+        # empty token must not reach the connector: with no credentials it falls back to an
+        # interactive browser login (see DatabricksDataSourceConnection._create_connection).
+        access_token = value.get("access_token")
+        if access_token is None or access_token == "":
+            raise ValueError(
+                "Databricks 'access_token' is missing or empty. If it is provided through ${env.VAR}, "
+                "make sure VAR is set where the contract verification runs."
+            )

--- a/soda-databricks/tests/data_sources/test_databricks.py
+++ b/soda-databricks/tests/data_sources/test_databricks.py
@@ -66,7 +66,7 @@ test_connections: list[TestConnection] = [
                     auth_type: not-a-real-mode
             """,
         valid_yaml=False,
-        expected_yaml_error="Unknown Databricks auth_type",
+        expected_yaml_error="does not match any of the expected tags: 'personal-access-token'",
     ),
     TestConnection(  # OAuth M2M without its required secret must be rejected at parse time
         test_name="oauth_m2m_missing_client_secret_rejected",

--- a/soda-databricks/tests/unit/test_databricks_empty_token.py
+++ b/soda-databricks/tests/unit/test_databricks_empty_token.py
@@ -1,0 +1,83 @@
+"""Unit tests: an empty or absent Databricks token must fail loudly and must never reach
+``databricks.sql.connect``.
+
+Background: ``databricks-sql-connector`` treats a falsy ``access_token`` (``""``/``None``) with
+no ``credentials_provider`` as "no auth configured" and falls back to its INTERACTIVE browser
+OAuth (U2M) flow — it opens a browser URL and blocks on ``localhost:8020`` waiting for the
+callback. In a headless run (agent pod, CI) that is an infinite hang with no warehouse
+queries. Typical way to get there: ``access_token: ${env.DATABRICKS_TOKEN}`` with the env
+var unset (or set to an empty value) where the verification runs.
+
+No live database; ``databricks.sql.connect`` is mocked.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+from soda_databricks.common.data_sources import (
+    databricks_data_source_connection as conn_mod,
+)
+from soda_databricks.common.data_sources.databricks_data_source_connection import (
+    DatabricksDataSourceConnection,
+)
+from soda_databricks.model.data_source.databricks_connection_properties import (
+    DatabricksTokenAuth,
+)
+from soda_databricks.model.data_source.databricks_data_source import (
+    DatabricksDataSource,
+)
+
+infer = DatabricksDataSource.infer_connection_type
+
+BASE = {"host": "abc.cloud.databricks.com", "http_path": "/sql/1.0/endpoints/abc"}
+
+
+def _make_connection() -> DatabricksDataSourceConnection:
+    return DatabricksDataSourceConnection.__new__(DatabricksDataSourceConnection)
+
+
+# --------------------------------------------------------------------------- model / dispatch
+
+
+@pytest.mark.parametrize("token", ["", None])
+def test_empty_access_token_rejected_at_parse_time(token):
+    """``access_token`` present but empty (e.g. an unresolved ``${env.X}``) must be a clear
+    error, not a model with an empty secret."""
+    with pytest.raises(ValueError, match="access_token"):
+        infer({**BASE, "access_token": token})
+
+
+@pytest.mark.parametrize("token", ["", None])
+def test_empty_access_token_with_explicit_auth_type_rejected(token):
+    with pytest.raises(ValueError, match="access_token"):
+        infer({**BASE, "auth_type": "personal-access-token", "access_token": token})
+
+
+# ------------------------------------------------------------------------ connection guard
+
+
+def test_connection_refuses_to_connect_with_empty_token():
+    """Last line of defence: never call sql.connect() without a credentials_provider or a
+    non-empty access_token — the connector's fallback is an interactive browser login."""
+    props = DatabricksTokenAuth.model_construct(**BASE, access_token=SecretStr(""))
+    with patch.object(conn_mod.sql, "connect") as mock_connect:
+        with pytest.raises(ValueError, match="interactive"):
+            _make_connection()._create_connection(props)
+    mock_connect.assert_not_called()
+
+
+def test_connection_refuses_to_connect_with_missing_token():
+    props = DatabricksTokenAuth.model_construct(**BASE, access_token=None)
+    with patch.object(conn_mod.sql, "connect") as mock_connect:
+        with pytest.raises(ValueError, match="interactive"):
+            _make_connection()._create_connection(props)
+    mock_connect.assert_not_called()
+
+
+def test_connection_still_connects_with_token():
+    props = infer({**BASE, "access_token": "dapi123"})
+    with patch.object(conn_mod.sql, "connect") as mock_connect:
+        _make_connection()._create_connection(props)
+    assert mock_connect.call_args.kwargs["access_token"] == "dapi123"
+    assert "credentials_provider" not in mock_connect.call_args.kwargs

--- a/soda-databricks/tests/unit/test_databricks_empty_token.py
+++ b/soda-databricks/tests/unit/test_databricks_empty_token.py
@@ -42,8 +42,8 @@ def _make_connection() -> DatabricksDataSourceConnection:
 
 @pytest.mark.parametrize("token", ["", None])
 def test_empty_access_token_rejected_at_parse_time(token):
-    """``access_token`` present but empty (e.g. an unresolved ``${env.X}``) must be a clear
-    error, not a model with an empty secret."""
+    """``access_token`` present but empty (e.g. an unresolved variable reference) is rejected
+    by the model (``min_length=1``), not accepted as an empty secret."""
     with pytest.raises(ValueError, match="access_token"):
         infer({**BASE, "access_token": token})
 

--- a/soda-databricks/tests/unit/test_databricks_empty_token.py
+++ b/soda-databricks/tests/unit/test_databricks_empty_token.py
@@ -28,7 +28,12 @@ from soda_databricks.model.data_source.databricks_data_source import (
     DatabricksDataSource,
 )
 
-infer = DatabricksDataSource.infer_connection_type
+
+def infer(connection: dict):
+    """Validate a raw ``connection`` block the way a data source YAML does and return the
+    selected auth-mode model."""
+    return DatabricksDataSource(name="test", type="databricks", connection=connection).connection_properties
+
 
 BASE = {"host": "abc.cloud.databricks.com", "http_path": "/sql/1.0/endpoints/abc"}
 

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -22,7 +22,11 @@ from soda_databricks.model.data_source.databricks_data_source import (
     DatabricksDataSource,
 )
 
-infer = DatabricksDataSource.infer_connection_type
+
+def infer(connection: dict):
+    """Validate a raw ``connection`` block the way a data source YAML does and return the
+    selected auth-mode model."""
+    return DatabricksDataSource(name="test", type="databricks", connection=connection).connection_properties
 
 
 # --------------------------------------------------------------------------- dispatch
@@ -80,12 +84,14 @@ def test_azure_service_principal_dispatch():
 
 
 def test_unknown_auth_type_raises():
-    with pytest.raises(ValueError, match="Unknown Databricks auth_type"):
+    """An unknown auth_type is reported against the list of expected tags, as a single error."""
+    with pytest.raises(ValueError, match="'nope'.*expected tags.*personal-access-token.*databricks-oauth-m2m"):
         infer({"auth_type": "nope", "host": "h", "http_path": "/x"})
 
 
 def test_no_auth_type_no_access_token_raises():
-    with pytest.raises(ValueError, match="Could not infer"):
+    """No auth_type means PAT, so the missing token is reported for that mode only."""
+    with pytest.raises(ValueError, match="personal-access-token.access_token\n  Field required"):
         infer({"host": "h", "http_path": "/x"})
 
 
@@ -249,3 +255,21 @@ def test_m2m_connection_strips_host_scheme():
 
     assert mock_connect.call_args.kwargs["server_hostname"] == "abc.cloud.databricks.com"
     assert cfg.call_args.kwargs["host"] == "https://abc.cloud.databricks.com"
+
+
+def test_auth_type_discriminator_not_in_connection_kwargs():
+    """Our auth_type is a model discriminator, never a sql.connect kwarg (the connector has its
+    own, differently-valued `auth_type` argument that would select the browser OAuth flow)."""
+    for connection in (
+        {"auth_type": "personal-access-token", "host": "h", "http_path": "/x", "access_token": "t"},
+        {"auth_type": "databricks-oauth-m2m", "host": "h", "http_path": "/x", "client_id": "c", "client_secret": "s"},
+        {
+            "auth_type": "azure-service-principal",
+            "host": "h",
+            "http_path": "/x",
+            "azure_client_id": "a",
+            "azure_client_secret": "s",
+            "azure_tenant_id": "t",
+        },
+    ):
+        assert "auth_type" not in infer(connection).to_connection_kwargs()


### PR DESCRIPTION
## What

Databricks: refuse to connect when there are no credentials, instead of letting `databricks-sql-connector` fall back to its **interactive browser OAuth (U2M)** flow.

## Why

An empty `access_token` — typically `access_token: ${env.VAR}` with `VAR` unset or empty where the verification runs — reached `databricks.sql.connect(access_token="")`. The connector treats a falsy token as "no auth configured" and starts its U2M flow: it prints

```
Opening https://<workspace>/oidc/oauth2/v2.0/authorize?...client_id=databricks-sql-python&redirect_uri=http://localhost:8020...
Listening for OAuth authorization callback at http://localhost:8020
```

and blocks forever waiting for a browser callback — an infinite hang in any headless run (CI, agent).

Three parts:

1. `DatabricksTokenAuth.access_token` gets `min_length=1`: an empty token is rejected by the model at parse time (a missing/`None` one already was; an empty one produced a model with an empty secret).
2. `DatabricksDataSourceConnection._create_connection`: never calls `sql.connect()` without a `credentials_provider` or a non-empty `access_token`. This is the guard that ends the hang class regardless of how the token went missing.
3. (review follow-up, @mivds) the `connection` block is now a pydantic discriminated union keyed on `auth_type`, and the hand-written `infer_connection_type` validator plus its dispatch table are gone:

```python
DatabricksConnection = Annotated[
    Union[
        Annotated[DatabricksTokenAuth, Tag("personal-access-token")],
        Annotated[DatabricksOAuthM2M, Tag("databricks-oauth-m2m")],
        Annotated[DatabricksAzureServicePrincipal, Tag("azure-service-principal")],
    ],
    Discriminator(_discriminate_auth_type),   # omitted auth_type -> PAT (backward compatible)
]
```

   `DatabricksTokenAuth.auth_type` is `Optional[Literal["personal-access-token"]] = None`, the OAuth members require their Literal. A *callable* discriminator (rather than `Field(discriminator="auth_type")`, which needs a required Literal on every member, or a plain `Union`, which reports one bad input against all three members) keeps errors scoped to the selected mode:

```
connection.personal-access-token.access_token
  Field required                                      # no auth_type, no token
connection.personal-access-token.access_token
  Value should have at least 1 item ...               # empty token
connection.databricks-oauth-m2m.client_secret
  Field required
connection
  Input tag 'nope' ... does not match any of the expected tags: 'personal-access-token', 'databricks-oauth-m2m', 'azure-service-principal'
```

   `auth_type` is stripped in `DatabricksSharedConnectionProperties.to_connection_kwargs()` so the discriminator never reaches `sql.connect(**kwargs)` — the connector has its own, differently-valued `auth_type` argument (`databricks-oauth` selects the browser flow); regression test added. Same pattern as Trino's `connection_properties` union, plus the callable discriminator for the error scoping.

## Tests

`soda-databricks/tests/unit/` — 42 passing, no live database (`databricks.sql.connect` mocked): empty/None token rejected at parse time (with and without explicit `auth_type`), connection guard for empty/None, a control that a real token still connects, `auth_type` never in connect kwargs. In `test_databricks_oauth.py` the two message assertions for "unknown auth_type" / "no auth_type, no token" follow the pydantic wording and the `infer` helper validates through `DatabricksDataSource` like a YAML load does.

### 📣 Customer-facing release note

```customer-facing-release-note
Databricks contract verifications with a missing or empty access token now fail fast.
```
