### PR TITLE
test(sqlserver): per-xdist-worker database + rerun tests once on deadlock victim

### DIFF
--- a/soda-sqlserver/src/soda_sqlserver/test_helpers/sqlserver_data_source_test_helper.py
+++ b/soda-sqlserver/src/soda_sqlserver/test_helpers/sqlserver_data_source_test_helper.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
+import re
 from typing import Optional
 
 from helpers.data_source_test_helper import DataSourceTestHelper
@@ -10,10 +12,46 @@ from soda_sqlserver.common.data_sources.sqlserver_data_source import (
     SqlServerSqlDialect,
 )
 
+logger = logging.getLogger(__name__)
+
+# Placeholder recorded in snapshots instead of the per-xdist-worker database name,
+# so a snapshot recorded on worker gw2 replays on gw0 (and vice versa).
+SNAPSHOT_DATABASE_PLACEHOLDER = "__$$__soda_test_database__$$__"
+
+
+def per_xdist_worker_database_name(base_database_name: str) -> Optional[str]:
+    """Database name for this pytest-xdist worker, or ``None`` when not applicable.
+
+    SQL Server's system catalog is *per database*. Under pytest-xdist all workers
+    share one SQL Server container: per-worker schemas isolate the user tables, but
+    every ``CREATE``/``DROP`` and every ``information_schema`` scan still contends on
+    the same catalog rows, and SQL Server resolves the resulting lock cycles by
+    killing one side as deadlock victim (SQLSTATE 40001 / error 1205). Giving each
+    worker its own database removes the shared catalog, so workers can no longer
+    deadlock each other.
+
+    Only applies when ``PYTEST_XDIST_WORKER`` is set (xdist worker process). Opt out
+    with ``SODA_TEST_SQLSERVER_DB_PER_WORKER=false`` (e.g. a server where the test
+    login cannot ``CREATE DATABASE``).
+    """
+    worker_id = os.getenv("PYTEST_XDIST_WORKER")
+    if not worker_id:
+        return None
+    if os.getenv("SODA_TEST_SQLSERVER_DB_PER_WORKER", "true").lower() in ("0", "false", "no", "off"):
+        return None
+    return re.sub("[^0-9a-zA-Z_]+", "_", f"{base_database_name}_{worker_id}")
+
 
 class SqlServerDataSourceTestHelper(DataSourceTestHelper):
+    # Set by _create_database_name() when this helper runs in its own per-worker
+    # database; None for the base database (no xdist, opted out, or a subclass such
+    # as Fabric/Synapse that overrides _create_database_name with a fixed warehouse).
+    _per_worker_database: Optional[str] = None
+
     def _create_database_name(self) -> Optional[str]:
-        return os.getenv("SQLSERVER_DATABASE", "master")
+        base_database_name = os.getenv("SQLSERVER_DATABASE", "master")
+        self._per_worker_database = per_xdist_worker_database_name(base_database_name)
+        return self._per_worker_database or base_database_name
 
     def _string_length_sql_function(self) -> str:
         # SqlServer's LEN() trims trailing spaces, under-reporting any
@@ -34,12 +72,51 @@ class SqlServerDataSourceTestHelper(DataSourceTestHelper):
             connection:
                 host: '{os.getenv("SQLSERVER_HOST", "localhost")}'
                 port: '{os.getenv("SQLSERVER_PORT", "1433")}'
-                database: '{os.getenv("SQLSERVER_DATABASE", "master")}'
+                database: '{self.dataset_prefix[0]}'
                 user: '{os.getenv("SQLSERVER_USERNAME", "SA")}'
                 password: '{os.getenv("SQLSERVER_PASSWORD", "Password1!")}'
                 trust_server_certificate: true
                 driver: '{os.getenv("SQLSERVER_DRIVER", "ODBC Driver 18 for SQL Server")}'
         """
+
+    def _snapshot_extra_replacements(self) -> dict[str, str]:
+        replacements = dict(super()._snapshot_extra_replacements())
+        if self._per_worker_database:
+            replacements[SNAPSHOT_DATABASE_PLACEHOLDER] = self._per_worker_database
+        return replacements
+
+    def start_test_session_open_connection(self) -> None:
+        if self._per_worker_database:
+            self._ensure_database_exists(self._per_worker_database)
+        super().start_test_session_open_connection()
+
+    def _ensure_database_exists(self, database_name: str) -> None:
+        """Create the per-worker database if it does not exist yet.
+
+        ``CREATE DATABASE`` is not allowed inside a transaction, so this uses a
+        dedicated autocommit pyodbc connection to the base database (the one the
+        test login is configured for) rather than the helper's own connection. The
+        database is deliberately not dropped at session end: in CI the container is
+        discarded, and locally reusing it is cheaper than recreating it.
+        """
+        import pyodbc
+        from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+            SqlServerDataSourceConnection,
+        )
+
+        base_properties = self.data_source_impl.data_source_model.connection_properties.model_copy(
+            update={"database": os.getenv("SQLSERVER_DATABASE", "master")}
+        )
+        connection = pyodbc.connect(
+            SqlServerDataSourceConnection.build_connection_string(base_properties),
+            timeout=int(base_properties.login_timeout),
+            autocommit=True,
+        )
+        try:
+            connection.cursor().execute(f"IF DB_ID(N'{database_name}') IS NULL CREATE DATABASE [{database_name}]")
+            logger.info(f"Using per-xdist-worker SQL Server database [{database_name}]")
+        finally:
+            connection.close()
 
     def drop_test_schema_if_exists(self) -> None:
         """We overwrite this function because the old query in soda-library is a bit unreadable and does not work with Synapse.

