### PR TITLE
refactor(databricks): discriminated union for the auth mode instead of a manual validator

### DIFF
--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -1,10 +1,16 @@
 from abc import ABC
-from typing import ClassVar, Dict, Optional
+from typing import Annotated, Any, ClassVar, Dict, Literal, Optional, Union
 
-from pydantic import Field, SecretStr
+from pydantic import Discriminator, Field, SecretStr, Tag
 from soda_core.model.data_source.data_source_connection_properties import (
     DataSourceConnectionProperties,
 )
+
+# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
+# are the cross-repo contract: they match soda-library#759 and the Cloud connection form.
+AUTH_TYPE_TOKEN = "personal-access-token"
+AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
+AUTH_TYPE_AZURE_SP = "azure-service-principal"
 
 
 class DatabricksConnectionProperties(DataSourceConnectionProperties, ABC):
@@ -26,6 +32,9 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
     def to_connection_kwargs(self) -> dict:
         connection_kwargs = super().to_connection_kwargs()
+        # The auth mode discriminator is ours, never a sql.connect kwarg (the connector has its
+        # own, differently-valued `auth_type` argument).
+        connection_kwargs.pop("auth_type", None)
         server_hostname: str = connection_kwargs["server_hostname"]
         # Check if the server_hostname starts with https:// or http:// and remove it
         prefixes = ["https://", "http://"]
@@ -38,6 +47,8 @@ class DatabricksSharedConnectionProperties(DatabricksConnectionProperties, ABC):
 
 
 class DatabricksTokenAuth(DatabricksSharedConnectionProperties):
+    # Backward compatibility: PAT is the mode when auth_type is omitted.
+    auth_type: Optional[Literal["personal-access-token"]] = Field(None, description="Auth mode discriminator")
     # min_length: an empty token (e.g. an unresolved variable reference) must be rejected here —
     # the connector treats a falsy access_token as "no auth" and falls back to an interactive
     # browser login (see DatabricksDataSourceConnection._create_connection).
@@ -53,6 +64,7 @@ class DatabricksOAuthM2M(DatabricksSharedConnectionProperties):
     plain ``sql.connect`` kwargs, hence the ``to_connection_kwargs`` override below.
     """
 
+    auth_type: Literal["databricks-oauth-m2m"] = Field(..., description="Auth mode discriminator")
     client_id: str = Field(..., description="Databricks OAuth service-principal client ID")
     client_secret: SecretStr = Field(..., description="Databricks OAuth service-principal client secret")
 
@@ -75,6 +87,7 @@ class DatabricksAzureServicePrincipal(DatabricksSharedConnectionProperties):
     fields; they must NOT be emitted as plain ``sql.connect`` kwargs.
     """
 
+    auth_type: Literal["azure-service-principal"] = Field(..., description="Auth mode discriminator")
     azure_client_id: str = Field(..., description="Entra ID (Azure AD) service-principal application/client ID")
     azure_client_secret: SecretStr = Field(..., description="Entra ID (Azure AD) service-principal client secret")
     azure_tenant_id: str = Field(..., description="Entra ID (Azure AD) directory/tenant ID")
@@ -86,3 +99,28 @@ class DatabricksAzureServicePrincipal(DatabricksSharedConnectionProperties):
         for field_name in self._credential_fields:
             connection_kwargs.pop(field_name, None)
         return connection_kwargs
