### PR TITLE
chore: set codeowners & update PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sodadata/data-engineers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,11 @@
 ## Description
 
-Please provide a description of your changes:
+<!-- What does this PR change and why? Link the related issue if there is one. -->
 
-- What problem are you solving?
-- Any expected impact on downstream packages/services?
-- Reference issue # if available.
-
+Fixes #
 
 ## Checklist
 
-- [ ] I added a test to verify the new functionality.
-- [ ] I verified this PR does not break [soda-extensions][1].
-
-[1]: (https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml)
+- [ ] Tests added or updated to cover the change
+- [ ] Documentation updated where relevant
+- [ ] PR title follows the conventional commit format (e.g. `fix(sqlserver): ...`)


### PR DESCRIPTION
* Adds `CODEOWNERS` so reviewers are added automatically
* Updates PR template to remove reference to soda-internal repos