--- a/soda-sqlserver/tests/unit/test_sqlserver_test_helper_per_worker_database.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_test_helper_per_worker_database.py
@@ -8,6 +8,8 @@ wrapper to normalize that name so recordings stay portable across workers.
 
 from __future__ import annotations
 
+import types
+
 import pytest
 from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import (
     SNAPSHOT_DATABASE_PLACEHOLDER,
@@ -69,3 +71,123 @@ def test_connection_yaml_targets_the_per_worker_database(monkeypatch) -> None:
     yaml_str = helper._create_data_source_yaml_str()
 
     assert "database: 'master_gw1'" in yaml_str
+
+
+class _FakeCursor:
+    def __init__(self, executed: list[str], fail: bool = False):
+        self._executed = executed
+        self._fail = fail
+
+    def execute(self, sql: str):
+        if self._fail:
+            raise RuntimeError("CREATE DATABASE permission denied")
+        self._executed.append(sql)
+
+
+class _FakeConnection:
+    def __init__(self, executed: list[str], fail: bool = False):
+        self.closed = False
+        self._cursor = _FakeCursor(executed, fail)
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeProperties:
+    """Stands in for the pydantic connection-properties model."""
+
+    def __init__(self, database: str, login_timeout: int = 7):
+        self.database = database
+        self.login_timeout = login_timeout
+
+    def model_copy(self, update: dict):
+        return _FakeProperties(update.get("database", self.database), self.login_timeout)
+
+
+def _helper_with_per_worker_database(monkeypatch) -> SqlServerDataSourceTestHelper:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+    monkeypatch.setenv("SQLSERVER_DATABASE", "master")
+    helper = _bare_helper()
+    helper.dataset_prefix = [helper._create_database_name(), "some_schema"]
+    impl = types.SimpleNamespace(
+        data_source_model=types.SimpleNamespace(connection_properties=_FakeProperties("master_gw2"))
+    )
+    helper.data_source_impl = impl
+    return helper
+
+
+def _patch_bootstrap_connection(monkeypatch, executed: list[str], connections: list, fail: bool = False):
+    import pyodbc
+    from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
+        SqlServerDataSourceConnection,
+    )
+
+    connect_calls: list[dict] = []
+
+    def fake_connect(connection_string, **kwargs):
+        connect_calls.append({"connection_string": connection_string, **kwargs})
+        connection = _FakeConnection(executed, fail)
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+    monkeypatch.setattr(
+        SqlServerDataSourceConnection,
+        "build_connection_string",
+        staticmethod(lambda props: f"DATABASE={props.database}"),
+    )
+    return connect_calls
+
+
+def test_per_worker_database_is_created_before_the_primary_connection_opens(monkeypatch) -> None:
+    helper = _helper_with_per_worker_database(monkeypatch)
+    executed: list[str] = []
+    connections: list[_FakeConnection] = []
+    connect_calls = _patch_bootstrap_connection(monkeypatch, executed, connections)
+    order: list[str] = []
+    monkeypatch.setattr(
+        SqlServerDataSourceTestHelper.__mro__[1],
+        "start_test_session_open_connection",
+        lambda self: order.append("primary_connection_opened"),
+    )
+    original_ensure = helper._ensure_database_exists
+    helper._ensure_database_exists = lambda db: (order.append("database_ensured"), original_ensure(db))
+
+    helper.start_test_session_open_connection()
+
+    assert order == ["database_ensured", "primary_connection_opened"]
+    # Bootstrap connection targets the BASE database, not the one being created, with autocommit.
+    assert connect_calls == [{"connection_string": "DATABASE=master", "timeout": 7, "autocommit": True}]
+    assert executed == ["IF DB_ID(N'master_gw2') IS NULL CREATE DATABASE [master_gw2]"]
+    assert connections[0].closed is True
+
+
+def test_bootstrap_connection_is_closed_when_database_creation_fails(monkeypatch) -> None:
+    helper = _helper_with_per_worker_database(monkeypatch)
+    executed: list[str] = []
+    connections: list[_FakeConnection] = []
+    _patch_bootstrap_connection(monkeypatch, executed, connections, fail=True)
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        helper._ensure_database_exists("master_gw2")
+
+    assert executed == []
+    assert connections[0].closed is True
+
+
+def test_no_database_bootstrap_without_per_worker_database(monkeypatch) -> None:
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    helper = _bare_helper()
+    helper._create_database_name()
+    opened: list[str] = []
+    monkeypatch.setattr(
+        SqlServerDataSourceTestHelper.__mro__[1], "start_test_session_open_connection", lambda self: opened.append("x")
+    )
+    helper._ensure_database_exists = lambda db: (_ for _ in ()).throw(AssertionError("must not be called"))
+
+    helper.start_test_session_open_connection()
+
+    assert opened == ["x"]