+
+
+def _discriminate_auth_type(value: Any) -> Optional[str]:
+    """Pick the auth mode from the raw ``connection`` mapping (or an already-built model).
+
+    An omitted ``auth_type`` means PAT, the only mode that existed before the discriminator.
+    Returning an unknown tag makes pydantic report it against the expected tags.
+    """
+    if isinstance(value, dict):
+        auth_type = value.get("auth_type")
+    else:
+        auth_type = getattr(value, "auth_type", None)
+    return auth_type or AUTH_TYPE_TOKEN
+
+
+DatabricksConnection = Annotated[
+    Union[
+        Annotated[DatabricksTokenAuth, Tag(AUTH_TYPE_TOKEN)],
+        Annotated[DatabricksOAuthM2M, Tag(AUTH_TYPE_OAUTH_M2M)],
+        Annotated[DatabricksAzureServicePrincipal, Tag(AUTH_TYPE_AZURE_SP)],
+    ],
+    Discriminator(_discriminate_auth_type),
+]
+"""The ``connection`` block of a Databricks data source: one of the auth modes, selected by
+``auth_type`` (PAT when omitted). Validation errors are scoped to the selected mode only."""

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_data_source.py
@@ -1,59 +1,20 @@
 import abc
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_databricks.model.data_source.databricks_connection_properties import (
-    DatabricksAzureServicePrincipal,
-    DatabricksConnectionProperties,
-    DatabricksOAuthM2M,
-    DatabricksTokenAuth,
+from soda_databricks.model.data_source.databricks_connection_properties import (  # noqa: F401 — re-exported
+    AUTH_TYPE_AZURE_SP,
+    AUTH_TYPE_OAUTH_M2M,
+    AUTH_TYPE_TOKEN,
+    DatabricksConnection,
 )
-
-# Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
-# are the cross-repo contract: they match soda-library#759 and the Cloud connection form.
-AUTH_TYPE_TOKEN = "personal-access-token"
-AUTH_TYPE_OAUTH_M2M = "databricks-oauth-m2m"
-AUTH_TYPE_AZURE_SP = "azure-service-principal"
-
-_AUTH_TYPE_TO_PROPERTIES = {
-    AUTH_TYPE_TOKEN: DatabricksTokenAuth,
-    AUTH_TYPE_OAUTH_M2M: DatabricksOAuthM2M,
-    AUTH_TYPE_AZURE_SP: DatabricksAzureServicePrincipal,
-}
 
 
 class DatabricksDataSource(DataSourceBase, abc.ABC):
     type: Literal["databricks"] = Field("databricks")
-    connection_properties: DatabricksConnectionProperties = Field(
+    # Auth mode is picked by the `auth_type` discriminator on DatabricksConnection (PAT when
+    # omitted, for backward compatibility), so validation errors name the selected mode only.
+    connection_properties: DatabricksConnection = Field(
         ..., alias="connection", description="Databricks connection configuration"
     )
-
-    @field_validator("connection_properties", mode="before")
-    @classmethod
-    def infer_connection_type(cls, value):
-        # Already a resolved properties object (e.g. constructed in code) — pass through.
-        if isinstance(value, DatabricksConnectionProperties):
-            return value
-        if not isinstance(value, dict):
-            raise ValueError("Could not infer Databricks connection type from input")
-
-        # Copy so the discriminator can be stripped without mutating caller input; also
-        # prevents auth_type leaking into sql.connect kwargs (base model has extra='allow').
-        value = dict(value)
-        auth_type = value.pop("auth_type", None)
-
-        if auth_type is not None:
-            properties_class = _AUTH_TYPE_TO_PROPERTIES.get(auth_type)
-            if properties_class is None:
-                supported = ", ".join(sorted(_AUTH_TYPE_TO_PROPERTIES))
-                raise ValueError(f"Unknown Databricks auth_type '{auth_type}'. Supported: {supported}")
-            return properties_class(**value)
-
-        # Backward compatibility: no explicit auth_type → infer PAT from field presence.
-        if "access_token" in value:
-            return DatabricksTokenAuth(**value)
-        raise ValueError(
-            "Could not infer Databricks connection type: provide 'auth_type' "
-            f"(one of {', '.join(sorted(_AUTH_TYPE_TO_PROPERTIES))}) or 'access_token'."
-        )

--- a/soda-databricks/tests/unit/test_databricks_empty_token.py
+++ b/soda-databricks/tests/unit/test_databricks_empty_token.py
@@ -28,7 +28,12 @@ from soda_databricks.model.data_source.databricks_data_source import (
     DatabricksDataSource,
 )
 
-infer = DatabricksDataSource.infer_connection_type
+
+def infer(connection: dict):
+    """Validate a raw ``connection`` block the way a data source YAML does and return the
+    selected auth-mode model."""
+    return DatabricksDataSource(name="test", type="databricks", connection=connection).connection_properties
+
 
 BASE = {"host": "abc.cloud.databricks.com", "http_path": "/sql/1.0/endpoints/abc"}
 

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -22,7 +22,11 @@ from soda_databricks.model.data_source.databricks_data_source import (
     DatabricksDataSource,
 )
 
-infer = DatabricksDataSource.infer_connection_type
+
+def infer(connection: dict):
+    """Validate a raw ``connection`` block the way a data source YAML does and return the
+    selected auth-mode model."""
+    return DatabricksDataSource(name="test", type="databricks", connection=connection).connection_properties
 
 
 # --------------------------------------------------------------------------- dispatch
@@ -80,12 +84,14 @@ def test_azure_service_principal_dispatch():
 
 
 def test_unknown_auth_type_raises():
-    with pytest.raises(ValueError, match="Unknown Databricks auth_type"):
+    """An unknown auth_type is reported against the list of expected tags, as a single error."""
+    with pytest.raises(ValueError, match="'nope'.*expected tags.*personal-access-token.*databricks-oauth-m2m"):
         infer({"auth_type": "nope", "host": "h", "http_path": "/x"})
 
 
 def test_no_auth_type_no_access_token_raises():
-    with pytest.raises(ValueError, match="Could not infer"):
+    """No auth_type means PAT, so the missing token is reported for that mode only."""
+    with pytest.raises(ValueError, match="personal-access-token.access_token\n  Field required"):
         infer({"host": "h", "http_path": "/x"})
 
 
@@ -249,3 +255,21 @@ def test_m2m_connection_strips_host_scheme():
 
     assert mock_connect.call_args.kwargs["server_hostname"] == "abc.cloud.databricks.com"
     assert cfg.call_args.kwargs["host"] == "https://abc.cloud.databricks.com"
+
+
+def test_auth_type_discriminator_not_in_connection_kwargs():
+    """Our auth_type is a model discriminator, never a sql.connect kwarg (the connector has its
+    own, differently-valued `auth_type` argument that would select the browser OAuth flow)."""
+    for connection in (
+        {"auth_type": "personal-access-token", "host": "h", "http_path": "/x", "access_token": "t"},
+        {"auth_type": "databricks-oauth-m2m", "host": "h", "http_path": "/x", "client_id": "c", "client_secret": "s"},
+        {
+            "auth_type": "azure-service-principal",
+            "host": "h",
+            "http_path": "/x",
+            "azure_client_id": "a",
+            "azure_client_secret": "s",
+            "azure_tenant_id": "t",
+        },
+    ):
+        assert "auth_type" not in infer(connection).to_connection_kwargs()


### PR DESCRIPTION
## What

Follow-up to #2826, picking up @mivds's review suggestion: the Databricks `connection` block is now a pydantic discriminated union keyed on `auth_type`, and the hand-written `infer_connection_type` validator plus its dispatch table are gone.

```python
DatabricksConnection = Annotated[
    Union[
        Annotated[DatabricksTokenAuth, Tag("personal-access-token")],
        Annotated[DatabricksOAuthM2M, Tag("databricks-oauth-m2m")],
        Annotated[DatabricksAzureServicePrincipal, Tag("azure-service-principal")],
    ],
    Discriminator(_discriminate_auth_type),   # omitted auth_type -> PAT (backward compatible)
]
```

`DatabricksTokenAuth.auth_type` is `Optional[Literal["personal-access-token"]] = None`, the OAuth members require their Literal. A *callable* discriminator (rather than `Field(discriminator="auth_type")`, which needs a required Literal on every member, or a plain `Union`, which reports one bad input against all three members) keeps errors scoped to the selected mode:

```
connection.personal-access-token.access_token
  Field required                                      # no auth_type, no token
connection.personal-access-token.access_token
  Value should have at least 1 item ...               # empty token (min_length=1 from #2826)
connection.databricks-oauth-m2m.client_secret
  Field required
connection
  Input tag 'nope' ... does not match any of the expected tags: 'personal-access-token', 'databricks-oauth-m2m', 'azure-service-principal'
```

`auth_type` is stripped in `DatabricksSharedConnectionProperties.to_connection_kwargs()` so the discriminator never reaches `sql.connect(**kwargs)` — the connector has its own, differently-valued `auth_type` argument (`databricks-oauth` selects the browser flow). Regression test added for that.

Same pattern as Trino's `TrinoDataSource.connection_properties` union, with the callable discriminator on top for the error scoping.

## Tests

`soda-databricks/tests/unit/` — 42 passing, no live database. The two message assertions for "unknown auth_type" / "no auth_type, no token" updated to the pydantic wording; `infer` helper now validates through `DatabricksDataSource` like a YAML load does.

### 📣 Customer-facing release note

```customer-facing-release-note
NONE
```
