### PR TITLE
fix(sparkdf): qualify SHOW TABLES with the catalog in HiveMetadataTablesQuery

### DIFF
--- a/soda-databricks/src/soda_databricks/common/statements/hive_metadata_tables_query.py
+++ b/soda-databricks/src/soda_databricks/common/statements/hive_metadata_tables_query.py
@@ -73,13 +73,16 @@ class HiveMetadataTablesQuery(MetadataTablesQuery):
         exclude_table_name_like_filters: Optional[list[str]] = None,
         object_type_to_fetch: TableType = TableType.TABLE,
     ) -> str:  # Return type for this function is a string, not a list (for the super method it is a list!)
-        schema_str = ""
+        from_str = ""
         if schema_name:
-            schema_str = f" FROM {self.sql_dialect.quote_default(schema_name)}"
+            # An unqualified schema resolves against the session's current catalog, which is not
+            # necessarily the catalog in the prefixes — sparkdf never issues USE CATALOG.
+            name_parts = [database_name, schema_name] if database_name else [schema_name]
+            from_str = " FROM " + ".".join(self.sql_dialect.quote_default(part) for part in name_parts)
         if object_type_to_fetch == TableType.TABLE:
-            return f"SHOW TABLES{schema_str}"
+            return f"SHOW TABLES{from_str}"
         elif object_type_to_fetch == TableType.VIEW:
-            return f"SHOW VIEWS{schema_str}"
+            return f"SHOW VIEWS{from_str}"
         else:
             raise ValueError(f"Invalid object type to fetch: {object_type_to_fetch}")
 

--- a/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
+++ b/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
@@ -66,8 +66,9 @@ def test_build_sql_statement(database_name, schema_name, object_type, expected_s
 
 
 def test_invalid_object_type_raises():
+    query = _query()
     with pytest.raises(ValueError, match="Invalid object type to fetch"):
-        _query().build_sql_statement(
+        query.build_sql_statement(
             database_name="my_uc_catalog",
             schema_name="soda_diagnostics",
             object_type_to_fetch=TableType.MATERIALIZED_VIEW,

--- a/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
+++ b/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
@@ -44,12 +44,17 @@ def _query() -> HiveMetadataTablesQuery:
             "SHOW TABLES FROM `soda_diagnostics`",
             id="no_catalog_stays_unqualified",
         ),
+        # KNOWN GAP, documented rather than endorsed: with no schema there is nothing to
+        # qualify, so the catalog is dropped too and Spark resolves against the session's
+        # current catalog AND schema. SHOW TABLES cannot express "every schema in this
+        # catalog" — that needs SHOW SCHEMAS + a loop, or information_schema. Reachable
+        # via `discover-data-source`, which passes prefixes=[] to discover everything.
         pytest.param(
             "my_uc_catalog",
             None,
             TableType.TABLE,
             "SHOW TABLES",
-            id="no_schema_emits_no_from",
+            id="no_schema_drops_catalog_too_known_gap",
         ),
     ],
 )