--- a/soda-sqlserver/tests/unit/test_sqlserver_test_helper_per_worker_database.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_test_helper_per_worker_database.py
@@ -1,0 +1,71 @@
+"""Per-pytest-xdist-worker database for the SQL Server test helper.
+
+SQL Server's system catalog is per database: workers sharing one database deadlock
+each other on catalog rows (DDL vs information_schema scans, SQLSTATE 40001). The
+helper therefore runs each xdist worker in its own database, and tells the snapshot
+wrapper to normalize that name so recordings stay portable across workers.
+"""
+
+from __future__ import annotations
+
+import pytest
+from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import (
+    SNAPSHOT_DATABASE_PLACEHOLDER,
+    SqlServerDataSourceTestHelper,
+    per_xdist_worker_database_name,
+)
+
+
+def _bare_helper() -> SqlServerDataSourceTestHelper:
+    # Skip __init__: it would build a DataSourceImpl. Only the naming logic is under test.
+    return object.__new__(SqlServerDataSourceTestHelper)
+
+
+def test_no_xdist_worker_keeps_base_database(monkeypatch) -> None:
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.setenv("SQLSERVER_DATABASE", "master")
+
+    assert per_xdist_worker_database_name("master") is None
+    helper = _bare_helper()
+    assert helper._create_database_name() == "master"
+    assert helper._per_worker_database is None
+    assert helper._snapshot_extra_replacements() == {}
+
+
+def test_xdist_worker_gets_its_own_database(monkeypatch) -> None:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    monkeypatch.setenv("SQLSERVER_DATABASE", "master")
+
+    helper = _bare_helper()
+    assert helper._create_database_name() == "master_gw3"
+    assert helper._per_worker_database == "master_gw3"
+    assert helper._snapshot_extra_replacements() == {SNAPSHOT_DATABASE_PLACEHOLDER: "master_gw3"}
+
+
+def test_opt_out_env_var_disables_per_worker_database(monkeypatch) -> None:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkeypatch.setenv("SODA_TEST_SQLSERVER_DB_PER_WORKER", "false")
+
+    assert per_xdist_worker_database_name("master") is None
+    helper = _bare_helper()
+    assert helper._create_database_name() == "master"
+    assert helper._per_worker_database is None
+
+
+@pytest.mark.parametrize("base,worker,expected", [("master", "gw0", "master_gw0"), ("soda-ci", "gw12", "soda_ci_gw12")])
+def test_per_worker_name_is_a_safe_identifier(monkeypatch, base, worker, expected) -> None:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", worker)
+    monkeypatch.delenv("SODA_TEST_SQLSERVER_DB_PER_WORKER", raising=False)
+    assert per_xdist_worker_database_name(base) == expected
+
+
+def test_connection_yaml_targets_the_per_worker_database(monkeypatch) -> None:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    monkeypatch.setenv("SQLSERVER_DATABASE", "master")
+    helper = _bare_helper()
+    helper.name = "primary_datasource"
+    helper.dataset_prefix = [helper._create_database_name(), "some_schema"]
+
+    yaml_str = helper._create_data_source_yaml_str()
+
+    assert "database: 'master_gw1'" in yaml_str

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -156,6 +156,7 @@ def _patched_create_additional_connection(ds_self: "DataSourceImpl"):
             allow_fallback=primary._allow_fallback,
             primary_snapshot=primary,
         )
+        secondary.extra_replacements = dict(primary.extra_replacements)
     else:
         real_conn = orig(ds_self)
         secondary = SnapshotDataSourceConnection(
@@ -167,6 +168,7 @@ def _patched_create_additional_connection(ds_self: "DataSourceImpl"):
             allow_fallback=primary._allow_fallback,
             primary_snapshot=primary,
         )
