### PR TITLE
fix(aggregate): key the aggregate metric on its function

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/aggregate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/aggregate_check.py
@@ -133,6 +133,14 @@ class AggregateFunctionMetricImpl(AggregationMetricImpl):
             column_expression=column_expression or check_impl.column_expression,
         )
 
+    def _get_id_properties(self) -> dict[str, any]:
+        # Without the function, min(age) and max(age) hash to the same metric id and the
+        # metrics resolver dedupes them into one: only the first is queried and every other
+        # aggregate check on that column silently reports its value.
+        id_properties: dict[str, any] = super()._get_id_properties()
+        id_properties["function"] = self.function
+        return id_properties
+
     def sql_expression(self) -> SqlExpression:
         is_missing = self.missing_and_validity.is_missing_expr(self.column_expression)
         is_invalid = self.missing_and_validity.is_invalid_expr(self.column_expression)

--- a/soda-tests/tests/integration/test_aggregate_check.py
+++ b/soda-tests/tests/integration/test_aggregate_check.py
@@ -269,3 +269,32 @@ def test_aggregate_function_avg_warn(data_source_test_helper: DataSourceTestHelp
     soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
     check_json: dict = soda_core_insert_scan_results_command["checks"][0]
     assert check_json["diagnostics"]["v4"] == {"type": "aggregate", "datasetRowsTested": 5, "checkRowsTested": 5}
+
+
+def test_aggregate_functions_on_same_column_are_measured_separately(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_pass(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            columns:
+              - name: age
+                checks:
+                  - aggregate:
+                      qualifier: min_age
+                      function: min
+                      threshold:
+                        must_be: 0
+                  - aggregate:
+                      qualifier: max_age
+                      function: max
+                      threshold:
+                        must_be: 10
+        """,
+    )
+    min_check_result: CheckResult = contract_verification_result.check_results[0]
+    max_check_result: CheckResult = contract_verification_result.check_results[1]
+    assert get_diagnostic_value(min_check_result, "min") == 0
+    assert get_diagnostic_value(max_check_result, "max") == 10


### PR DESCRIPTION
Two `aggregate` checks on the same column, with different functions, resolved to a single metric. Only the first was queried; every other aggregate check on that column silently reported its value.

Reported by a user who wrote min and max on one column to force a failure:

```yaml
- name: difficulty
  checks:
    - aggregate:
        function: min
        threshold: { must_be_greater_than_or_equal: 0 }
    - aggregate:
        function: max
        threshold: { must_be_less_than_or_equal: 2 }
```

The column holds `{0, 1, 2, 3}`, so the max check has to fail. It passed, reporting `max: 0.0`, and the generated query contained a `MIN(...)` and no `MAX(...)`.

`MetricImpl._get_id_properties()` builds the metric identity from type, data source, dataset, column, check filter, missing/validity config and column expression. `AggregateFunctionMetricImpl` never added the aggregate function, so `MetricsResolver.resolve_metric()` considered `min(age)` and `max(age)` the same metric and deduped them. A check `qualifier` doesn't help — that makes the *check* identity unique, and the metric identity is separate.

Affects any pair of aggregate functions on a column (min/max, sum/avg, …) on every data source, and has been there since the v4 release.

The fix adds `function` to the metric's id properties, which is what `metric_check`, `freshness_check`, `failed_rows_check` and `duplicate_check` already do for their own distinguishing state.

**Test:** `test_aggregate_functions_on_same_column_are_measured_separately` fails on `main` (max check reads the min value and the contract fails) and passes with the fix. Full `soda-tests` + `soda-duckdb` suites green; the one `test_duckdb_connections` failure in the combined run is pre-existing and reproduces on an unmodified tree.

### 📣 Customer-facing release note

```customer-facing-release-note
Multiple aggregate checks on the same column now each report their own value.
```