--- a/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
+++ b/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
@@ -1,0 +1,69 @@
+"""HiveMetadataTablesQuery SHOW TABLES/VIEWS catalog qualification.
+
+SHOW TABLES resolves an unqualified schema against the session's current catalog. The
+catalog in the prefixes is not necessarily that one, so it must be emitted when known —
+while callers with no catalog concept (sparkdf legacy mode, database_prefix_index=None)
+must keep the unqualified form.
+"""
+
+import pytest
+from soda_core.common.statements.table_types import TableType
+from soda_databricks.common.data_sources.databricks_data_source import (
+    DatabricksHiveSqlDialect,
+)
+from soda_databricks.common.statements.hive_metadata_tables_query import (
+    HiveMetadataTablesQuery,
+)
+
+
+def _query() -> HiveMetadataTablesQuery:
+    return HiveMetadataTablesQuery(sql_dialect=DatabricksHiveSqlDialect(), data_source_connection=None)
+
+
+@pytest.mark.parametrize(
+    "database_name, schema_name, object_type, expected_sql",
+    [
+        pytest.param(
+            "my_uc_catalog",
+            "soda_diagnostics",
+            TableType.TABLE,
+            "SHOW TABLES FROM `my_uc_catalog`.`soda_diagnostics`",
+            id="tables_qualified_with_catalog",
+        ),
+        pytest.param(
+            "my_uc_catalog",
+            "soda_diagnostics",
+            TableType.VIEW,
+            "SHOW VIEWS FROM `my_uc_catalog`.`soda_diagnostics`",
+            id="views_qualified_with_catalog",
+        ),
+        pytest.param(
+            None,
+            "soda_diagnostics",
+            TableType.TABLE,
+            "SHOW TABLES FROM `soda_diagnostics`",
+            id="no_catalog_stays_unqualified",
+        ),
+        pytest.param(
+            "my_uc_catalog",
+            None,
+            TableType.TABLE,
+            "SHOW TABLES",
+            id="no_schema_emits_no_from",
+        ),
+    ],
+)
+def test_build_sql_statement(database_name, schema_name, object_type, expected_sql):
+    sql = _query().build_sql_statement(
+        database_name=database_name, schema_name=schema_name, object_type_to_fetch=object_type
+    )
+    assert sql == expected_sql
+
+
+def test_invalid_object_type_raises():
+    with pytest.raises(ValueError, match="Invalid object type to fetch"):
+        _query().build_sql_statement(
+            database_name="my_uc_catalog",
+            schema_name="soda_diagnostics",
+            object_type_to_fetch=TableType.MATERIALIZED_VIEW,
+        )

--- a/soda-sparkdf/tests/unit/test_sparkdf_metadata_tables_query.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_metadata_tables_query.py
@@ -1,0 +1,33 @@
+"""SparkDataFrameMetadataTablesQuery inherits HiveMetadataTablesQuery.build_sql_statement.
+
+Unlike the Databricks SQL connector it is used unconditionally, so catalog mode must emit
+the catalog: nothing in sparkdf issues USE CATALOG, and the session's current_catalog() is
+typically hive_metastore even for Unity-Catalog-only users.
+"""
+
+from soda_core.common.statements.table_types import TableType
+from soda_sparkdf.common.data_sources.sparkdf_data_source import (
+    SparkDataFrameMetadataTablesQuery,
+    SparkDataFrameSqlDialect,
+)
+
+
+def _query(use_catalog: bool) -> SparkDataFrameMetadataTablesQuery:
+    return SparkDataFrameMetadataTablesQuery(
+        sql_dialect=SparkDataFrameSqlDialect(use_catalog=use_catalog), data_source_connection=None
+    )
+
+
+def test_catalog_mode_qualifies_show_tables_with_the_catalog():
+    sql = _query(use_catalog=True).build_sql_statement(
+        database_name="my_uc_catalog", schema_name="soda_diagnostics", object_type_to_fetch=TableType.TABLE
+    )
+    assert sql == "SHOW TABLES FROM `my_uc_catalog`.`soda_diagnostics`"
+
+
+def test_legacy_mode_has_no_catalog_and_stays_unqualified():
+    # get_database_prefix_index() is None in legacy mode, so database_name is always None.
+    sql = _query(use_catalog=False).build_sql_statement(
+        database_name=None, schema_name="soda_diagnostics", object_type_to_fetch=TableType.TABLE
+    )
+    assert sql == "SHOW TABLES FROM `soda_diagnostics`"


### PR DESCRIPTION
## Description

**What problem are you solving?**

`HiveMetadataTablesQuery.build_sql_statement` accepts `database_name` and never uses it, emitting
`SHOW TABLES FROM <schema>`. An unqualified schema resolves against the **session's current
catalog**, not the catalog carried in the prefixes.

For the Databricks SQL connector that is harmless: the class is gated behind `_is_hive_catalog()`,
so it only runs when the connection catalog really is `hive_metastore`, and that catalog is passed
to `sql.connect()` so the session default matches.