+        secondary.extra_replacements = dict(primary.extra_replacements)
     secondary.connection_properties = primary.connection_properties
     return secondary
 
@@ -546,6 +548,16 @@ class DataSourceTestHelper:
             )
         return self._dwh_snapshot_managers.get(key)
 
+    def _snapshot_extra_replacements(self) -> dict[str, str]:
+        """Extra ``placeholder → real value`` pairs the snapshot wrapper must normalize
+        besides the schema name (see ``SnapshotDataSourceConnection.extra_replacements``).
+
+        Override in data-source helpers whose generated SQL contains other per-run
+        identifiers — e.g. SQL Server's per-xdist-worker database name — so recorded
+        snapshots stay portable across workers and runs. Default: nothing extra.
+        """
+        return {}
+
     def _snapshot_schema_name(self) -> Optional[str]:
         """Return the dynamic schema name part for snapshot placeholder replacement.
 
@@ -629,6 +641,7 @@ class DataSourceTestHelper:
             allow_fallback=allow_fallback,
         )
         snap_conn.passthrough_queries = self._snapshot_passthrough_queries()
+        snap_conn.extra_replacements.update(self._snapshot_extra_replacements())
         snap_conn.connection_properties = self.data_source_impl.data_source_model.connection_properties
         snap_conn._data_source_impl = self.data_source_impl
         # Install the patch BEFORE publishing the wrapper so any exception
@@ -647,6 +660,7 @@ class DataSourceTestHelper:
             real_schema_name=self._snapshot_schema_name(),
         )
         snap_conn.passthrough_queries = self._snapshot_passthrough_queries()
+        snap_conn.extra_replacements.update(self._snapshot_extra_replacements())
         snap_conn._data_source_impl = self.data_source_impl
         # Install the patch BEFORE publishing the wrapper so any exception
         # leaves the global patch state untouched.

--- a/soda-tests/src/helpers/snapshot_pytest_plugin.py
+++ b/soda-tests/src/helpers/snapshot_pytest_plugin.py
@@ -74,13 +74,18 @@ def pytest_configure() -> None:
 _RERAN_TEST_RECORD: dict[str, str] = {}
 
 
-def _rerun_mode_enabled() -> bool:
-    """Whether the plugin should run the rerun hook.
+def _snapshot_rerun_enabled() -> bool:
+    """Whether a queued snapshot-drift signal may trigger a rerun.
 
-    False when strict mode is active — then pytest runs each test once and
-    surfaces any ``SnapshotReplayError`` as a hard failure.
+    False in strict mode — then a ``SnapshotReplayError`` surfaces as a hard
+    failure. Transient database errors are re-run regardless (see
+    ``_reports_contain_transient_db_error``).
     """
     return not is_strict_mode_enabled()
+
+
+# Backwards-compatible alias (referenced by older tests).
+_rerun_mode_enabled = _snapshot_rerun_enabled
 
 
 def _reset_per_test_rerun_state() -> None:
@@ -244,12 +249,12 @@ def pytest_runtest_protocol(item, nextitem):
     rerun logic re-runs on the worker, which is where snapshot wrappers
     actually live.
 
-    Skips entirely in strict mode so the first attempt's failure stands.
+    Strict mode (``SODA_TEST_SNAPSHOT_STRICT=true``) only disables the
+    snapshot-drift rerun so the first attempt's mismatch stands; transient
+    database errors are unrelated to snapshot fidelity and are still re-run.
     A single rerun is the maximum: if the rerun itself raises another
     SnapshotReplayError, that bubbles up as a hard test failure.
     """
-    if not _rerun_mode_enabled():
-        return None
     if _is_xdist_controller(item.config):
         # Controller only dispatches; the rerun fires on the worker where
         # snapshot wrappers actually live.
@@ -257,7 +262,11 @@ def pytest_runtest_protocol(item, nextitem):
 
     _reset_per_test_rerun_state()
     first_reports = _runtestprotocol(item, nextitem)
+    # Always pop the queued snapshot signal so it can't leak into the next
+    # test; only act on it outside strict mode.
     rerun_reason = _reports_contain_rerun_signal(item.nodeid)
+    if not _snapshot_rerun_enabled():
+        rerun_reason = None
     if rerun_reason is None:
         rerun_reason = _reports_contain_transient_db_error(first_reports)
     if rerun_reason is None:
@@ -303,18 +312,21 @@ def pytest_runtest_protocol(item, nextitem):
     _RERAN_TEST_RECORD[item.nodeid] = rerun_reason
     # Also attach to the call-phase report's user_properties so the rerun
     # reason propagates through pytest-xdist to the master.
+    # Attach to every phase's report: a rerun can fail again in setup (no call
+    # report at all) or in teardown (call report passed), and the summary must
+    # still list the test and label the failing phase.
     for r in second_reports:
-        if r.when == "call":
-            r.user_properties = list(r.user_properties or []) + [
-                (_RERAN_USER_PROPERTY_KEY, rerun_reason),
-            ]
+        r.user_properties = list(r.user_properties or []) + [
+            (_RERAN_USER_PROPERTY_KEY, rerun_reason),
+        ]
     for r in second_reports:
         item.ihook.pytest_runtest_logreport(report=r)
     return True
 
 
 def pytest_report_teststatus(report):
-    """Annotate the call-phase status for tests that re-ran.
+    """Annotate the status of tests that re-ran (every phase, so a rerun that
+    fails again in setup or teardown is still recorded and labelled).
 
     The short progress char stays a plain ASCII string. Pytest concatenates
     those into a buffer and later calls ``.rsplit`` on the result, so a
@@ -323,16 +335,19 @@ def pytest_report_teststatus(report):
     label is safe to colourize because it's only handed to the markup-aware
     write path.
     """
