### PR TITLE
feat(cloud): add agent source to scan token usage

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1774,7 +1774,7 @@ def _build_token_usage_dicts(contract_verification_result: ContractVerificationR
                 "totalTokens": tu.total_tokens,
                 "model": tu.model,
                 "operation": tu.operation,
-                "agentSource": tu.agent_source,
+                **({"agentSource": tu.agent_source} if tu.agent_source is not None else {}),
             }
             for tu in contract_verification_result.token_usage
         ]

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1774,6 +1774,7 @@ def _build_token_usage_dicts(contract_verification_result: ContractVerificationR
                 "totalTokens": tu.total_tokens,
                 "model": tu.model,
                 "operation": tu.operation,
+                "agentSource": tu.agent_source,
             }
             for tu in contract_verification_result.token_usage
         ]
@@ -1837,17 +1838,7 @@ def _build_check_collection_results_json_dict(
 
     token_usage: list[dict] = []
     for r in results:
-        if r.token_usage:
-            token_usage.extend(
-                {
-                    "promptTokens": tu.prompt_tokens,
-                    "completionTokens": tu.completion_tokens,
-                    "totalTokens": tu.total_tokens,
-                    "model": tu.model,
-                    "operation": tu.operation,
-                }
-                for tu in r.token_usage
-            )
+        token_usage.extend(_build_token_usage_dicts(r))
 
     ingestion_mode = VerificationIngestionMode.FULL
     for r in results:

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -558,6 +558,7 @@ class ScanTokenUsage:
     total_tokens: int
     model: Optional[str] = None
     operation: Optional[str] = None  # "autopilot" or "llmCheck" (matches server Gson @SerializedName)
+    agent_source: Optional[str] = None
 
 
 class PostProcessingStageState(Enum):

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -558,6 +558,7 @@ class ScanTokenUsage:
     total_tokens: int
     model: Optional[str] = None
     operation: Optional[str] = None  # "autopilot" or "llmCheck" (matches server Gson @SerializedName)
+    # Case-sensitive "SODA" or "BYOK"; Cloud Gson maps anything else to null without error.
     agent_source: Optional[str] = None
 
 

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -27,7 +27,9 @@ from soda_core.common.exceptions import (
 from soda_core.common.soda_cloud import (
     ContractSkeletonGenerationState,
     SodaCloud,
+    _build_check_collection_results_json_dict,
     _build_diagnostics_json_dict,
+    _build_token_usage_dicts,
 )
 from soda_core.common.yaml import ContractYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_publication import ContractPublicationResult
@@ -835,8 +837,6 @@ def test_build_diagnostics_json_dict_omits_measure_for_non_time_checks():
 
 
 def test_build_token_usage_dicts_serialization():
-    from soda_core.common.soda_cloud import _build_token_usage_dicts
-
     mock_result = mock.MagicMock()
     mock_result.token_usage = [
         ScanTokenUsage(
@@ -845,28 +845,116 @@ def test_build_token_usage_dicts_serialization():
             total_tokens=2000,
             model="gpt-4o",
             operation="autopilot",
+            agent_source="SODA",
+        ),
+        ScanTokenUsage(
+            prompt_tokens=300,
+            completion_tokens=100,
+            total_tokens=400,
+            model="gpt-4o-mini",
+            operation="autopilot",
         ),
     ]
     token_dicts = _build_token_usage_dicts(mock_result)
-    assert len(token_dicts) == 1
-    assert token_dicts[0] == {
-        "promptTokens": 1500,
-        "completionTokens": 500,
-        "totalTokens": 2000,
-        "model": "gpt-4o",
-        "operation": "autopilot",
-    }
+    assert token_dicts == [
+        {
+            "promptTokens": 1500,
+            "completionTokens": 500,
+            "totalTokens": 2000,
+            "model": "gpt-4o",
+            "operation": "autopilot",
+            "agentSource": "SODA",
+        },
+        {
+            "promptTokens": 300,
+            "completionTokens": 100,
+            "totalTokens": 400,
+            "model": "gpt-4o-mini",
+            "operation": "autopilot",
+            "agentSource": None,
+        },
+    ]
 
 
 def test_build_token_usage_dicts_empty_when_no_usage():
-    from soda_core.common.soda_cloud import _build_token_usage_dicts
-
     mock_result = mock.MagicMock()
     mock_result.token_usage = None
     assert _build_token_usage_dicts(mock_result) == []
 
     mock_result.token_usage = []
     assert _build_token_usage_dicts(mock_result) == []
+
+
+def _build_result_with_token_usage(token_usage: Optional[list[ScanTokenUsage]]) -> mock.MagicMock:
+    timestamp = datetime(2026, 8, 18, tzinfo=timezone.utc)
+    result = mock.MagicMock()
+    result.check_collection = mock.MagicMock(soda_qualified_dataset_name="test_ds/schema/table")
+    result.data_source = None
+    result.data_timestamp = timestamp
+    result.started_timestamp = timestamp
+    result.ended_timestamp = timestamp
+    result.check_results = []
+    result.log_records = None
+    result.post_processing_stages = None
+    result.token_usage = token_usage
+    result.measurement_dicts = []
+    result.has_errors = False
+    result.is_warned = False
+    result.is_failed = False
+    return result
+
+
+def test_build_check_collection_results_serializes_token_usage_in_result_and_entry_order():
+    results = [
+        _build_result_with_token_usage(None),
+        _build_result_with_token_usage(
+            [
+                ScanTokenUsage(10, 20, 30, model="model-a", operation="autopilot", agent_source="SODA"),
+                ScanTokenUsage(40, 50, 90, model="model-b", operation="llmCheck"),
+            ]
+        ),
+        _build_result_with_token_usage([]),
+        _build_result_with_token_usage(
+            [ScanTokenUsage(60, 70, 130, model="model-c", operation="autopilot", agent_source="BYOK")]
+        ),
+    ]
+
+    payload = _build_check_collection_results_json_dict(results, wire_source="data-standard")
+
+    assert payload["tokenUsage"] == [
+        {
+            "promptTokens": 10,
+            "completionTokens": 20,
+            "totalTokens": 30,
+            "model": "model-a",
+            "operation": "autopilot",
+            "agentSource": "SODA",
+        },
+        {
+            "promptTokens": 40,
+            "completionTokens": 50,
+            "totalTokens": 90,
+            "model": "model-b",
+            "operation": "llmCheck",
+        },
+        {
+            "promptTokens": 60,
+            "completionTokens": 70,
+            "totalTokens": 130,
+            "model": "model-c",
+            "operation": "autopilot",
+            "agentSource": "BYOK",
+        },
+    ]
+
+
+def test_build_check_collection_results_keeps_empty_token_usage_list():
+    payload = _build_check_collection_results_json_dict(
+        [_build_result_with_token_usage(None), _build_result_with_token_usage([])],
+        wire_source="data-standard",
+    )
+
+    assert payload["tokenUsage"] == []
 
 
 @mock.patch("requests.post")

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -871,7 +871,6 @@ def test_build_token_usage_dicts_serialization():
             "totalTokens": 400,
             "model": "gpt-4o-mini",
             "operation": "autopilot",
-            "agentSource": None,
         },
     ]
 


### PR DESCRIPTION
## Description

Scan token usage can now carry optional source attribution through the existing scan-results payload.

- add a trailing optional `agent_source` field to `ScanTokenUsage`
- serialize it as optional `agentSource`, omitting the key when unset
- consolidate token-usage dictionary construction while preserving result and entry order
- preserve the existing empty `tokenUsage` list behavior

Downstream packages that populate `agent_source` must require this or a later soda-core build. Existing callers remain compatible because the field is trailing and defaulted.

## Coordination

- Linear: [PLATL-970](https://linear.app/sodadata/issue/PLATL-970/thread-contract-autopilot-agentsource-into-scan-token-usage). Siblings: [soda#13146](https://github.com/sodadata/soda/pull/13146), [soda-core#2835](https://github.com/sodadata/soda-core/pull/2835), [soda-extensions#564](https://github.com/sodadata/soda-extensions/pull/564).
- Order: soda is independent; soda-core precedes soda-extensions, which must pin its published dev artifact.

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1].

[1]: https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml

### Customer-facing release note

```customer-facing-release-note
NONE
```