`SparkDataFrameMetadataTablesQuery` inherits the method and, unlike the connector, is returned
**unconditionally** — no gate. Nothing in sparkdf ever issues `USE CATALOG`, so in catalog mode a
DWH prefix `[catalog, soda_diagnostics]` loses its catalog and the lookup lands in whatever
`current_catalog()` happens to be — commonly `hive_metastore` on clusters with no workspace default
catalog, regardless of which catalog the data actually lives in.

Because DWH writes are already fully qualified (`qualify_dataset_name` →
`` `catalog`.`soda_diagnostics`.`fr_…` ``), the read and write paths disagree within a single run:

1. `SHOW TABLES FROM \`soda_diagnostics\`` misses — or throws `AnalysisException` when that schema
   does not exist in the session catalog, which sparkdf's `execute()` swallows into an empty result
2. `DwhMetadataCache.has_table()` reports False for a table that exists
3. `failed_rows_check_extension.py:654` takes the create branch → `CREATE TABLE … AS SELECT`, which
   has no `IF NOT EXISTS` (`sql_dialect.py:612`) → `TABLE_OR_VIEW_ALREADY_EXISTS`

Symptom: the first run is clean — nothing exists yet, the CTAS succeeds, and `mark_table_exists`
masks the bad lookup for the remainder of that run — and every subsequent run fails. The same lookup
also feeds `rows_diff_check_extension.py:125` and `create_view_from_table`, which silently skips view
creation.

Present since sparkdf catalog mode landed (#2723 / #2730 / #2740).

**The fix:** qualify the `FROM` with `database_name` when it is set, keeping the unqualified form
when it is not. The guard is load-bearing — sparkdf legacy mode has
`get_database_prefix_index() == None`, so `database_name` is always `None` there and must keep
emitting the bare schema.

**Why this wasn't caught:** every sparkdf DWH test runs on local Spark where `spark_catalog` is the
only catalog, so the session catalog always equals the target catalog. The Databricks workflow
exercises `DATABRICKS_CATALOG=hive_metastore` and UC separately, never mixed.

**Any expected impact on downstream packages/services?**

One behaviour change for existing users: the Databricks hive branch now emits
`` SHOW TABLES FROM `hive_metastore`.`schema` `` instead of `` SHOW TABLES FROM `schema` ``.
Semantically identical — the session catalog is already `hive_metastore` — but it is a new statement
shape against a real metastore, so **the hive CI lane is the gate for this PR**
(`.github/workflows/main.workflow.yaml:291-295`).

Deliberately **not** in scope:

- `get_results` still hardcodes `database_name="hive_metastore"` (`:105,111`). Correct everywhere it
  currently runs — sparkdf overrides `get_results` to emit `None` — and fixing it means a signature
  change plus DQN blast radius via `DatasetIdentifier` / `build_dwh_qualified_table_names`.
- The per-connection `_is_hive_catalog()` gate is wrong for **mixed hive+UC workspaces**: a
  `hive_metastore` connection reading UC dataset prefixes drops the catalog, and a UC connection
  reading `hive_metastore` prefixes queries a `hive_metastore.information_schema` that does not
  exist. Separate defect, tracked separately.
- sparkdf's blanket `except Exception: pass` in `execute()` is why this degraded silently rather than
  erroring. Changing it would convert previously-silent misses into new failures elsewhere.

## Checklist

- [x] I added a test to verify the new functionality.
- [ ] I verified this PR does not break [soda-extensions][1].

[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)

## Verification

- **The new tests fail without the fix** — ran them against the unfixed source: the 3
  catalog-qualification assertions fail, the 4 unchanged-behaviour guards pass.
- **No regressions** across all 13 unit suites: `1437 passed / 16 errors` before → `1444 passed /
  16 errors` after. Identical 16 pre-existing `data_source_test_helper_session` fixture errors
  (they need a live datasource); `+7` is exactly the new tests.
- `black --check` clean at line-length 120.
- **Not verified locally:** `SHOW TABLES FROM cat.schema` under Spark Connect / Databricks
  serverless. Worth a live check before undrafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