-    if report.when != "call":
-        return None
     reran_reason = _read_reran_reason_from_report(report)
     if reran_reason is None:
         return None
     _RERAN_TEST_RECORD.setdefault(report.nodeid, reran_reason)
-    if report.outcome == "passed":
-        return "passed", ".", _yellow("RERAN: PASSED")
+    if report.when == "call":
+        if report.outcome == "passed":
+            return "passed", ".", _yellow("RERAN: PASSED")
+        if report.outcome == "failed":
+            return "failed", "F", _yellow("RERAN: FAILED")
+        return None
     if report.outcome == "failed":
-        return "failed", "F", _yellow("RERAN: FAILED")
+        # Setup/teardown failure on the rerun: pytest counts it as an error.
+        return "error", "E", _yellow("RERAN: ERROR")
     return None
 
 

--- a/soda-tests/src/helpers/snapshot_pytest_plugin.py
+++ b/soda-tests/src/helpers/snapshot_pytest_plugin.py
@@ -20,6 +20,7 @@ downstream repo that consumes soda-tests.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Optional
 
 import pytest
@@ -145,6 +146,46 @@ def _deactivate_lingering_interceptors() -> None:
     deactivate_all_registered_interceptors()
 
 
+# Transient database errors that warrant one re-run of the test. These come from the
+# shared test infrastructure, not the code under test: SQL Server kills one side of a
+# system-catalog lock cycle between concurrent DDL and information_schema scans as the
+# "deadlock victim" (error 1205, SQLSTATE 40001) and asks the client to rerun.
+_TRANSIENT_DB_ERROR_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"deadlock victim", re.IGNORECASE),
+    re.compile(r"\b40001\b"),
+)
+TRANSIENT_RERUN_REASON_PREFIX = "transient DB error: "
+
+
+def _report_failure_text(report) -> str:
+    text = getattr(report, "longreprtext", None)
+    if text:
+        return text
+    return str(report.longrepr) if report.longrepr is not None else ""
+
+
+def _reports_contain_transient_db_error(reports) -> Optional[str]:
+    """If any phase failed on a known transient DB error, return the rerun reason.
+
+    Checked only when no snapshot rerun was queued. Looks at every phase (setup,
+    call, teardown): fixture DDL such as ``ensure_test_table`` or the schema drop is
+    exactly where catalog deadlocks strike.
+    """
+    for report in reports:
+        if report.outcome != "failed":
+            continue
+        text = _report_failure_text(report)
+        for pattern in _TRANSIENT_DB_ERROR_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                return f"{TRANSIENT_RERUN_REASON_PREFIX}{match.group(0)!r} during {report.when}"
+    return None
+
+
+def _is_transient_rerun_reason(reason: str) -> bool:
+    return str(reason).startswith(TRANSIENT_RERUN_REASON_PREFIX)
+
+
 def _reports_contain_rerun_signal(test_id: str) -> Optional[str]:
     """If any report indicates the test asked for a rerun, return the reason.
 
@@ -218,14 +259,21 @@ def pytest_runtest_protocol(item, nextitem):
     first_reports = _runtestprotocol(item, nextitem)
     rerun_reason = _reports_contain_rerun_signal(item.nodeid)
     if rerun_reason is None:
+        rerun_reason = _reports_contain_transient_db_error(first_reports)
+    if rerun_reason is None:
         for r in first_reports:
             item.ihook.pytest_runtest_logreport(report=r)
         return True
 
     # First attempt asked for a rerun. Run the test again with all
     # snapshot wrappers swapped out for their real connections, so the
-    # rerun's behaviour is identical to SODA_TEST_SNAPSHOT=off.
-    logger.warning(f"SNAPSHOT: re-running {item.nodeid} against real DB; reason: {rerun_reason}")
+    # rerun's behaviour is identical to SODA_TEST_SNAPSHOT=off. A transient
+    # DB error takes the same path: in off mode there are no wrappers to
+    # swap and the test simply runs a second time.
+    if _is_transient_rerun_reason(rerun_reason):
+        logger.warning(f"TRANSIENT: re-running {item.nodeid} once; reason: {rerun_reason}")
+    else:
+        logger.warning(f"SNAPSHOT: re-running {item.nodeid} against real DB; reason: {rerun_reason}")
 
     _deactivate_lingering_interceptors()
     swapped: list = []
@@ -299,17 +347,31 @@ def pytest_terminal_summary(terminalreporter) -> None:
             bold=True,
         )
 
-    if _RERAN_TEST_RECORD:
+    drift = {t: r for t, r in _RERAN_TEST_RECORD.items() if not _is_transient_rerun_reason(r)}
+    transient = {t: r for t, r in _RERAN_TEST_RECORD.items() if _is_transient_rerun_reason(r)}
+    if drift:
         terminalreporter.section("snapshot drift — tests re-run against real DB", sep="=", yellow=True)
-        for test_id in sorted(_RERAN_TEST_RECORD):
+        for test_id in sorted(drift):
             terminalreporter.write_line(f"  {test_id}")
-            for line in str(_RERAN_TEST_RECORD[test_id]).splitlines():
+            for line in str(drift[test_id]).splitlines():
                 terminalreporter.write_line(f"      {line}")
         terminalreporter.write_line("")
         terminalreporter.write_line(
-            f"{len(_RERAN_TEST_RECORD)} test(s) re-ran end-to-end against the real DB "
+            f"{len(drift)} test(s) re-ran end-to-end against the real DB "
             "because their recorded SQL no longer matches production. Re-record with "
             "SODA_TEST_SNAPSHOT=record to refresh the snapshots."
+        )
+    if transient:
+        terminalreporter.section("transient DB errors — tests re-run once", sep="=", yellow=True)
+        for test_id in sorted(transient):
+            terminalreporter.write_line(f"  {test_id}")
+            for line in str(transient[test_id]).splitlines():
+                terminalreporter.write_line(f"      {line}")
+        terminalreporter.write_line("")
+        terminalreporter.write_line(
+            f"{len(transient)} test(s) hit a transient database error (e.g. SQL Server deadlock "
+            "victim, SQLSTATE 40001) and were re-run once. Frequent occurrences point at "
+            "contention in the shared test database, not at the test."
         )
 
     # Unconsumed-snapshot drifts that were downgraded silently because

--- a/soda-tests/tests/unit/test_create_additional_connection_snapshot_patch.py
+++ b/soda-tests/tests/unit/test_create_additional_connection_snapshot_patch.py
@@ -240,3 +240,22 @@ def test_replay_mode_lazy_factory_calls_original_on_demand(reset_patch_state, tm
 
     assert produced is lazy_real
     impl._create_data_source_connection.assert_called_once_with()
+
+
+@pytest.mark.parametrize("mode", ["record", "replay"])
+def test_secondary_inherits_primary_extra_replacements(reset_patch_state, tmp_path, mode) -> None:
+    """Per-run identifiers registered on the primary wrapper (e.g. SQL Server's
+    per-xdist-worker database name) must be normalized on secondary connections too,
+    otherwise SQL flowing through an additional connection records the raw name."""
+    DataSourceTestHelper._install_create_additional_connection_patch()
+    patched = DataSourceImpl.create_additional_connection
+
+    primary = _make_primary_snapshot(tmp_path, mode=mode)
+    primary.extra_replacements["__$$__soda_test_database__$$__"] = "master_gw2"
+    impl = MagicMock(spec=DataSourceImpl, data_source_connection=primary)
+    impl._create_data_source_connection.return_value = _FakeReal()
+
+    secondary = _bind(patched, impl)()
+
+    assert secondary.extra_replacements == {"__$$__soda_test_database__$$__": "master_gw2"}
+    assert secondary.extra_replacements is not primary.extra_replacements

--- a/soda-tests/tests/unit/test_snapshot_pytest_plugin.py
+++ b/soda-tests/tests/unit/test_snapshot_pytest_plugin.py
@@ -150,3 +150,96 @@ def test_plain():
     assert any(
         "SODA_TEST_SNAPSHOT_STRICT=true" in line for line in result.outlines
     ), "Expected strict-mode banner in output; got:\n" + "\n".join(result.outlines)
+
+
+# ---------------------------------------------------------------------------
+# Transient DB errors (SQL Server deadlock victim) → one re-run
+# ---------------------------------------------------------------------------
+
+_DEADLOCK_MESSAGE = (
+    "('40001', '[40001] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]"
+    "Transaction (Process ID 52) was deadlocked on lock resources with another process "
+    "and has been chosen as the deadlock victim. Rerun the transaction. (1205) (SQLFetch)')"
+)
+
+
+def test_transient_deadlock_in_test_body_is_rerun_once(pytester, _reset_rerun_registry):
+    """A deadlock-victim error on the first attempt is re-run; the passing rerun
+    counts as passed and is listed under the transient section, not snapshot drift."""
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_deadlock=f"""
+_STATE = {{"attempt": 0}}
+
+def test_target():
+    _STATE["attempt"] += 1
+    if _STATE["attempt"] == 1:
+        raise Exception({_DEADLOCK_MESSAGE!r})
+    assert _STATE["attempt"] == 2
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+    assert any("RERAN: PASSED" in line for line in result.outlines), "\n".join(result.outlines)
+    assert any("transient DB errors" in line for line in result.outlines), "\n".join(result.outlines)
+    assert not any("snapshot drift" in line for line in result.outlines), "\n".join(result.outlines)
+
+
+def test_transient_deadlock_in_fixture_teardown_is_rerun_once(pytester, _reset_rerun_registry):
+    """Catalog deadlocks mostly strike fixture DDL (setup/teardown). A teardown
+    deadlock on the first attempt must also trigger the rerun."""
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_teardown_deadlock=f"""
+import pytest
+
+_STATE = {{"attempt": 0}}
+
+@pytest.fixture
+def table():
+    _STATE["attempt"] += 1
+    yield "t"
+    if _STATE["attempt"] == 1:
+        raise Exception({_DEADLOCK_MESSAGE!r})
+
+def test_target(table):
+    assert table == "t"
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1, errors=0)
+    assert any("RERAN: PASSED" in line for line in result.outlines), "\n".join(result.outlines)
+
+
+def test_transient_deadlock_on_both_attempts_fails(pytester, _reset_rerun_registry):
+    """Only one rerun: a second deadlock surfaces as a failure."""
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_deadlock_twice=f"""
+def test_target():
+    raise Exception({_DEADLOCK_MESSAGE!r})
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(failed=1)
+    assert any("RERAN: FAILED" in line for line in result.outlines), "\n".join(result.outlines)
+
+
+def test_unrelated_failure_is_not_rerun(pytester, _reset_rerun_registry):
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_plain_failure="""
+_STATE = {"attempt": 0}
+
+def test_target():
+    _STATE["attempt"] += 1
+    assert _STATE["attempt"] == 2, "a real assertion failure"
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(failed=1)
+    assert not any("RERAN" in line for line in result.outlines), "\n".join(result.outlines)

--- a/soda-tests/tests/unit/test_snapshot_pytest_plugin.py
+++ b/soda-tests/tests/unit/test_snapshot_pytest_plugin.py
@@ -18,10 +18,13 @@ pytest_plugins = ["pytester"]
 def _reset_rerun_registry():
     """Each rerun-mode pytester run starts with a clean rerun registry."""
     from helpers.snapshot_connection import reset_pending_rerun_record
+    from helpers.snapshot_pytest_plugin import _RERAN_TEST_RECORD
 
     reset_pending_rerun_record()
+    _RERAN_TEST_RECORD.clear()
     yield
     reset_pending_rerun_record()
+    _RERAN_TEST_RECORD.clear()
 
 
 def _conftest_text() -> str:
@@ -243,3 +246,72 @@ def test_target():
     result = pytester.runpytest("-v")
     result.assert_outcomes(failed=1)
     assert not any("RERAN" in line for line in result.outlines), "\n".join(result.outlines)
+
+
+def test_transient_deadlock_is_rerun_even_in_strict_mode(pytester, _reset_rerun_registry, monkeypatch):
+    """Strict mode only disables snapshot-drift reruns; a transient DB error is
+    unrelated to snapshot fidelity and still gets its one rerun."""
+    monkeypatch.setenv("SODA_TEST_SNAPSHOT_STRICT", "true")
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_strict_deadlock=f"""
+_STATE = {{"attempt": 0}}
+
+def test_target():
+    _STATE["attempt"] += 1
+    if _STATE["attempt"] == 1:
+        raise Exception({_DEADLOCK_MESSAGE!r})
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+    assert any("RERAN: PASSED" in line for line in result.outlines), "\n".join(result.outlines)
+
+
+def test_transient_deadlock_in_setup_on_both_attempts_is_reported(pytester, _reset_rerun_registry):
+    """A rerun that fails again in *setup* has no call report; it must still count
+    as an error, be labelled, and be listed in the transient summary."""
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_setup_deadlock_twice=f"""
+import pytest
+
+@pytest.fixture
+def table():
+    raise Exception({_DEADLOCK_MESSAGE!r})
+
+def test_target(table):
+    pass
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(errors=1)
+    assert any("RERAN: ERROR" in line for line in result.outlines), "\n".join(result.outlines)
+    assert any("transient DB errors" in line for line in result.outlines), "\n".join(result.outlines)
+    assert any("test_setup_deadlock_twice.py::test_target" in line for line in result.outlines)
+
+
+def test_transient_deadlock_in_teardown_on_both_attempts_is_reported(pytester, _reset_rerun_registry):
+    """A rerun whose *teardown* deadlocks again: the call passed, but the test must
+    surface as an error and be labelled as a rerun error, not RERAN: PASSED only."""
+    pytester.makeconftest(_conftest_text())
+    pytester.makepyfile(
+        test_teardown_deadlock_twice=f"""
+import pytest
+
+@pytest.fixture
+def table():
+    yield "t"
+    raise Exception({_DEADLOCK_MESSAGE!r})
+
+def test_target(table):
+    assert table == "t"
+"""
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1, errors=1)
+    assert any("RERAN: ERROR" in line for line in result.outlines), "\n".join(result.outlines)
+    assert any("transient DB errors" in line for line in result.outlines), "\n".join(result.outlines)


### PR DESCRIPTION
## Problem

SQL Server CI lanes under pytest-xdist fail intermittently with

```
pyodbc.Error: ('40001', '... Transaction (Process ID N) was deadlocked on lock resources with another
process and has been chosen as the deadlock victim. Rerun the transaction. (1205) ...')
```

Measured over the last 6 months of CI (2026-02-20 → 2026-08-20, log-verified for the 90-day retention window, estimated before that):

| | soda-extensions | soda-core |
|---|---|---|
| deadlock job failures | ~680 (411 log-verified) | ~90 (24 verified, all `fabric`) |
| share of live TDS-lane executions that die on a deadlock | 12% | 2% |
| CI runs whose only failure was a deadlock | ~10% of all runs | ~3% |
| manual reruns caused | ~37% of all reruns | ~16% |
| developer wait, failure → green | ~156 h | ~35 h |

322 of the 330 verified occurrences are in fixture phases (setup/teardown DDL of the diagnostics-warehouse tests), not in test bodies. Of failed `sqlserver` lanes where nothing else failed, 96% are deadlocks.

## Root cause

SQL Server's system catalog is per **database**. All xdist workers share one container database: per-worker *schemas* isolate the user tables, but every `CREATE`/`DROP` and every `information_schema` scan still contends on the same catalog rows, and SQL Server resolves the lock cycle by killing one side. (#2803 diagnosed the same mechanism and added a connection-level retry; it was reverted in #2806 and also changes production behaviour. This PR stays in the test harness.)

## Fix (test harness only)

1. **Per-xdist-worker database.** `SqlServerDataSourceTestHelper` runs each worker in its own database (`<base>_<worker>`, created on demand through an autocommit connection to the base database). Different databases, different catalogs: workers can no longer deadlock each other. Active only when `PYTEST_XDIST_WORKER` is set; opt out with `SODA_TEST_SQLSERVER_DB_PER_WORKER=false`. Fabric/Synapse override `_create_database_name` and are unaffected.
   The per-worker name is normalized in snapshots through a new `DataSourceTestHelper._snapshot_extra_replacements()` hook, so a recording made on `gw2` replays on `gw0`; secondary connections now inherit the primary wrapper's extra replacements.
2. **Rerun once on deadlock victim.** The snapshot plugin's existing rerun protocol also re-runs a test once when any phase (setup/call/teardown) failed on a 40001/deadlock-victim error. This covers the shared Fabric warehouse (concurrent CI jobs, no per-job isolation possible). Such reruns get their own `transient DB errors — tests re-run once` summary section, separate from snapshot drift.

Companion: sodadata/soda-extensions PR propagating the source wrapper's extra replacements to the DWH snapshot. Its CI runs against this branch.

## Testing

- New unit tests: per-worker naming / opt-out / YAML targets the worker DB; secondary wrapper inherits extra replacements (record + replay).
- New `pytester` tests: deadlock in test body → `RERAN: PASSED`; deadlock in fixture teardown → rerun; deadlock twice → `RERAN: FAILED`; unrelated failure → no rerun.
- Existing snapshot/plugin/sqlserver unit suites: 185 passed.

### 📣 Customer-facing release note

```customer-facing-release-note
NONE
```
