### PR TITLE
feat(core): query timing, row counts, and DEBUG-formatting guards

### DIFF
--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -19,7 +19,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from logging import ERROR, WARNING, LogRecord
 from numbers import Number
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    # Type-only: the check-collection layer must not import the CLI layer at
+    # runtime (the CLI wiring imports this module).
+    from soda_core.cli.handlers.batched_scan import BatchedScanContext
 
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.datetime_conversions import convert_str_to_datetime
@@ -493,6 +498,7 @@ class CheckCollectionImpl:
         all_data_source_impls: Optional[dict[str, DataSourceImpl]] = None,
         dwh_files: Optional[DiagnosticsWarehouseFiles] = None,
         logs: Optional[Logs] = None,
+        batched_scan_context: Optional["BatchedScanContext"] = None,
     ):
         # Defer import: CheckImpl/ColumnImpl/MetricsResolver/RowCountMetricImpl live in
         # contract_verification_impl.py which imports this module.
@@ -502,6 +508,10 @@ class CheckCollectionImpl:
         from soda_core.contracts.impl.contract_verification_impl import MetricsResolver
 
         self.logs: Logs = logs if logs is not None else Logs()
+        # Set on managed batched-ingestion CLI runs (run_batched_scan); None
+        # everywhere else. Subtypes that publish results themselves consult it
+        # to route the upload through the async batch pipeline.
+        self.batched_scan_context: Optional["BatchedScanContext"] = batched_scan_context
         self.yaml: CheckCollectionYaml = yaml
         self.only_validate_without_execute: bool = only_validate_without_execute
         # Stamp this collection's ``thread`` label on every record it emits.

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -508,9 +508,9 @@ class CheckCollectionImpl:
         from soda_core.contracts.impl.contract_verification_impl import MetricsResolver
 
         self.logs: Logs = logs if logs is not None else Logs()
-        # Set on managed batched-ingestion CLI runs (run_batched_scan); None
-        # everywhere else. Subtypes that publish results themselves consult it
-        # to route the upload through the async batch pipeline.
+        # Set on CLI runs wired through run_batched_scan (the context is threaded regardless of whether the run
+        # is managed — its scan_id discriminates); None on every other construction path. Subtypes that publish
+        # results themselves consult it to open the async ingestion bracket and route the upload through it.
         self.batched_scan_context: Optional["BatchedScanContext"] = batched_scan_context
         self.yaml: CheckCollectionYaml = yaml
         self.only_validate_without_execute: bool = only_validate_without_execute

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -13,7 +13,12 @@ with a 1-element ``contract_yaml_sources`` list) sets
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    # Type-only: the check-collection layer must not import the CLI layer at
+    # runtime (the CLI wiring imports this module).
+    from soda_core.cli.handlers.batched_scan import BatchedScanContext
 
 from soda_core.check_collections.base import (
     CheckCollectionImpl,
@@ -55,6 +60,7 @@ def execute_check_collections(
     dwh_files: Optional[DiagnosticsWarehouseFiles] = None,
     abort_on_first_error: bool = False,
     logs: Optional[Logs] = None,
+    batched_scan_context: Optional["BatchedScanContext"] = None,
     primary_data_source_impl: Optional[DataSourceImpl] = None,
     default_impl_class: Optional[type[CheckCollectionImpl]] = None,
     expected_kinds: Optional[set[str]] = None,
@@ -192,6 +198,7 @@ def execute_check_collections(
                 all_data_source_impls=all_data_source_impls,
                 dwh_files=dwh_files,
                 logs=logs,
+                batched_scan_context=batched_scan_context,
                 # ``data_timestamp`` and ``execution_timestamp`` are
                 # first-class fields on ``CheckCollectionYaml``: every
                 # subtype yaml has them after construction.

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -198,12 +198,15 @@ def execute_check_collections(
                 all_data_source_impls=all_data_source_impls,
                 dwh_files=dwh_files,
                 logs=logs,
-                batched_scan_context=batched_scan_context,
                 # ``data_timestamp`` and ``execution_timestamp`` are
                 # first-class fields on ``CheckCollectionYaml``: every
                 # subtype yaml has them after construction.
                 data_timestamp=yaml.data_timestamp,
                 execution_timestamp=yaml.execution_timestamp,
+                # Only when set: impl subclasses with explicit __init__
+                # signatures (e.g. ContractImpl) predate the kwarg, and the
+                # flows constructing them never run batched.
+                **({"batched_scan_context": batched_scan_context} if batched_scan_context is not None else {}),
             )
             constructed.append((impl, impl_class, None, yaml_source))
         except Exception as exc:

--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -9,6 +9,7 @@ from typing import Dict, List, NoReturn, Optional, Union
 
 from soda_core.__version__ import SODA_CORE_VERSION
 from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.batched_scan import run_batched_scan
 from soda_core.cli.handlers.contract import (
     handle_fetch_contract,
     handle_publish_contract,
@@ -556,18 +557,20 @@ def _setup_data_source_discover_command(data_source_parsers) -> None:
             # SODA_SCAN_DEFINITION) resolve inside the wrapped command: their
             # failures take the standard mark-with-logs mapping.
             # Discovery constructs no inner Logs (discover_dataset_dqns emits via soda_logger,
-            # which already lands in the active wrapper collector); the wrapper's
-            # ``logs`` is threaded through so the success payload carries the
-            # run's logs to Soda Cloud.
-            exit_code = run_with_failure_reporting(
+            # which already lands in the active capture target); the bracket's
+            # ``logs`` is threaded through so a sync run's payload carries the
+            # run's logs (a managed run streams them instead).
+            exit_code = run_batched_scan(
                 soda_cloud,
-                lambda logs: handle_discover_data_source(
+                stage="main",
+                command=lambda context: handle_discover_data_source(
                     resolve_data_source(args.data_source),
                     soda_cloud,
                     scan_definition_name=resolve_scan_definition_name(args.scan_definition_name),
                     include=args.include,
                     exclude=args.exclude,
-                    logs=logs,
+                    logs=context.logs,
+                    batched_scan_context=context,
                 ),
             )
             exit_with_code(exit_code)

--- a/soda-core/src/soda_core/cli/handlers/batched_scan.py
+++ b/soda-core/src/soda_core/cli/handlers/batched_scan.py
@@ -1,28 +1,22 @@
 """Batched scan ingestion for Cloud-launched CLI flows.
 
-A managed scan (``SODA_SCAN_ID`` set by the Runner/launcher) delivers nothing
-to Soda Cloud until the run ends: logs and results travel in one end-of-run
-payload. ``run_batched_scan`` brackets a results-publishing command so results
-go through the async ingestion pipeline (``sodaCoreScanStart`` →
-``sodaCoreInsertScanDataBatch`` → ``sodaCoreScanEndAsync``) and logs stream
-while it runs (scan-id-keyed ``batchV4``). Without a scan id it is exactly
-``run_with_failure_reporting`` + today's sync inserts.
+A managed scan (``SODA_SCAN_ID`` set by the Runner/launcher) delivers nothing to Soda Cloud until the run
+ends: logs and results travel in one end-of-run payload. ``run_batched_scan`` brackets a results-publishing
+command so results go through the async ingestion pipeline (``sodaCoreScanStart`` →
+``sodaCoreInsertScanDataBatch`` → ``sodaCoreScanEndAsync``) and logs stream while it runs (scan-id-keyed
+``batchV4``). Without a scan id it is exactly ``run_with_failure_reporting`` + today's sync inserts.
 
-The scan start cannot happen at bracket time: ``sodaCoreScanStart`` requires
-the scan-definition name, data source name and data timestamp, which each flow
-only knows once its dependencies resolve inside the wrapped command — and the
-backend only accepts ``batchV4`` log uploads after a successful start. The
-flow therefore calls ``context.start_scan(...)`` as soon as it has resolved
-those values (before its engine work, so the expensive phase streams); the
-context then upgrades the run's ``Logs`` from the in-memory collector to a
-streaming queue, replaying what was already captured. A run that never starts
-(ad-hoc, or a rejected start) stays fully in-memory, so its results payload
-carries the logs exactly as today and nothing is ever lost to a stream the
-backend would reject.
+The scan start cannot happen at bracket time: ``sodaCoreScanStart`` requires the scan-definition name, data
+source name and data timestamp, which each flow only knows once its dependencies resolve inside the wrapped
+command — and the backend only accepts ``batchV4`` log uploads after a successful start. The flow therefore
+calls ``context.start_scan(...)`` as soon as it has resolved those values (before its engine work, so the
+expensive phase streams); the context then upgrades the run's ``Logs`` from the in-memory collector to a
+streaming queue, replaying what was already captured. A run that never starts (ad-hoc, or a rejected start)
+stays fully in-memory, so its results payload carries the logs exactly as today and nothing is ever lost to a
+stream the backend would reject.
 
-This is opt-in composition sugar: the pieces (``build_streaming_logs``, the
-``SodaCloud`` transport methods, ``run_with_failure_reporting``) are usable
-directly by any target that needs a different shape.
+This is opt-in composition sugar: the pieces (``build_streaming_logs``, the ``SodaCloud`` transport methods,
+``run_with_failure_reporting``) are usable directly by any target that needs a different shape.
 """
 
 from __future__ import annotations
@@ -45,10 +39,11 @@ if TYPE_CHECKING:
 class BatchedScanContext:
     """What a batched-scan command needs from the bracket around it.
 
-    ``scan_id`` discriminates managed from ad-hoc runs (targets that must keep
-    a distinct ad-hoc path branch on it); ``scan_reference`` is set by a
-    successful ``start_scan`` — ``insert_results`` falls back to the sync
-    upload without it, so callers never branch on it for sending.
+    ``scan_id`` discriminates managed from ad-hoc runs (targets that must keep a distinct ad-hoc path branch on
+    it); ``scan_reference`` is set by a successful ``start_scan`` — ``insert_results`` falls back to the sync
+    upload without it, so callers never branch on it for sending. ``results_delivered`` records an acknowledged
+    upload: the bracket only closes the scan (``scan_end_async``) when it is set, so a run whose results never
+    made it leaves the scan open for the failure report / launcher fallback instead of ending it "cleanly".
     """
 
     logs: Logs
@@ -56,6 +51,7 @@ class BatchedScanContext:
     scan_id: Optional[str]
     stage: str = "main"
     scan_reference: Optional[str] = None
+    results_delivered: bool = field(default=False, repr=False)
     _start_attempted: bool = field(default=False, repr=False)
 
     def start_scan(
@@ -64,17 +60,14 @@ class BatchedScanContext:
         default_data_source: str,
         data_timestamp: Optional[datetime] = None,
     ) -> None:
-        """Open the async ingestion bracket once the flow has resolved the
-        backend-mandatory scan coordinates. Call before the engine work: on
-        success the run's logs switch to the scan's Cloud log stream (with the
-        records captured so far replayed into it), so the expensive phase is
-        visible mid-run. No-op on ad-hoc runs and on repeat calls; a rejected
-        start warns and leaves the run on the sync path with in-memory logs.
+        """Open the async ingestion bracket once the flow has resolved the backend-mandatory scan coordinates.
+        Call before the engine work: on success the run's logs switch to the scan's Cloud log stream (with the
+        records captured so far replayed into it), so the expensive phase is visible mid-run. No-op on ad-hoc
+        runs and on repeat calls; a rejected start warns and leaves the run on the sync path with in-memory
+        logs.
         """
-        # Deferred: importing logs_queue (and via it soda_cloud) before the
-        # contracts package initializes trips the pre-existing
-        # soda_cloud<->contracts import cycle — this module is imported early
-        # by cli.py.
+        # Deferred: importing logs_queue (and via it soda_cloud) before the contracts package initializes trips
+        # the pre-existing soda_cloud<->contracts import cycle — this module is imported early by cli.py.
         from soda_core.common.logs_queue import LogsQueue
 
         if not self.scan_id or self._start_attempted:
@@ -90,16 +83,21 @@ class BatchedScanContext:
             )
             return
         self.scan_reference = scan_reference
-        # The queue is adopted by the run's existing Logs (which stays the
-        # active capture target; the bracket owns its lifecycle).
+        # The queue is adopted by the run's existing Logs (which stays the active capture target; the bracket
+        # owns its lifecycle).
         self.logs.switch_gatherer(
             LogsQueue(soda_cloud=self.soda_cloud, stage=self.stage, scan_id=self.scan_id, dataset="")
         )
 
     def insert_results(self, payload: SodaCoreInsertScanResultsDTO) -> bool:
-        if self.scan_reference:
-            return self.soda_cloud.insert_scan_data_batch(payload, self.scan_reference)
-        return self.soda_cloud.insert_scan_results(payload)
+        accepted: bool = (
+            self.soda_cloud.insert_scan_data_batch(payload, self.scan_reference)
+            if self.scan_reference
+            else self.soda_cloud.insert_scan_results(payload)
+        )
+        if accepted:
+            self.results_delivered = True
+        return accepted
 
 
 def run_batched_scan(
@@ -110,32 +108,30 @@ def run_batched_scan(
     """Run a results-publishing command with batched ingestion when managed.
 
     Policies:
-    - No ``SODA_SCAN_ID`` → fully today's behavior: in-memory ``Logs``, and
-      ``context.insert_results`` is the sync ``insert_scan_results``.
-    - The command opens the bracket itself via ``context.start_scan`` once its
-      dependencies resolve; a failed/absent start degrades to the sync insert
-      with in-memory logs.
-    - Ordering: results insert (inside the command) → final log flush (the
-      wrapper's ``finally`` close) → ``scan_end_async``. On an escaped failure
-      the report goes out first, attaching the records the gatherer selects
-      (unsent errors when streaming).
-    - ``scan_end_async`` failure → warning, not fatal: results were already
-      acknowledged (or the failure already reported).
+    - No ``SODA_SCAN_ID`` → fully today's behavior: in-memory ``Logs``, and ``context.insert_results`` is the
+      sync ``insert_scan_results``.
+    - The command opens the bracket itself via ``context.start_scan`` once its dependencies resolve; a
+      failed/absent start degrades to the sync insert with in-memory logs.
+    - Ordering: results insert (inside the command) → final log flush (the wrapper's ``finally`` close) →
+      ``scan_end_async``. On an escaped failure the report goes out first, attaching the records the gatherer
+      selects (unsent errors when streaming).
+    - ``scan_end_async`` is only sent for a started scan whose results were acknowledged; a run that could not
+      deliver leaves the scan un-ended, so the failure report / the launcher's exit-code fallback owns its
+      terminal state instead of an empty "clean" end. An unaccepted end is a warning, not fatal.
     """
     from soda_core.cli.handlers.dependencies import run_with_failure_reporting
 
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
     logs = Logs()
     context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id=scan_id, stage=stage)
-    try:
-        # run_with_failure_reporting owns the Logs lifecycle: the failure
-        # report happens inside it, and its finally-close is the stream's
-        # final flush — both before scan_end_async below.
-        return run_with_failure_reporting(soda_cloud, lambda _logs: command(context), logs=logs)
-    finally:
-        if context.scan_reference is not None:
-            if not soda_cloud.scan_end_async(context.scan_reference):
-                soda_logger.warning(
-                    f"sodaCoreScanEndAsync for scanReference '{context.scan_reference}' was not accepted; "
-                    f"the scan's results were already acknowledged."
-                )
+    # run_with_failure_reporting owns the Logs lifecycle: the failure report happens inside it, and its
+    # finally-close is the stream's final flush — both before scan_end_async below. Deliberately NOT a
+    # try/finally around the end: a BaseException (KeyboardInterrupt, SystemExit) must not end the scan either.
+    exit_code: ExitCode = run_with_failure_reporting(soda_cloud, lambda _logs: command(context), logs=logs)
+    if context.scan_reference is not None and context.results_delivered:
+        if not soda_cloud.scan_end_async(context.scan_reference):
+            soda_logger.warning(
+                f"sodaCoreScanEndAsync for scanReference '{context.scan_reference}' was not accepted; "
+                f"the scan's results were already acknowledged."
+            )
+    return exit_code

--- a/soda-core/src/soda_core/cli/handlers/batched_scan.py
+++ b/soda-core/src/soda_core/cli/handlers/batched_scan.py
@@ -2,11 +2,23 @@
 
 A managed scan (``SODA_SCAN_ID`` set by the Runner/launcher) delivers nothing
 to Soda Cloud until the run ends: logs and results travel in one end-of-run
-payload. ``run_batched_scan`` brackets a results-publishing command so logs
-stream while it runs (scan-id-keyed ``batchV4``) and results go through the
-async ingestion pipeline (``sodaCoreScanStart`` → ``sodaCoreInsertScanDataBatch``
-→ ``sodaCoreScanEndAsync``). Without a scan id it is exactly
+payload. ``run_batched_scan`` brackets a results-publishing command so results
+go through the async ingestion pipeline (``sodaCoreScanStart`` →
+``sodaCoreInsertScanDataBatch`` → ``sodaCoreScanEndAsync``) and logs stream
+while it runs (scan-id-keyed ``batchV4``). Without a scan id it is exactly
 ``run_with_failure_reporting`` + today's sync inserts.
+
+The scan start cannot happen at bracket time: ``sodaCoreScanStart`` requires
+the scan-definition name, data source name and data timestamp, which each flow
+only knows once its dependencies resolve inside the wrapped command — and the
+backend only accepts ``batchV4`` log uploads after a successful start. The
+flow therefore calls ``context.start_scan(...)`` as soon as it has resolved
+those values (before its engine work, so the expensive phase streams); the
+context then upgrades the run's ``Logs`` from the in-memory collector to a
+streaming queue, replaying what was already captured. A run that never starts
+(ad-hoc, or a rejected start) stays fully in-memory, so its results payload
+carries the logs exactly as today and nothing is ever lost to a stream the
+backend would reject.
 
 This is opt-in composition sugar: the pieces (``build_streaming_logs``, the
 ``SodaCloud`` transport methods, ``run_with_failure_reporting``) are usable
@@ -15,7 +27,8 @@ directly by any target that needs a different shape.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Optional
 
 from soda_core.cli.exit_codes import ExitCode
@@ -33,15 +46,55 @@ class BatchedScanContext:
     """What a batched-scan command needs from the bracket around it.
 
     ``scan_id`` discriminates managed from ad-hoc runs (targets that must keep
-    a distinct ad-hoc path branch on it); ``scan_reference`` is None when the
-    run is ad-hoc or ``scan_start`` degraded — ``insert_results`` then falls
-    back to the sync upload, so callers never branch on it for sending.
+    a distinct ad-hoc path branch on it); ``scan_reference`` is set by a
+    successful ``start_scan`` — ``insert_results`` falls back to the sync
+    upload without it, so callers never branch on it for sending.
     """
 
     logs: Logs
     soda_cloud: SodaCloud
     scan_id: Optional[str]
-    scan_reference: Optional[str]
+    stage: str = "main"
+    scan_reference: Optional[str] = None
+    _start_attempted: bool = field(default=False, repr=False)
+
+    def start_scan(
+        self,
+        definition_name: str,
+        default_data_source: str,
+        data_timestamp: Optional[datetime] = None,
+    ) -> None:
+        """Open the async ingestion bracket once the flow has resolved the
+        backend-mandatory scan coordinates. Call before the engine work: on
+        success the run's logs switch to the scan's Cloud log stream (with the
+        records captured so far replayed into it), so the expensive phase is
+        visible mid-run. No-op on ad-hoc runs and on repeat calls; a rejected
+        start warns and leaves the run on the sync path with in-memory logs.
+        """
+        # Deferred: importing logs_queue (and via it soda_cloud) before the
+        # contracts package initializes trips the pre-existing
+        # soda_cloud<->contracts import cycle — this module is imported early
+        # by cli.py.
+        from soda_core.common.logs_queue import LogsQueue
+
+        if not self.scan_id or self._start_attempted:
+            return
+        self._start_attempted = True
+        scan_reference: Optional[str] = self.soda_cloud.scan_start(
+            self.scan_id, definition_name, default_data_source, data_timestamp
+        )
+        if scan_reference is None:
+            soda_logger.warning(
+                "Could not start the batched-ingestion scan on Soda Cloud; "
+                "falling back to the synchronous results upload with in-memory logs."
+            )
+            return
+        self.scan_reference = scan_reference
+        # The queue is adopted by the run's existing Logs (which stays the
+        # active capture target; the bracket owns its lifecycle).
+        self.logs.switch_gatherer(
+            LogsQueue(soda_cloud=self.soda_cloud, stage=self.stage, scan_id=self.scan_id, dataset="")
+        )
 
     def insert_results(self, payload: SodaCoreInsertScanResultsDTO) -> bool:
         if self.scan_reference:
@@ -53,53 +106,36 @@ def run_batched_scan(
     soda_cloud: SodaCloud,
     stage: str,
     command: Callable[[BatchedScanContext], ExitCode],
-    definition_name: Optional[str] = None,
-    default_data_source: Optional[str] = None,
 ) -> ExitCode:
     """Run a results-publishing command with batched ingestion when managed.
 
     Policies:
     - No ``SODA_SCAN_ID`` → fully today's behavior: in-memory ``Logs``, and
       ``context.insert_results`` is the sync ``insert_scan_results``.
-    - ``scan_start`` failure → warn and degrade to the sync insert; log
-      streaming keeps running (``batchV4`` is keyed by scan id, not
-      scanReference).
+    - The command opens the bracket itself via ``context.start_scan`` once its
+      dependencies resolve; a failed/absent start degrades to the sync insert
+      with in-memory logs.
     - Ordering: results insert (inside the command) → final log flush (the
-      wrapper's ``finally`` close) → ``scan_end_async``. On an escaped
-      failure the report goes out first, attaching the records the gatherer
-      selects (unsent errors when streaming).
+      wrapper's ``finally`` close) → ``scan_end_async``. On an escaped failure
+      the report goes out first, attaching the records the gatherer selects
+      (unsent errors when streaming).
     - ``scan_end_async`` failure → warning, not fatal: results were already
       acknowledged (or the failure already reported).
     """
-    # Deferred: importing soda_cloud (via these modules) before the contracts
-    # package initializes trips the pre-existing soda_cloud<->contracts import
-    # cycle — this module is imported early by cli.py.
-    from soda_core.cli.handlers.data_source import build_streaming_logs
     from soda_core.cli.handlers.dependencies import run_with_failure_reporting
 
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
-    logs: Optional[Logs] = build_streaming_logs(soda_cloud, stage, scan_id) if scan_id else None
-    logs = logs if logs is not None else Logs()
-
-    scan_reference: Optional[str] = None
-    if scan_id:
-        scan_reference = soda_cloud.scan_start(scan_id, definition_name, default_data_source)
-        if scan_reference is None:
-            soda_logger.warning(
-                "Could not start the batched-ingestion scan on Soda Cloud; "
-                "falling back to the synchronous results upload."
-            )
-
-    context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id=scan_id, scan_reference=scan_reference)
+    logs = Logs()
+    context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id=scan_id, stage=stage)
     try:
         # run_with_failure_reporting owns the Logs lifecycle: the failure
         # report happens inside it, and its finally-close is the stream's
         # final flush — both before scan_end_async below.
         return run_with_failure_reporting(soda_cloud, lambda _logs: command(context), logs=logs)
     finally:
-        if scan_reference is not None:
-            if not soda_cloud.scan_end_async(scan_reference):
+        if context.scan_reference is not None:
+            if not soda_cloud.scan_end_async(context.scan_reference):
                 soda_logger.warning(
-                    f"sodaCoreScanEndAsync for scanReference '{scan_reference}' was not accepted; "
+                    f"sodaCoreScanEndAsync for scanReference '{context.scan_reference}' was not accepted; "
                     f"the scan's results were already acknowledged."
                 )

--- a/soda-core/src/soda_core/cli/handlers/batched_scan.py
+++ b/soda-core/src/soda_core/cli/handlers/batched_scan.py
@@ -13,17 +13,19 @@ This is opt-in composition sugar: the pieces (``build_streaming_logs``, the
 directly by any target that needs a different shape.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.data_source import build_streaming_logs
-from soda_core.cli.handlers.dependencies import run_with_failure_reporting
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
-from soda_core.common.soda_cloud import SodaCloud
-from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO
+
+if TYPE_CHECKING:
+    from soda_core.common.soda_cloud import SodaCloud
+    from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO
 
 
 @dataclass
@@ -69,6 +71,12 @@ def run_batched_scan(
     - ``scan_end_async`` failure → warning, not fatal: results were already
       acknowledged (or the failure already reported).
     """
+    # Deferred: importing soda_cloud (via these modules) before the contracts
+    # package initializes trips the pre-existing soda_cloud<->contracts import
+    # cycle — this module is imported early by cli.py.
+    from soda_core.cli.handlers.data_source import build_streaming_logs
+    from soda_core.cli.handlers.dependencies import run_with_failure_reporting
+
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
     logs: Optional[Logs] = build_streaming_logs(soda_cloud, stage, scan_id) if scan_id else None
     logs = logs if logs is not None else Logs()

--- a/soda-core/src/soda_core/cli/handlers/batched_scan.py
+++ b/soda-core/src/soda_core/cli/handlers/batched_scan.py
@@ -1,0 +1,97 @@
+"""Batched scan ingestion for Cloud-launched CLI flows.
+
+A managed scan (``SODA_SCAN_ID`` set by the Runner/launcher) delivers nothing
+to Soda Cloud until the run ends: logs and results travel in one end-of-run
+payload. ``run_batched_scan`` brackets a results-publishing command so logs
+stream while it runs (scan-id-keyed ``batchV4``) and results go through the
+async ingestion pipeline (``sodaCoreScanStart`` → ``sodaCoreInsertScanDataBatch``
+→ ``sodaCoreScanEndAsync``). Without a scan id it is exactly
+``run_with_failure_reporting`` + today's sync inserts.
+
+This is opt-in composition sugar: the pieces (``build_streaming_logs``, the
+``SodaCloud`` transport methods, ``run_with_failure_reporting``) are usable
+directly by any target that needs a different shape.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.data_source import build_streaming_logs
+from soda_core.cli.handlers.dependencies import run_with_failure_reporting
+from soda_core.common.env_config_helper import EnvConfigHelper
+from soda_core.common.logging_constants import soda_logger
+from soda_core.common.logs import Logs
+from soda_core.common.soda_cloud import SodaCloud
+from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO
+
+
+@dataclass
+class BatchedScanContext:
+    """What a batched-scan command needs from the bracket around it.
+
+    ``scan_id`` discriminates managed from ad-hoc runs (targets that must keep
+    a distinct ad-hoc path branch on it); ``scan_reference`` is None when the
+    run is ad-hoc or ``scan_start`` degraded — ``insert_results`` then falls
+    back to the sync upload, so callers never branch on it for sending.
+    """
+
+    logs: Logs
+    soda_cloud: SodaCloud
+    scan_id: Optional[str]
+    scan_reference: Optional[str]
+
+    def insert_results(self, payload: SodaCoreInsertScanResultsDTO) -> bool:
+        if self.scan_reference:
+            return self.soda_cloud.insert_scan_data_batch(payload, self.scan_reference)
+        return self.soda_cloud.insert_scan_results(payload)
+
+
+def run_batched_scan(
+    soda_cloud: SodaCloud,
+    stage: str,
+    command: Callable[[BatchedScanContext], ExitCode],
+    definition_name: Optional[str] = None,
+    default_data_source: Optional[str] = None,
+) -> ExitCode:
+    """Run a results-publishing command with batched ingestion when managed.
+
+    Policies:
+    - No ``SODA_SCAN_ID`` → fully today's behavior: in-memory ``Logs``, and
+      ``context.insert_results`` is the sync ``insert_scan_results``.
+    - ``scan_start`` failure → warn and degrade to the sync insert; log
+      streaming keeps running (``batchV4`` is keyed by scan id, not
+      scanReference).
+    - Ordering: results insert (inside the command) → final log flush (the
+      wrapper's ``finally`` close) → ``scan_end_async``. On an escaped
+      failure the report goes out first, attaching the records the gatherer
+      selects (unsent errors when streaming).
+    - ``scan_end_async`` failure → warning, not fatal: results were already
+      acknowledged (or the failure already reported).
+    """
+    scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
+    logs: Optional[Logs] = build_streaming_logs(soda_cloud, stage, scan_id) if scan_id else None
+    logs = logs if logs is not None else Logs()
+
+    scan_reference: Optional[str] = None
+    if scan_id:
+        scan_reference = soda_cloud.scan_start(scan_id, definition_name, default_data_source)
+        if scan_reference is None:
+            soda_logger.warning(
+                "Could not start the batched-ingestion scan on Soda Cloud; "
+                "falling back to the synchronous results upload."
+            )
+
+    context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id=scan_id, scan_reference=scan_reference)
+    try:
+        # run_with_failure_reporting owns the Logs lifecycle: the failure
+        # report happens inside it, and its finally-close is the stream's
+        # final flush — both before scan_end_async below.
+        return run_with_failure_reporting(soda_cloud, lambda _logs: command(context), logs=logs)
+    finally:
+        if scan_reference is not None:
+            if not soda_cloud.scan_end_async(scan_reference):
+                soda_logger.warning(
+                    f"sodaCoreScanEndAsync for scanReference '{scan_reference}' was not accepted; "
+                    f"the scan's results were already acknowledged."
+                )

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -93,19 +93,48 @@ def handle_test_data_source(
             upload_logs.close()
 
 
+def build_streaming_logs(
+    soda_cloud: Optional[SodaCloud],
+    stage: str,
+    scan_id: Optional[str] = None,
+) -> Optional[Logs]:
+    """Returns a ``Logs`` backed by a ``LogsQueue`` bound to the scan id, so
+    root-logger records stream to the scan's Soda Cloud log stream while the
+    command runs — or None when there is no scan id / Cloud client, so callers
+    fall back to an in-memory ``Logs``. Must be closed to flush the final batch.
+
+    ``stage`` is a closed backend enum (``CoreStageType``: "main" |
+    "diagnosticWarehouse"; unknown values degrade to MAIN server-side).
+    """
+    if scan_id is None:
+        # The scan id is a Cloud-only concept set by the Runner/launcher as SODA_SCAN_ID; it is
+        # read from the env helper rather than a CLI argument so the generic CLI stays Cloud-agnostic.
+        scan_id = EnvConfigHelper().soda_scan_id
+    if not scan_id or soda_cloud is None:
+        return None
+
+    logs_queue = LogsQueue(
+        soda_cloud=soda_cloud,
+        stage=stage,
+        scan_id=scan_id,
+        dataset="",
+    )
+    return Logs(gatherer=logs_queue)
+
+
 def build_test_connection_log_uploader(
     soda_cloud_file_path: Optional[str],
 ) -> Optional[Logs]:
-    """Returns a ``Logs`` backed by a ``LogsQueue`` bound to the scan id, so
-    root-logger records during the test stream to Soda Cloud — or None when
-    there is no scan id / cloud config. Must be closed to flush the final batch.
+    """File-path-resolving wrapper around ``build_streaming_logs`` for
+    connection tests: resolves the Cloud client from the ``-sc`` YAML, streams
+    to the scan's main stage. Returns None when there is no scan id / cloud
+    config. Must be closed to flush the final batch.
 
     Public because connection-test commands outside soda-core (e.g. the
     soda-extensions ``diagnostics-warehouse test`` command) reuse it to stream
-    their logs to the same scan-id-keyed endpoint.
+    their logs to the same scan-id-keyed endpoint; flows that already hold a
+    ``SodaCloud`` call ``build_streaming_logs`` directly.
     """
-    # The scan id is a Cloud-only concept set by the Runner/launcher as SODA_SCAN_ID; it is
-    # read from the env helper rather than a CLI argument so the generic CLI stays Cloud-agnostic.
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
     if not scan_id or not soda_cloud_file_path:
         return None
@@ -126,13 +155,7 @@ def build_test_connection_log_uploader(
         soda_logger.warning("Soda Cloud configuration could not be parsed; test-connection logs will not be uploaded.")
         return None
 
-    logs_queue = LogsQueue(
-        soda_cloud=soda_cloud,
-        stage="test_connection",
-        scan_id=scan_id,
-        dataset="",
-    )
-    return Logs(gatherer=logs_queue)
+    return build_streaming_logs(soda_cloud=soda_cloud, stage="main", scan_id=scan_id)
 
 
 def _discover_dqns(

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -205,15 +205,28 @@ def handle_discover_data_source(
     failure: it returns ``RESULTS_NOT_SENT_TO_CLOUD`` directly, so no failure
     report is sent.
 
-    With a ``batched_scan_context`` the upload routes through
+    With a ``batched_scan_context`` the run opens the async ingestion bracket
+    here — the handler is the first point where the scan coordinates
+    (definition name, data source name, data timestamp) are all resolved — so
+    the discovery queries stream their logs, and the upload routes through
     ``context.insert_results`` (async batch pipeline on managed runs, sync
-    fallback otherwise); the payload build is unchanged — a streaming-backed
-    ``logs`` yields no records, so the payload's ``logs`` field is empty and
-    the stream stays the single log channel.
+    fallback otherwise). The payload build is unchanged: once streaming, the
+    ``logs`` yield no records, so the payload's ``logs`` field is empty and the
+    stream stays the single log channel.
     """
-    from soda_core.discovery.discovery_payload import build_discovery_payload
+    from soda_core.discovery.discovery_payload import (
+        build_discovery_payload,
+        resolve_data_timestamp,
+    )
 
     soda_logger.info(f"Discovering datasets in data source '{data_source_impl.name}'")
+
+    if batched_scan_context is not None:
+        batched_scan_context.start_scan(
+            definition_name=scan_definition_name,
+            default_data_source=data_source_impl.name,
+            data_timestamp=resolve_data_timestamp(datetime.now(timezone.utc)),
+        )
 
     scan_start_timestamp: datetime = datetime.now(timezone.utc)
     dqns: list[str] = _discover_dqns(data_source_impl, include, exclude)

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -101,13 +101,15 @@ def build_streaming_logs(
     stage: str,
     scan_id: Optional[str] = None,
 ) -> Optional[Logs]:
-    """Returns a ``Logs`` backed by a ``LogsQueue`` bound to the scan id, so
-    root-logger records stream to the scan's Soda Cloud log stream while the
-    command runs — or None when there is no scan id / Cloud client, so callers
-    fall back to an in-memory ``Logs``. Must be closed to flush the final batch.
+    """Returns a ``Logs`` backed by a ``LogsQueue`` bound to the scan id, so root-logger records stream to the
+    scan's Soda Cloud log stream while the command runs — or None when there is no scan id / Cloud client, so
+    callers fall back to an in-memory ``Logs``. Must be closed to flush the final batch. The backend only
+    accepts these uploads once the scan is started (``sodaCoreScanStart``) — flows that publish results open
+    that bracket via ``BatchedScanContext.start_scan``, which builds its queue itself; this builder serves the
+    connection-test commands (whose scans accept logs without a start) and direct composition.
 
-    ``stage`` is a closed backend enum (``CoreStageType``: "main" |
-    "diagnosticWarehouse"; unknown values degrade to MAIN server-side).
+    ``stage`` is a closed backend enum (``CoreStageType``: "main" | "diagnosticWarehouse"; unknown values
+    degrade to MAIN server-side).
     """
     if scan_id is None:
         # The scan id is a Cloud-only concept set by the Runner/launcher as SODA_SCAN_ID; it is
@@ -128,15 +130,12 @@ def build_streaming_logs(
 def build_test_connection_log_uploader(
     soda_cloud_file_path: Optional[str],
 ) -> Optional[Logs]:
-    """File-path-resolving wrapper around ``build_streaming_logs`` for
-    connection tests: resolves the Cloud client from the ``-sc`` YAML, streams
-    to the scan's main stage. Returns None when there is no scan id / cloud
-    config. Must be closed to flush the final batch.
+    """File-path-resolving wrapper around ``build_streaming_logs`` for connection tests: resolves the Cloud
+    client from the ``-sc`` YAML, streams to the scan's main stage. Returns None when there is no scan id /
+    cloud config. Must be closed to flush the final batch.
 
-    Public because connection-test commands outside soda-core (e.g. the
-    soda-extensions ``diagnostics-warehouse test`` command) reuse it to stream
-    their logs to the same scan-id-keyed endpoint; flows that already hold a
-    ``SodaCloud`` call ``build_streaming_logs`` directly.
+    Public because connection-test commands outside soda-core (e.g. the soda-extensions
+    ``diagnostics-warehouse test`` command) reuse it to stream their logs to the same scan-id-keyed endpoint.
     """
     scan_id: Optional[str] = EnvConfigHelper().soda_scan_id
     if not scan_id or not soda_cloud_file_path:
@@ -205,14 +204,12 @@ def handle_discover_data_source(
     failure: it returns ``RESULTS_NOT_SENT_TO_CLOUD`` directly, so no failure
     report is sent.
 
-    With a ``batched_scan_context`` the run opens the async ingestion bracket
-    here — the handler is the first point where the scan coordinates
-    (definition name, data source name, data timestamp) are all resolved — so
-    the discovery queries stream their logs, and the upload routes through
-    ``context.insert_results`` (async batch pipeline on managed runs, sync
-    fallback otherwise). The payload build is unchanged: once streaming, the
-    ``logs`` yield no records, so the payload's ``logs`` field is empty and the
-    stream stays the single log channel.
+    With a ``batched_scan_context`` the run opens the async ingestion bracket here — the handler is the first
+    point where the scan coordinates (definition name, data source name, data timestamp) are all resolved — so
+    the discovery queries stream their logs, and the upload routes through ``context.insert_results`` (async
+    batch pipeline on managed runs, sync fallback otherwise). The payload build is unchanged: once streaming,
+    the ``logs`` yield no records, so the payload's ``logs`` field is empty and the stream stays the single log
+    channel.
     """
     from soda_core.discovery.discovery_payload import (
         build_discovery_payload,
@@ -221,11 +218,14 @@ def handle_discover_data_source(
 
     soda_logger.info(f"Discovering datasets in data source '{data_source_impl.name}'")
 
+    # One dataTimestamp for the whole scan: sodaCoreScanStart and the results payload must carry the same value
+    # (SODA_SCAN_DATA_TIMESTAMP from the launcher, now otherwise).
+    data_timestamp: datetime = resolve_data_timestamp(datetime.now(timezone.utc))
     if batched_scan_context is not None:
         batched_scan_context.start_scan(
             definition_name=scan_definition_name,
             default_data_source=data_source_impl.name,
-            data_timestamp=resolve_data_timestamp(datetime.now(timezone.utc)),
+            data_timestamp=data_timestamp,
         )
 
     scan_start_timestamp: datetime = datetime.now(timezone.utc)
@@ -236,6 +236,7 @@ def handle_discover_data_source(
         dqns=dqns,
         data_source_name=data_source_impl.name,
         scan_definition_name=scan_definition_name,
+        data_timestamp=data_timestamp,
         scan_start_timestamp=scan_start_timestamp,
         scan_end_timestamp=scan_end_timestamp,
         log_records=logs.get_log_records() if logs else None,

--- a/soda-core/src/soda_core/cli/handlers/data_source.py
+++ b/soda-core/src/soda_core/cli/handlers/data_source.py
@@ -15,6 +15,9 @@ from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import DataSourceYamlSource, SodaCloudYamlSource
 
 if TYPE_CHECKING:
+    # batched_scan imports build_streaming_logs from this module: type-only to
+    # keep the runtime import acyclic.
+    from soda_core.cli.handlers.batched_scan import BatchedScanContext
     from soda_core.common.data_source_impl import DataSourceImpl
     from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO
 
@@ -190,15 +193,23 @@ def handle_discover_data_source(
     include: Optional[list[str]] = None,
     exclude: Optional[list[str]] = None,
     logs: Optional[Logs] = None,
+    batched_scan_context: Optional["BatchedScanContext"] = None,
 ) -> ExitCode:
     """Discover datasets and send the results to Soda Cloud.
 
     Receives fully resolved dependencies — including the mandatory scan
     definition name (``resolve_scan_definition_name``). Engine failures
-    propagate raw: the CLI wiring (``dependencies.run_with_failure_reporting``)
-    is the single logging site and maps them to failure reporting. A rejected
-    results upload is not an engine failure: it returns
-    ``RESULTS_NOT_SENT_TO_CLOUD`` directly, so no failure report is sent.
+    propagate raw: the CLI wiring (``run_batched_scan`` /
+    ``dependencies.run_with_failure_reporting``) is the single logging site and
+    maps them to failure reporting. A rejected results upload is not an engine
+    failure: it returns ``RESULTS_NOT_SENT_TO_CLOUD`` directly, so no failure
+    report is sent.
+
+    With a ``batched_scan_context`` the upload routes through
+    ``context.insert_results`` (async batch pipeline on managed runs, sync
+    fallback otherwise); the payload build is unchanged — a streaming-backed
+    ``logs`` yields no records, so the payload's ``logs`` field is empty and
+    the stream stays the single log channel.
     """
     from soda_core.discovery.discovery_payload import build_discovery_payload
 
@@ -216,7 +227,12 @@ def handle_discover_data_source(
         scan_end_timestamp=scan_end_timestamp,
         log_records=logs.get_log_records() if logs else None,
     )
-    if not soda_cloud.insert_scan_results(payload):
+    accepted: bool = (
+        batched_scan_context.insert_results(payload)
+        if batched_scan_context is not None
+        else soda_cloud.insert_scan_results(payload)
+    )
+    if not accepted:
         soda_logger.error(f"{Emoticons.POLICE_CAR_LIGHT} Discovery results were not accepted by Soda Cloud.")
         return ExitCode.RESULTS_NOT_SENT_TO_CLOUD
 

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -168,12 +168,10 @@ def run_with_failure_reporting(
     captured, so it is part of the report). Otherwise the command's own exit
     code is returned unchanged.
 
-    A pre-built ``logs`` (e.g. a streaming-backed ``Logs`` from
-    ``build_streaming_logs``) may be handed in; the gatherer then decides what
-    the failure report attaches — the full record list for the in-memory
-    collector, only unsent error records for a streaming queue. No mode branch
-    here. The lifecycle is owned here either way: the ``finally`` close is the
-    stream's final flush.
+    A pre-built ``logs`` (e.g. the batched-scan bracket's, which may upgrade to a streaming gatherer mid-run)
+    may be handed in; the gatherer then decides what the failure report attaches — the full record list for the
+    in-memory collector, only unsent error records for a streaming queue. No mode branch here. The lifecycle is
+    owned here either way: the ``finally`` close is the stream's final flush.
     """
     logs = logs if logs is not None else Logs()
     try:

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -138,6 +138,7 @@ def resolve_scan_definition_name(scan_definition_name: Optional[str]) -> str:
 def run_with_failure_reporting(
     soda_cloud: Optional[SodaCloud],
     command: Callable[[Logs], ExitCode],
+    logs: Optional[Logs] = None,
 ) -> ExitCode:
     """Run a command with every failure mapped to an exit code and reported to
     Soda Cloud in one place.
@@ -162,19 +163,26 @@ def run_with_failure_reporting(
       user-facing message is logged clean, without a traceback.
     - Any other exception: unexpected — logged with the traceback.
 
-    Both then report via ``report_scan_execution_failure`` with the captured
-    log records (the failure line is logged before the records are captured,
-    so it is part of the report). Otherwise the command's own exit code is
-    returned unchanged.
+    Both then report via ``report_scan_execution_failure`` with the records
+    the gatherer selects (the failure line is logged before the records are
+    captured, so it is part of the report). Otherwise the command's own exit
+    code is returned unchanged.
+
+    A pre-built ``logs`` (e.g. a streaming-backed ``Logs`` from
+    ``build_streaming_logs``) may be handed in; the gatherer then decides what
+    the failure report attaches — the full record list for the in-memory
+    collector, only unsent error records for a streaming queue. No mode branch
+    here. The lifecycle is owned here either way: the ``finally`` close is the
+    stream's final flush.
     """
-    logs: Logs = Logs()
+    logs = logs if logs is not None else Logs()
     try:
         return command(logs)
     except ScanExecutionFailedException as exc:
         soda_logger.error(f"{Emoticons.POLICE_CAR_LIGHT} {exc}")
-        return report_scan_execution_failure(soda_cloud, logs.get_log_records())
+        return report_scan_execution_failure(soda_cloud, logs.records_for_failure_report())
     except Exception as exc:
         soda_logger.exception(f"Scan execution failed: {exc}")
-        return report_scan_execution_failure(soda_cloud, logs.get_log_records())
+        return report_scan_execution_failure(soda_cloud, logs.records_for_failure_report())
     finally:
         logs.close()

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -4,8 +4,10 @@ import contextlib
 import logging
 import os
 import re
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any, Callable, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -16,6 +18,21 @@ from soda_core.common.logging_constants import soda_logger
 logger: logging.Logger = soda_logger
 
 from tabulate import tabulate
+
+
+@dataclass
+class QueryCounters:
+    """Per-connection query counters that callers (extensions building scan
+    summaries) read directly. Deliberately dumb and public: a plain
+    count/duration accumulator with no locking, since a single connection is
+    only ever driven by one thread at a time."""
+
+    query_count: int = 0
+    total_duration_seconds: float = 0.0
+
+    def record(self, duration_seconds: float) -> None:
+        self.query_count += 1
+        self.total_duration_seconds += duration_seconds
 
 
 class MemoryOptimizedDriverSettings:
@@ -204,6 +221,7 @@ class DataSourceConnection(ABC):
         self.connection_properties: dict = connection_properties
         self.connection: Optional[object] = connection
         self._session_timezone_cache: Optional[tzinfo] = None
+        self.query_counters: QueryCounters = QueryCounters()
 
         # Auto-open on creation if no connection already supplied. See DataSource.open_connection()
         self.open_connection()
@@ -307,6 +325,7 @@ class DataSourceConnection(ABC):
     def execute_query(self, sql: str, log_query: bool = True) -> QueryResult:
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
+        start_time: float = time.perf_counter()
         try:
             if log_query:
                 logger.debug(
@@ -316,26 +335,34 @@ class DataSourceConnection(ABC):
             cursor.execute(sql)
             rows = cursor.fetchall()
             formatted_rows = self._format_rows(rows)
-            truncated_rows = self.truncate_rows(formatted_rows)
-            headers = [self._execute_query_get_result_row_column_name(c) for c in cursor.description]
-            # The tabulate can crash if the rows contain non-ASCII characters.
-            # This is purely for debugging/logging purposes, so we can try/catch this.
-            try:
-                table_text: str = tabulate(
-                    truncated_rows,
-                    headers=headers,
-                    tablefmt="github",
-                )
-            except UnicodeDecodeError as e:
-                logger.debug(f"Error formatting rows. These may contain non-ASCII characters. {e}")
-                table_text = "Error formatting rows. These may contain non-ASCII characters."
-            except Exception as e:
-                logger.debug(f"Error formatting rows. {e}")
-                table_text = f"Error formatting rows. This may be due to the rows containing non-ASCII characters.\n{e}"
+            duration_seconds: float = time.perf_counter() - start_time
+            self.query_counters.record(duration_seconds)
 
-            logger.debug(
-                f"SQL query result (max {self.MAX_ROWS} rows, {self.MAX_CHARS_PER_STRING} chars per string):\n{table_text}"
-            )
+            # Truncating/tabulating the result set is purely for DEBUG-level
+            # logging, so skip that work entirely when DEBUG is disabled.
+            if logger.isEnabledFor(logging.DEBUG):
+                truncated_rows = self.truncate_rows(formatted_rows)
+                headers = [self._execute_query_get_result_row_column_name(c) for c in cursor.description]
+                # The tabulate can crash if the rows contain non-ASCII characters.
+                # This is purely for debugging/logging purposes, so we can try/catch this.
+                try:
+                    table_text: str = tabulate(
+                        truncated_rows,
+                        headers=headers,
+                        tablefmt="github",
+                    )
+                except UnicodeDecodeError as e:
+                    logger.debug(f"Error formatting rows. These may contain non-ASCII characters. {e}")
+                    table_text = "Error formatting rows. These may contain non-ASCII characters."
+                except Exception as e:
+                    logger.debug(f"Error formatting rows. {e}")
+                    table_text = (
+                        f"Error formatting rows. This may be due to the rows containing non-ASCII characters.\n{e}"
+                    )
+
+                logger.debug(
+                    f"SQL query result in {duration_seconds:.3f}s ({len(formatted_rows)} rows, max {self.MAX_ROWS} shown, {self.MAX_CHARS_PER_STRING} chars per string):\n{table_text}"
+                )
             return QueryResult(rows=formatted_rows, columns=cursor.description)
         finally:
             cursor.close()
@@ -372,10 +399,15 @@ class DataSourceConnection(ABC):
     def execute_update(self, sql: str, log_query: bool = True) -> int:
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
+        start_time: float = time.perf_counter()
         try:
             if log_query:
                 logger.debug(f"SQL update (first {self.MAX_CHARS_PER_SQL} chars): \n{self.truncate_sql(sql)}")
-            return self._cursor_execute_update_and_commit(cursor, sql)
+            rowcount: int = self._cursor_execute_update_and_commit(cursor, sql)
+            duration_seconds: float = time.perf_counter() - start_time
+            self.query_counters.record(duration_seconds)
+            logger.debug(f"SQL update affected {rowcount} rows in {duration_seconds:.3f}s")
+            return rowcount
 
         finally:
             cursor.close()
@@ -403,9 +435,12 @@ class DataSourceConnection(ABC):
         """
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
+        start_time: float = time.perf_counter()
         try:
             if log_query:
-                logger.debug(f"SQL query fetch one-by-one:\n{sql}")
+                logger.debug(
+                    f"SQL query fetch one-by-one (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}"
+                )
             cursor.execute(sql)
 
             description: tuple[tuple] = cursor.description
@@ -417,6 +452,10 @@ class DataSourceConnection(ABC):
                 rows_processed += 1
                 row_callback(row, description)
                 row = cursor.fetchone()
+
+            duration_seconds: float = time.perf_counter() - start_time
+            self.query_counters.record(duration_seconds)
+            logger.debug(f"SQL query fetch one-by-one processed {rows_processed} rows in {duration_seconds:.3f}s")
 
         finally:
             cursor.close()
@@ -484,12 +523,23 @@ class DataSourceConnection(ABC):
     @contextlib.contextmanager
     def execute_query_iterate(self, sql: str, log_query: bool = True) -> Iterator[QueryResultIterator]:
         cursor = self.connection.cursor()
+        start_time: float = time.perf_counter()
         if log_query:
-            logger.debug(f"SQL query iterate:\n{sql}")
+            logger.debug(f"SQL query iterate (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}")
+        # The caller drives the iterator at its own pace outside this function's
+        # scope (the ``with`` block body), so the row count is only known once
+        # control returns here — on normal exit or on an exception propagating
+        # out of the ``with`` block.
+        result_iterator: Optional[QueryResultIterator] = None
         try:
             cursor.execute(sql)
-            yield QueryResultIterator(cursor, self._format_row)
+            result_iterator = QueryResultIterator(cursor, self._format_row)
+            yield result_iterator
         finally:
+            duration_seconds: float = time.perf_counter() - start_time
+            self.query_counters.record(duration_seconds)
+            rows_yielded: int = result_iterator.rows_yielded if result_iterator is not None else 0
+            logger.debug(f"SQL query iterate yielded {rows_yielded} rows in {duration_seconds:.3f}s")
             cursor.close()
 
     def commit(self) -> None:

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -25,7 +25,28 @@ class QueryCounters:
     """Per-connection query counters that callers (extensions building scan
     summaries) read directly. Deliberately dumb and public: a plain
     count/duration accumulator with no locking, since a single connection is
-    only ever driven by one thread at a time."""
+    only ever driven by one thread at a time.
+
+    Duration semantics: ``total_duration_seconds`` is wall-clock time measured
+    around each ``execute_*`` call, NOT pure warehouse/network time. For
+    ``execute_query`` it includes client-side result formatting (row
+    conversion via ``_format_rows``); for the one-by-one and iterate/streaming
+    paths it includes every second spent in the caller's ``row_callback`` (or,
+    for ``execute_query_iterate``, however long the caller's ``with`` block
+    takes to drain the iterator) — i.e. it's "time this connection was busy
+    on this query end-to-end", not an isolated server-round-trip metric.
+    Recorded on every attempt, success or failure (via ``finally``): a query
+    that ran 40s then failed is exactly what a timing summary should surface.
+
+    Scope: counters accumulate for the connection's entire lifetime with no
+    automatic reset — deliberately, since resetting a counter on a
+    potentially shared connection is a footgun (a second reader loses the
+    first reader's numbers). Callers that want a *per-scan* total should
+    snapshot-and-subtract: call ``snapshot()`` before the scan segment, run
+    the segment, call ``snapshot()`` again after, and diff the two
+    (``after.query_count - before.query_count``, likewise for
+    ``total_duration_seconds``).
+    """
 
     query_count: int = 0
     total_duration_seconds: float = 0.0
@@ -33,6 +54,11 @@ class QueryCounters:
     def record(self, duration_seconds: float) -> None:
         self.query_count += 1
         self.total_duration_seconds += duration_seconds
+
+    def snapshot(self) -> "QueryCounters":
+        """Return an independent copy of the current counts, for the
+        snapshot-and-subtract pattern described above."""
+        return QueryCounters(query_count=self.query_count, total_duration_seconds=self.total_duration_seconds)
 
 
 class MemoryOptimizedDriverSettings:
@@ -326,6 +352,9 @@ class DataSourceConnection(ABC):
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
         start_time: float = time.perf_counter()
+        # None until the query completes successfully — the finally block uses this
+        # to decide whether a completion line (row count) is possible to log at all.
+        formatted_rows: Optional[list[tuple]] = None
         try:
             if log_query:
                 logger.debug(
@@ -335,14 +364,20 @@ class DataSourceConnection(ABC):
             cursor.execute(sql)
             rows = cursor.fetchall()
             formatted_rows = self._format_rows(rows)
+            return QueryResult(rows=formatted_rows, columns=cursor.description)
+        finally:
+            # Duration + counters are recorded for every attempt, success or
+            # failure: a query that ran 40s then failed is exactly what a
+            # timing summary should surface (see QueryCounters docstring).
             duration_seconds: float = time.perf_counter() - start_time
             self.query_counters.record(duration_seconds)
 
             # Truncating/tabulating the result set is purely for DEBUG-level
-            # logging, so skip that work entirely when DEBUG is disabled.
-            if logger.isEnabledFor(logging.DEBUG):
+            # logging, so skip that work entirely when DEBUG is disabled — and
+            # only attempt it once the query actually produced rows.
+            if log_query and formatted_rows is not None and logger.isEnabledFor(logging.DEBUG):
                 truncated_rows = self.truncate_rows(formatted_rows)
-                headers = [self._execute_query_get_result_row_column_name(c) for c in cursor.description]
+                headers = [self._execute_query_get_result_row_column_name(c) for c in (cursor.description or [])]
                 # The tabulate can crash if the rows contain non-ASCII characters.
                 # This is purely for debugging/logging purposes, so we can try/catch this.
                 try:
@@ -363,8 +398,6 @@ class DataSourceConnection(ABC):
                 logger.debug(
                     f"SQL query result in {duration_seconds:.3f}s ({len(formatted_rows)} rows, max {self.MAX_ROWS} shown, {self.MAX_CHARS_PER_STRING} chars per string):\n{table_text}"
                 )
-            return QueryResult(rows=formatted_rows, columns=cursor.description)
-        finally:
             cursor.close()
 
     def _format_rows(self, rows: list[tuple]) -> list[tuple]:
@@ -400,16 +433,17 @@ class DataSourceConnection(ABC):
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
         start_time: float = time.perf_counter()
+        rowcount: Optional[int] = None
         try:
             if log_query:
                 logger.debug(f"SQL update (first {self.MAX_CHARS_PER_SQL} chars): \n{self.truncate_sql(sql)}")
-            rowcount: int = self._cursor_execute_update_and_commit(cursor, sql)
+            rowcount = self._cursor_execute_update_and_commit(cursor, sql)
+            return rowcount
+        finally:
             duration_seconds: float = time.perf_counter() - start_time
             self.query_counters.record(duration_seconds)
-            logger.debug(f"SQL update affected {rowcount} rows in {duration_seconds:.3f}s")
-            return rowcount
-
-        finally:
+            if log_query and rowcount is not None:
+                logger.debug(f"SQL update affected {rowcount} rows in {duration_seconds:.3f}s")
             cursor.close()
 
     def _cursor_execute_update_and_commit(self, cursor: Any, sql: str) -> int:
@@ -436,28 +470,29 @@ class DataSourceConnection(ABC):
         # noinspection PyUnresolvedReferences
         cursor = self.connection.cursor()
         start_time: float = time.perf_counter()
+        # Tracked incrementally, so unlike execute_query's row count this is known
+        # even if the loop below fails partway through — the completion line (and
+        # the counters) fire regardless, in `finally`.
+        rows_processed: int = 0
         try:
             if log_query:
                 logger.debug(
-                    f"SQL query fetch one-by-one (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}"
+                    f"SQL query fetch one-by-one in datasource {self.name} (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}"
                 )
             cursor.execute(sql)
 
-            description: tuple[tuple] = cursor.description
-
-            rows_processed: int = 0
+            description: tuple[tuple] = cursor.description or []
 
             row = cursor.fetchone()
             while row and (row_limit is None or rows_processed < row_limit):
                 rows_processed += 1
                 row_callback(row, description)
                 row = cursor.fetchone()
-
+        finally:
             duration_seconds: float = time.perf_counter() - start_time
             self.query_counters.record(duration_seconds)
-            logger.debug(f"SQL query fetch one-by-one processed {rows_processed} rows in {duration_seconds:.3f}s")
-
-        finally:
+            if log_query:
+                logger.debug(f"SQL query fetch one-by-one processed {rows_processed} rows in {duration_seconds:.3f}s")
             cursor.close()
         return description
 
@@ -525,7 +560,9 @@ class DataSourceConnection(ABC):
         cursor = self.connection.cursor()
         start_time: float = time.perf_counter()
         if log_query:
-            logger.debug(f"SQL query iterate (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}")
+            logger.debug(
+                f"SQL query iterate in datasource {self.name} (first {self.MAX_CHARS_PER_SQL} chars):\n{self.truncate_sql(sql)}"
+            )
         # The caller drives the iterator at its own pace outside this function's
         # scope (the ``with`` block body), so the row count is only known once
         # control returns here — on normal exit or on an exception propagating
@@ -538,8 +575,9 @@ class DataSourceConnection(ABC):
         finally:
             duration_seconds: float = time.perf_counter() - start_time
             self.query_counters.record(duration_seconds)
-            rows_yielded: int = result_iterator.rows_yielded if result_iterator is not None else 0
-            logger.debug(f"SQL query iterate yielded {rows_yielded} rows in {duration_seconds:.3f}s")
+            if log_query:
+                rows_yielded: int = result_iterator.rows_yielded if result_iterator is not None else 0
+                logger.debug(f"SQL query iterate yielded {rows_yielded} rows in {duration_seconds:.3f}s")
             cursor.close()
 
     def commit(self) -> None:

--- a/soda-core/src/soda_core/common/data_source_results.py
+++ b/soda-core/src/soda_core/common/data_source_results.py
@@ -60,6 +60,10 @@ class QueryResultIterator:
     def __init__(self, cursor: Cursor, format_row: Callable[[Any], tuple]):
         self._cursor = cursor
         self._format_row = format_row
+        # Dumb, public counter of rows actually delivered to the caller so far —
+        # read by DataSourceConnection.execute_query_iterate to log rows yielded
+        # once the caller's ``with`` block completes.
+        self.rows_yielded: int = 0
 
     def __iter__(self) -> QueryResultIterator:
         return self
@@ -68,6 +72,7 @@ class QueryResultIterator:
         row = self._cursor.fetchone()
         if row is None:
             raise StopIteration
+        self.rows_yielded += 1
         return self._format_row(row)
 
     @property

--- a/soda-core/src/soda_core/common/logs.py
+++ b/soda-core/src/soda_core/common/logs.py
@@ -122,6 +122,11 @@ class Logs:
     def get_log_records(self) -> list[LogRecord]:
         return self.gatherer.get_all_logs()
 
+    def records_for_failure_report(self) -> list[LogRecord]:
+        # The gatherer decides what a failure report attaches: everything for
+        # the in-memory collector, unsent error records for a streaming queue.
+        return self.gatherer.records_for_failure_report()
+
     def get_logs(self) -> list[str]:
         return [r.getMessage() for r in self.gatherer.get_all_logs()]
 

--- a/soda-core/src/soda_core/common/logs.py
+++ b/soda-core/src/soda_core/common/logs.py
@@ -127,6 +127,20 @@ class Logs:
         # the in-memory collector, unsent error records for a streaming queue.
         return self.gatherer.records_for_failure_report()
 
+    def switch_gatherer(self, gatherer: LogsBase, replay: bool = True) -> None:
+        """Swap the capture backend mid-run, keeping this ``Logs`` the active
+        target. With ``replay`` the records the old gatherer collected are
+        re-emitted into the new one first, so a run that upgrades from the
+        in-memory collector to a streaming queue delivers its full history to
+        the stream. The old gatherer is closed after the swap.
+        """
+        old_gatherer: LogsBase = self.gatherer
+        if replay:
+            for record in old_gatherer.get_all_logs():
+                gatherer.emit(record)
+        self.gatherer = gatherer
+        old_gatherer.close()
+
     def get_logs(self) -> list[str]:
         return [r.getMessage() for r in self.gatherer.get_all_logs()]
 

--- a/soda-core/src/soda_core/common/logs.py
+++ b/soda-core/src/soda_core/common/logs.py
@@ -123,21 +123,19 @@ class Logs:
         return self.gatherer.get_all_logs()
 
     def records_for_failure_report(self) -> list[LogRecord]:
-        # The gatherer decides what a failure report attaches: everything for
-        # the in-memory collector, unsent error records for a streaming queue.
+        # The gatherer decides what a failure report attaches: everything for the in-memory collector, unsent
+        # error records for a streaming queue.
         return self.gatherer.records_for_failure_report()
 
-    def switch_gatherer(self, gatherer: LogsBase, replay: bool = True) -> None:
-        """Swap the capture backend mid-run, keeping this ``Logs`` the active
-        target. With ``replay`` the records the old gatherer collected are
-        re-emitted into the new one first, so a run that upgrades from the
-        in-memory collector to a streaming queue delivers its full history to
-        the stream. The old gatherer is closed after the swap.
+    def switch_gatherer(self, gatherer: LogsBase) -> None:
+        """Swap the capture backend mid-run, keeping this ``Logs`` the active target. The records the old
+        gatherer collected are re-emitted into the new one first, so a run that upgrades from the in-memory
+        collector to a streaming queue delivers its full history to the stream. The old gatherer is closed
+        after the swap.
         """
         old_gatherer: LogsBase = self.gatherer
-        if replay:
-            for record in old_gatherer.get_all_logs():
-                gatherer.emit(record)
+        for record in old_gatherer.get_all_logs():
+            gatherer.emit(record)
         self.gatherer = gatherer
         old_gatherer.close()
 

--- a/soda-core/src/soda_core/common/logs_base.py
+++ b/soda-core/src/soda_core/common/logs_base.py
@@ -26,10 +26,9 @@ class LogsBase(ABC):
         pass
 
     def records_for_failure_report(self) -> list[LogRecord]:
-        # Records a failure report (sodaCoreMarkScanFailed) should attach.
-        # In-memory gatherers return everything (nothing was sent elsewhere);
-        # streaming gatherers override to return only what Soda Cloud has not
-        # confirmed received, so the report doesn't duplicate the stream.
+        # Records a failure report (sodaCoreMarkScanFailed) should attach. In-memory gatherers return
+        # everything (nothing was sent elsewhere); streaming gatherers override to return only what Soda Cloud
+        # has not confirmed received, so the report doesn't duplicate the stream.
         return self.get_all_logs()
 
     @abstractmethod

--- a/soda-core/src/soda_core/common/logs_base.py
+++ b/soda-core/src/soda_core/common/logs_base.py
@@ -25,6 +25,13 @@ class LogsBase(ABC):
     def get_all_logs(self) -> list[LogRecord]:
         pass
 
+    def records_for_failure_report(self) -> list[LogRecord]:
+        # Records a failure report (sodaCoreMarkScanFailed) should attach.
+        # In-memory gatherers return everything (nothing was sent elsewhere);
+        # streaming gatherers override to return only what Soda Cloud has not
+        # confirmed received, so the report doesn't duplicate the stream.
+        return self.get_all_logs()
+
     @abstractmethod
     def reset(self):
         pass

--- a/soda-core/src/soda_core/common/logs_queue.py
+++ b/soda-core/src/soda_core/common/logs_queue.py
@@ -60,10 +60,11 @@ class LogsQueue(LogsBase):
         self.dataset = dataset
         self.flush_interval = DEFAULT_FLUSH_INTERVAL
         self.batch_size = MAX_LOG_LINES
-        # Identities (id()) of records confirmed flushed (2xx) to the log
-        # stream. Error records stay alive in self.logs, so their identity is
-        # stable for records_for_failure_report(); non-error records are never
-        # reported, so their ids going stale after GC is harmless.
+        # Identities (id()) of ERROR-level records confirmed flushed (2xx) to the log stream, consulted by
+        # records_for_failure_report(). Only error records are tracked: they stay alive in self.logs, so their id()
+        # cannot be reused. Tracking freed non-error records would poison the set — CPython reuses a dead record's
+        # address for the next allocation, and a later (unsent) error record landing on it would silently drop out
+        # of the failure report.
         self._flushed_records: set[int] = set()
         self.log_queue = queue.Queue()
         self.shutdown_flag = threading.Event()
@@ -76,24 +77,23 @@ class LogsQueue(LogsBase):
 
     # Public API
     def get_error_logs(self) -> list[LogRecord]:
-        return [log for log in self.logs if log.level == logging.ERROR]
+        # levelno, not the nonexistent LogRecord.level, and `==` to match LogsCollector.get_error_logs exactly:
+        # a streaming run's has_errors/status determination must agree with the in-memory ad-hoc behavior.
+        return [log for log in self.logs if log.levelno == logging.ERROR]
 
     def get_error_or_warning_logs(self) -> list[LogRecord]:
         raise AssertionError("Warning logs unavailable in LogsQueue")
 
     def get_all_logs(self) -> list[LogRecord]:
-        # Streamed records are not re-gatherable: they are shipped (or in
-        # flight) to the scan's log stream. The empty list is what keeps a
-        # streaming run's results payload `logs` field empty at the existing
-        # fill sites. Callers needing failure-report content use
-        # records_for_failure_report().
+        # Streamed records are not re-gatherable: they are shipped (or in flight) to the scan's log stream. The
+        # empty list is what keeps a streaming run's results payload `logs` field empty at the existing fill
+        # sites. Callers needing failure-report content use records_for_failure_report().
         return []
 
     def records_for_failure_report(self) -> list[LogRecord]:
-        # Error records not confirmed flushed (2xx) to the log stream —
-        # in-flight, rejected, or dropped-after-retries batches. The failure
-        # report attaches only these, so errors reach Cloud exactly once when
-        # the stream works and are never lost when it doesn't.
+        # Error records not confirmed flushed (2xx) to the log stream — in-flight, rejected, or
+        # dropped-after-retries batches. The failure report attaches only these, so errors reach Cloud exactly
+        # once when the stream works and are never lost when it doesn't.
         return [record for record in self.logs if id(record) not in self._flushed_records]
 
     def reset(self):
@@ -125,7 +125,10 @@ class LogsQueue(LogsBase):
         with self.condition:
             log_record.__setattr__("stage", self.stage)
             log_record.__setattr__("index", self.index)
-            log_record.__setattr__("thread", self.thread)
+            if not hasattr(log_record, "thread"):
+                # The active Logs stamps a collection label as `thread` (grouping in Cloud); keep it when
+                # present — the queue's own uuid is only a fallback identity for unlabeled streams.
+                log_record.__setattr__("thread", self.thread)
             log_record.__setattr__("dataset", self.dataset)
             self.index += 1
             _mask_record(log_record)
@@ -181,12 +184,12 @@ class LogsQueue(LogsBase):
                             f"Logs sent to the cloud, trace={response.headers.get('X-Soda-Trace-Id')}, code={response.status_code}"
                         )
 
-                    # Only a 2xx confirms the batch reached the stream; the
-                    # isinstance guard keeps non-Response test doubles (and any
-                    # response without a real status) counting as unconfirmed.
+                    # Only a 2xx confirms the batch reached the stream; the isinstance guard keeps non-Response
+                    # test doubles (and any response without a real status) counting as unconfirmed. Only
+                    # error-record ids are tracked — see the _flushed_records comment in __init__.
                     status_code = getattr(response, "status_code", None)
                     if isinstance(status_code, int) and 200 <= status_code < 300:
-                        self._flushed_records.update(id(record) for record in batch)
+                        self._flushed_records.update(id(record) for record in batch if record.levelno >= logging.ERROR)
 
                     return (
                         self.get_next_batch_timeout(response.headers.get("X-Soda-Next-Batch-Time"))

--- a/soda-core/src/soda_core/common/logs_queue.py
+++ b/soda-core/src/soda_core/common/logs_queue.py
@@ -60,6 +60,11 @@ class LogsQueue(LogsBase):
         self.dataset = dataset
         self.flush_interval = DEFAULT_FLUSH_INTERVAL
         self.batch_size = MAX_LOG_LINES
+        # Identities (id()) of records confirmed flushed (2xx) to the log
+        # stream. Error records stay alive in self.logs, so their identity is
+        # stable for records_for_failure_report(); non-error records are never
+        # reported, so their ids going stale after GC is harmless.
+        self._flushed_records: set[int] = set()
         self.log_queue = queue.Queue()
         self.shutdown_flag = threading.Event()
         self.condition = threading.Condition()
@@ -77,7 +82,19 @@ class LogsQueue(LogsBase):
         raise AssertionError("Warning logs unavailable in LogsQueue")
 
     def get_all_logs(self) -> list[LogRecord]:
-        raise AssertionError("All logs unavailable in LogsQueue")
+        # Streamed records are not re-gatherable: they are shipped (or in
+        # flight) to the scan's log stream. The empty list is what keeps a
+        # streaming run's results payload `logs` field empty at the existing
+        # fill sites. Callers needing failure-report content use
+        # records_for_failure_report().
+        return []
+
+    def records_for_failure_report(self) -> list[LogRecord]:
+        # Error records not confirmed flushed (2xx) to the log stream —
+        # in-flight, rejected, or dropped-after-retries batches. The failure
+        # report attaches only these, so errors reach Cloud exactly once when
+        # the stream works and are never lost when it doesn't.
+        return [record for record in self.logs if id(record) not in self._flushed_records]
 
     def reset(self):
         self.thread = str(uuid.uuid4())
@@ -86,6 +103,7 @@ class LogsQueue(LogsBase):
         self.verbose: bool = False
         self.has_error_logs = False
         self.has_warning_logs = False
+        self._flushed_records = set()
         return self
 
     # To make sure all logs have been sent trigger close method
@@ -162,6 +180,13 @@ class LogsQueue(LogsBase):
                         print(
                             f"Logs sent to the cloud, trace={response.headers.get('X-Soda-Trace-Id')}, code={response.status_code}"
                         )
+
+                    # Only a 2xx confirms the batch reached the stream; the
+                    # isinstance guard keeps non-Response test doubles (and any
+                    # response without a real status) counting as unconfirmed.
+                    status_code = getattr(response, "status_code", None)
+                    if isinstance(status_code, int) and 200 <= status_code < 300:
+                        self._flushed_records.update(id(record) for record in batch)
 
                     return (
                         self.get_next_batch_timeout(response.headers.get("X-Soda-Next-Batch-Time"))

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -60,6 +60,11 @@ from soda_core.contracts.impl.contract_yaml import ContractYaml
 
 logger: logging.Logger = soda_logger
 
+# Compiled once at import time rather than per request in
+# _clean_request_from_private_info — that method already only runs when DEBUG
+# is enabled, but there's no reason to re-compile the same pattern every call.
+_TOKEN_FIELD_REGEX: re.Pattern = re.compile(r'"token":\s*"[^"]+"')
+
 
 class RemoteScanStatus(Enum):
     QUEUING = ("queuing", False)
@@ -1486,8 +1491,7 @@ class SodaCloud:
             )
 
     def _clean_request_from_private_info(self, json_str: str) -> str:
-        regex = re.compile(r'"token":\s*"[^"]+"')
-        return regex.sub(r'"token": "****"', json_str)
+        return _TOKEN_FIELD_REGEX.sub(r'"token": "****"', json_str)
 
     def _http_post(self, request_log_name: str = None, **kwargs) -> Response:
         return requests.post(**kwargs)

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1432,11 +1432,15 @@ class SodaCloud:
     ) -> Optional[Response]:
         try:
             request_body["token"] = self._get_token()
-            # json.dumps(..., indent=2) plus the token-masking regex are built
-            # per request purely for this DEBUG line — skip both entirely when
-            # DEBUG is disabled.
+            # to_jsonnable(...) mutates request_body in place (datetime/Decimal/Enum/...
+            # -> JSON-safe values) and is required for the upcoming _http_post(json=...)
+            # to serialize at all — it must run unconditionally, not just when DEBUG is
+            # enabled. Only the pretty-print (json.dumps(..., indent=2)) and the
+            # token-masking regex substitution are built purely for the DEBUG line below,
+            # so only those stay behind the isEnabledFor guard.
+            to_jsonnable(request_body)
             if logger.isEnabledFor(logging.DEBUG):
-                log_body_text: str = json.dumps(to_jsonnable(request_body), indent=2)
+                log_body_text: str = json.dumps(request_body, indent=2)
                 logger.debug(
                     f"Sending {request_type} {request_log_name} to Soda Cloud with body: {self._clean_request_from_private_info(log_body_text)}"
                 )

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -382,6 +382,64 @@ class SodaCloud:
         )
         return response is not None and response.ok
 
+    def scan_start(
+        self,
+        scan_id: str,
+        definition_name: Optional[str] = None,
+        default_data_source: Optional[str] = None,
+    ) -> Optional[str]:
+        """Send ``sodaCoreScanStart`` for a pre-created Cloud scan; returns the
+        ``scanReference`` that keys the async ingestion pipeline
+        (``insert_scan_data_batch`` / ``scan_end_async``), or None when the
+        command was rejected or the response carried no reference — callers
+        degrade to the sync ``insert_scan_results`` path. The ``version`` is
+        the payload model version: this codebase is v4-only.
+        """
+        command: dict = {"type": "sodaCoreScanStart", "scanId": scan_id, "version": "4"}
+        if definition_name:
+            command["definitionName"] = definition_name
+        if default_data_source:
+            command["defaultDataSource"] = default_data_source
+        response: Optional[Response] = self._execute_command(
+            command_json_dict=command,
+            request_log_name="scan_start",
+        )
+        if response is None or not response.ok:
+            return None
+        try:
+            scan_reference: Optional[str] = response.json().get("scanReference")
+        except Exception:
+            scan_reference = None
+        if not scan_reference:
+            logger.warning(f"sodaCoreScanStart response for scan '{scan_id}' carried no scanReference")
+            return None
+        return scan_reference
+
+    def insert_scan_data_batch(self, payload: SodaCoreInsertScanResultsDTO, scan_reference: str) -> bool:
+        """Send one results payload through the async ingestion pipeline
+        (``sodaCoreInsertScanDataBatch``, keyed by the ``scan_start``
+        scanReference). Takes the same payload dict the sync flows build; the
+        batch type and scanReference are stamped on a copy so the caller's DTO
+        is untouched. Returns True when Soda Cloud accepted it (same contract
+        as ``insert_scan_results``).
+        """
+        command: dict = {**payload, "type": "sodaCoreInsertScanDataBatch", "scanReference": scan_reference}
+        response: Optional[Response] = self._execute_command(
+            command_json_dict=command,
+            request_log_name="insert_scan_data_batch",
+        )
+        return response is not None and response.ok
+
+    def scan_end_async(self, scan_reference: str) -> bool:
+        """Send ``sodaCoreScanEndAsync`` closing the async ingestion bracket
+        opened by ``scan_start``. Returns True when Soda Cloud accepted it.
+        """
+        response: Optional[Response] = self._execute_command(
+            command_json_dict={"type": "sodaCoreScanEndAsync", "scanReference": scan_reference},
+            request_log_name="scan_end_async",
+        )
+        return response is not None and response.ok
+
     def send_check_collection_results(
         self,
         results: list[ContractVerificationResult],

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -385,21 +385,35 @@ class SodaCloud:
     def scan_start(
         self,
         scan_id: str,
-        definition_name: Optional[str] = None,
-        default_data_source: Optional[str] = None,
+        definition_name: str,
+        default_data_source: str,
+        data_timestamp: Optional[datetime] = None,
     ) -> Optional[str]:
         """Send ``sodaCoreScanStart`` for a pre-created Cloud scan; returns the
         ``scanReference`` that keys the async ingestion pipeline
         (``insert_scan_data_batch`` / ``scan_end_async``), or None when the
         command was rejected or the response carried no reference — callers
-        degrade to the sync ``insert_scan_results`` path. The ``version`` is
-        the payload model version: this codebase is v4-only.
+        degrade to the sync ``insert_scan_results`` path.
+
+        ``definitionName``, ``defaultDataSource`` and ``dataTimestamp`` are
+        backend-mandatory (the executor dispatches on the definition's type and
+        upserts the scan's data containers from them); ``data_timestamp``
+        defaults to now. The ``version`` is the payload model version: this
+        codebase is v4-only, and the backend's v4 handling (e.g. hierarchical
+        discovery results) keys on it. A successful start also moves the scan
+        into its log-accepting state: the scan-id-keyed ``batchV4`` log stream
+        only accepts uploads after this command.
         """
-        command: dict = {"type": "sodaCoreScanStart", "scanId": scan_id, "version": "4"}
-        if definition_name:
-            command["definitionName"] = definition_name
-        if default_data_source:
-            command["defaultDataSource"] = default_data_source
+        command: dict = {
+            "type": "sodaCoreScanStart",
+            "scanId": scan_id,
+            "version": "4",
+            "definitionName": definition_name,
+            "defaultDataSource": default_data_source,
+            "dataTimestamp": convert_datetime_to_str(
+                data_timestamp if data_timestamp is not None else datetime.now(timezone.utc)
+            ),
+        }
         response: Optional[Response] = self._execute_command(
             command_json_dict=command,
             request_log_name="scan_start",
@@ -1792,10 +1806,15 @@ def _build_check_results_cloud_json_dicts(
     return check_dicts
 
 
-def _build_scan_definition_name(
-    contract_verification_result: ContractVerificationResult,
+def build_scan_definition_name(
+    soda_qualified_dataset_name: Optional[str],
     scan_definition_suffix: Optional[str] = None,
 ) -> str:
+    """The scan-definition name a check-collection run registers under:
+    SODA_SCAN_DEFINITION when set, otherwise derived from the dataset's
+    qualified name. Public because batched-ingestion flows need the name
+    before any result exists (``sodaCoreScanStart`` requires it).
+    """
     scan_definition_name: str = os.environ.get("SODA_SCAN_DEFINITION")
     if scan_definition_name:
         logger.debug(f"Using SODA_SCAN_DEFINITION from environment variable: {scan_definition_name}")
@@ -1805,10 +1824,9 @@ def _build_scan_definition_name(
     # non-empty ``scan_definition_suffix`` on their impl; the engine
     # threads it through here. Keeps subtype literals out of soda-core
     # common.
-    qualified_name = contract_verification_result.check_collection.soda_qualified_dataset_name
     if scan_definition_suffix:
-        return f"{qualified_name}_{scan_definition_suffix}"
-    return qualified_name
+        return f"{soda_qualified_dataset_name}_{scan_definition_suffix}"
+    return soda_qualified_dataset_name
 
 
 def _build_post_processing_stages_dicts(
@@ -1920,7 +1938,9 @@ def _build_check_collection_results_json_dict(
 
     payload: dict = {
         "scanId": os.environ.get("SODA_SCAN_ID", None),
-        "definitionName": _build_scan_definition_name(head, scan_definition_suffix=scan_definition_suffix),
+        "definitionName": build_scan_definition_name(
+            head.check_collection.soda_qualified_dataset_name, scan_definition_suffix=scan_definition_suffix
+        ),
         "defaultDataSource": head.data_source.name if head.data_source else None,
         "defaultDataSourceProperties": {"type": head.data_source.type} if head.data_source else None,
         "dataTimestamp": head.data_timestamp,

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1427,10 +1427,14 @@ class SodaCloud:
     ) -> Optional[Response]:
         try:
             request_body["token"] = self._get_token()
-            log_body_text: str = json.dumps(to_jsonnable(request_body), indent=2)
-            logger.debug(
-                f"Sending {request_type} {request_log_name} to Soda Cloud with body: {self._clean_request_from_private_info(log_body_text)}"
-            )
+            # json.dumps(..., indent=2) plus the token-masking regex are built
+            # per request purely for this DEBUG line — skip both entirely when
+            # DEBUG is disabled.
+            if logger.isEnabledFor(logging.DEBUG):
+                log_body_text: str = json.dumps(to_jsonnable(request_body), indent=2)
+                logger.debug(
+                    f"Sending {request_type} {request_log_name} to Soda Cloud with body: {self._clean_request_from_private_info(log_body_text)}"
+                )
             response: Response = self._http_post(
                 url=f"{self.api_url}/{request_type}",
                 headers=self.headers,

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from abc import ABC
 from datetime import timezone, tzinfo
@@ -246,71 +247,87 @@ class PostgresDataSourceConnection(DataSourceConnection):
         memory_optimized_driver_settings.log_active_once(type(self).__name__)
 
         cursor_name = f"soda_stream_{uuid.uuid4().hex[:12]}"
+        start_time: float = time.perf_counter()
+        # Tracked incrementally so it's known even if the fetch loop or a
+        # row_callback fails partway through — the completion line and the
+        # counters fire regardless, in `finally` (see QueryCounters docstring:
+        # a query that ran 40s then failed is exactly what a timing summary
+        # should surface).
+        rows_processed: int = 0
         if log_query:
             logger.debug(
                 f"SQL query one-by-one (server-side cursor {cursor_name}, "
-                f"byte-budgeted fetchmany — minimise memory):\n{sql}"
+                f"byte-budgeted fetchmany — minimise memory) (first {self.MAX_CHARS_PER_SQL} chars):\n"
+                f"{self.truncate_sql(sql)}"
             )
 
         try:
-            with self.connection.cursor(name=cursor_name, withhold=True) as cursor:
-                cursor.execute(sql)
-                description: tuple[tuple] = cursor.description
-                rows_processed: int = 0
-                batch_size: int = 1  # single probe row first, to size subsequent batches
-                max_row_bytes: int = 1
-                while True:
-                    if row_limit is not None and rows_processed >= row_limit:
-                        break
-                    fetch_count: int = batch_size
-                    if row_limit is not None:
-                        fetch_count = min(fetch_count, row_limit - rows_processed)
-                    rows = cursor.fetchmany(fetch_count)
-                    if not rows:
-                        break
-                    for row in rows:
-                        row_callback(row, description)
-                        rows_processed += 1
-                    # Size against the widest row seen so far (monotonic), so a
-                    # late fat row permanently shrinks the batch back down.
-                    # Growth is ramped: shrinking applies immediately, but the
-                    # batch may only grow STREAM_FETCH_GROWTH_FACTOR x per
-                    # fetch (thin-probe overshoot bound).
-                    max_row_bytes = max(max_row_bytes, max(_estimate_row_bytes(row) for row in rows))
-                    batch_size = max(
-                        1,
-                        min(
-                            STREAM_FETCH_MAX_BATCH_ROWS,
-                            STREAM_FETCH_BUDGET_BYTES // max_row_bytes,
-                            batch_size * STREAM_FETCH_GROWTH_FACTOR,
-                        ),
-                    )
-            return description
-        except psycopg.errors.Error as e:
-            # The error may come from the stream itself OR from a row_callback
-            # that hit the database (the DWH pump writes from inside the
-            # callback) — don't blame the SELECT. And honor log_query=False:
-            # callers suppress it because the query can embed MB-scale VALUES.
-            sql_blurb = f"\n{sql}" if log_query else " (query suppressed, log_query=False)"
-            logger.warning(f"Streaming query (or its row callback) failed:{sql_blurb}\n{e}")
-            logger.debug("Rolling back transaction")
-            self.rollback()
-            # Best-effort CLOSE of the named cursor. When the failure left
-            # the transaction in error state, psycopg's ServerCursor.close()
-            # (in the `with` exit above) skips issuing CLOSE — and a held
-            # (post-commit) portal survives the rollback, materialized
-            # server-side until the connection closes, which for DWH
-            # connections is the whole scan. After the rollback the
-            # transaction is clean, so an explicit CLOSE works; if the
-            # portal is already gone (never held), it errors harmlessly.
             try:
-                with self.connection.cursor() as close_cursor:
-                    close_cursor.execute(f'CLOSE "{cursor_name}"')
-                self.connection.commit()
-            except psycopg.errors.Error as close_error:
-                logger.debug(f"Best-effort CLOSE of held cursor {cursor_name} failed (harmless): {close_error}")
+                with self.connection.cursor(name=cursor_name, withhold=True) as cursor:
+                    cursor.execute(sql)
+                    description: tuple[tuple] = cursor.description or []
+                    batch_size: int = 1  # single probe row first, to size subsequent batches
+                    max_row_bytes: int = 1
+                    while True:
+                        if row_limit is not None and rows_processed >= row_limit:
+                            break
+                        fetch_count: int = batch_size
+                        if row_limit is not None:
+                            fetch_count = min(fetch_count, row_limit - rows_processed)
+                        rows = cursor.fetchmany(fetch_count)
+                        if not rows:
+                            break
+                        for row in rows:
+                            row_callback(row, description)
+                            rows_processed += 1
+                        # Size against the widest row seen so far (monotonic), so a
+                        # late fat row permanently shrinks the batch back down.
+                        # Growth is ramped: shrinking applies immediately, but the
+                        # batch may only grow STREAM_FETCH_GROWTH_FACTOR x per
+                        # fetch (thin-probe overshoot bound).
+                        max_row_bytes = max(max_row_bytes, max(_estimate_row_bytes(row) for row in rows))
+                        batch_size = max(
+                            1,
+                            min(
+                                STREAM_FETCH_MAX_BATCH_ROWS,
+                                STREAM_FETCH_BUDGET_BYTES // max_row_bytes,
+                                batch_size * STREAM_FETCH_GROWTH_FACTOR,
+                            ),
+                        )
+                return description
+            except psycopg.errors.Error as e:
+                # The error may come from the stream itself OR from a row_callback
+                # that hit the database (the DWH pump writes from inside the
+                # callback) — don't blame the SELECT. And honor log_query=False:
+                # callers suppress it because the query can embed MB-scale VALUES.
+                sql_blurb = f"\n{sql}" if log_query else " (query suppressed, log_query=False)"
+                logger.warning(f"Streaming query (or its row callback) failed:{sql_blurb}\n{e}")
+                logger.debug("Rolling back transaction")
+                self.rollback()
+                # Best-effort CLOSE of the named cursor. When the failure left
+                # the transaction in error state, psycopg's ServerCursor.close()
+                # (in the `with` exit above) skips issuing CLOSE — and a held
+                # (post-commit) portal survives the rollback, materialized
+                # server-side until the connection closes, which for DWH
+                # connections is the whole scan. After the rollback the
+                # transaction is clean, so an explicit CLOSE works; if the
+                # portal is already gone (never held), it errors harmlessly.
                 try:
-                    self.rollback()
-                except psycopg.errors.Error:
-                    pass
-            raise e
+                    with self.connection.cursor() as close_cursor:
+                        close_cursor.execute(f'CLOSE "{cursor_name}"')
+                    self.connection.commit()
+                except psycopg.errors.Error as close_error:
+                    logger.debug(f"Best-effort CLOSE of held cursor {cursor_name} failed (harmless): {close_error}")
+                    try:
+                        self.rollback()
+                    except psycopg.errors.Error:
+                        pass
+                raise e
+        finally:
+            duration_seconds: float = time.perf_counter() - start_time
+            self.query_counters.record(duration_seconds)
+            if log_query:
+                logger.debug(
+                    f"SQL query one-by-one (server-side cursor {cursor_name}) processed {rows_processed} rows "
+                    f"in {duration_seconds:.3f}s"
+                )

--- a/soda-tests/tests/unit/test_batched_scan.py
+++ b/soda-tests/tests/unit/test_batched_scan.py
@@ -1,0 +1,156 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.batched_scan import BatchedScanContext, run_batched_scan
+from soda_core.common.logs import Logs
+from soda_core.common.logs_collector import LogsCollector
+
+# run_batched_scan: the opt-in bracket for Cloud-launched results-publishing
+# commands. The fallback matrix — no scan id, scan_start failure, happy path —
+# plus the failure-report and end-of-scan orderings.
+
+
+def _payload() -> dict:
+    return {"type": "sodaCoreInsertScanResults", "definitionName": "my_scan"}
+
+
+def test_context_insert_results_batches_when_scan_reference_set():
+    soda_cloud = MagicMock()
+    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id="scan-123", scan_reference="org/ref-1")
+
+    context.insert_results(_payload())
+
+    soda_cloud.insert_scan_data_batch.assert_called_once_with(_payload(), "org/ref-1")
+    soda_cloud.insert_scan_results.assert_not_called()
+    context.logs.close()
+
+
+def test_context_insert_results_falls_back_to_sync_without_scan_reference():
+    soda_cloud = MagicMock()
+    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id=None, scan_reference=None)
+
+    context.insert_results(_payload())
+
+    soda_cloud.insert_scan_results.assert_called_once_with(_payload())
+    soda_cloud.insert_scan_data_batch.assert_not_called()
+    context.logs.close()
+
+
+def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
+    monkeypatch.delenv("SODA_SCAN_ID", raising=False)
+    soda_cloud = MagicMock()
+    seen = {}
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        seen["context"] = context
+        context.insert_results(_payload())
+        return ExitCode.OK
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert exit_code == ExitCode.OK
+    soda_cloud.scan_start.assert_not_called()
+    soda_cloud.scan_end_async.assert_not_called()
+    soda_cloud.insert_scan_results.assert_called_once()
+    soda_cloud.insert_scan_data_batch.assert_not_called()
+    assert seen["context"].scan_id is None
+    assert seen["context"].scan_reference is None
+    assert isinstance(seen["context"].logs.gatherer, LogsCollector)
+
+
+@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+def test_run_batched_scan_happy_path_batches_then_ends(mock_build_streaming_logs, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    order = []
+    soda_cloud.insert_scan_data_batch.side_effect = lambda *args, **kwargs: order.append("insert") or True
+    soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        assert context.insert_results(_payload()) is True
+        return ExitCode.OK
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert exit_code == ExitCode.OK
+    soda_cloud.scan_start.assert_called_once_with("scan-123", None, None)
+    assert order == ["insert", "end"]
+    mock_build_streaming_logs.assert_called_once_with(soda_cloud, "main", "scan-123")
+
+
+@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(mock_build_streaming_logs, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = None
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        context.insert_results(_payload())
+        return ExitCode.OK
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert exit_code == ExitCode.OK
+    soda_cloud.insert_scan_results.assert_called_once()
+    soda_cloud.insert_scan_data_batch.assert_not_called()
+    soda_cloud.scan_end_async.assert_not_called()
+
+
+@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+def test_run_batched_scan_failure_reports_then_ends(mock_build_streaming_logs, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    soda_cloud.mark_scan_as_failed.return_value = True
+    order = []
+    soda_cloud.mark_scan_as_failed.side_effect = lambda *args, **kwargs: order.append("mark") or True
+    soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        raise ValueError("boom")
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert exit_code == ExitCode.LOG_ERRORS
+    assert order == ["mark", "end"]
+    soda_cloud.scan_end_async.assert_called_once_with("org/ref-1")
+
+
+@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs")
+def test_run_batched_scan_failure_report_attaches_gatherer_selected_records(mock_build_streaming_logs, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    soda_cloud.mark_scan_as_failed.return_value = True
+
+    selected_records = [
+        logging.LogRecord(
+            name="soda", level=logging.ERROR, pathname=__file__, lineno=1, msg="unsent", args=(), exc_info=None
+        )
+    ]
+    gatherer = MagicMock()
+    gatherer.records_for_failure_report.return_value = selected_records
+    mock_build_streaming_logs.return_value = Logs(gatherer=gatherer)
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        raise ValueError("boom")
+
+    run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"] is selected_records
+    # The stream's final flush happens via the wrapper's close.
+    gatherer.close.assert_called_once()
+
+
+@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+def test_run_batched_scan_end_failure_is_not_fatal(mock_build_streaming_logs, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    soda_cloud.scan_end_async.return_value = False
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=lambda context: ExitCode.OK)
+
+    assert exit_code == ExitCode.OK

--- a/soda-tests/tests/unit/test_batched_scan.py
+++ b/soda-tests/tests/unit/test_batched_scan.py
@@ -59,7 +59,7 @@ def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
     assert isinstance(seen["context"].logs.gatherer, LogsCollector)
 
 
-@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
 def test_run_batched_scan_happy_path_batches_then_ends(mock_build_streaming_logs, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
@@ -80,7 +80,7 @@ def test_run_batched_scan_happy_path_batches_then_ends(mock_build_streaming_logs
     mock_build_streaming_logs.assert_called_once_with(soda_cloud, "main", "scan-123")
 
 
-@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
 def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(mock_build_streaming_logs, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
@@ -98,7 +98,7 @@ def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(mock_build_stre
     soda_cloud.scan_end_async.assert_not_called()
 
 
-@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
 def test_run_batched_scan_failure_reports_then_ends(mock_build_streaming_logs, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
@@ -118,7 +118,7 @@ def test_run_batched_scan_failure_reports_then_ends(mock_build_streaming_logs, m
     soda_cloud.scan_end_async.assert_called_once_with("org/ref-1")
 
 
-@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs")
+@patch("soda_core.cli.handlers.data_source.build_streaming_logs")
 def test_run_batched_scan_failure_report_attaches_gatherer_selected_records(mock_build_streaming_logs, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
@@ -144,7 +144,7 @@ def test_run_batched_scan_failure_report_attaches_gatherer_selected_records(mock
     gatherer.close.assert_called_once()
 
 
-@patch("soda_core.cli.handlers.batched_scan.build_streaming_logs", return_value=None)
+@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
 def test_run_batched_scan_end_failure_is_not_fatal(mock_build_streaming_logs, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()

--- a/soda-tests/tests/unit/test_batched_scan.py
+++ b/soda-tests/tests/unit/test_batched_scan.py
@@ -1,18 +1,43 @@
 import logging
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.batched_scan import BatchedScanContext, run_batched_scan
+from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
 from soda_core.common.logs_collector import LogsCollector
 
 # run_batched_scan: the opt-in bracket for Cloud-launched results-publishing
-# commands. The fallback matrix — no scan id, scan_start failure, happy path —
-# plus the failure-report and end-of-scan orderings.
+# commands. The flow opens the bracket itself via context.start_scan once its
+# dependencies resolve; the fallback matrix — no scan id, rejected start,
+# happy path — plus the failure-report and end-of-scan orderings.
+
+DATA_TIMESTAMP = datetime(2026, 7, 13, 8, 30, tzinfo=timezone.utc)
 
 
 def _payload() -> dict:
     return {"type": "sodaCoreInsertScanResults", "definitionName": "my_scan"}
+
+
+class _StreamingGathererStub(LogsCollector):
+    """LogsQueue stand-in with its streaming-mode contract: records preserved
+    on emit (via the collector base), get_all_logs empty, failure reports
+    select error records only."""
+
+    def __init__(self):
+        super().__init__()
+        self.reset()
+        self.closed = False
+
+    def get_all_logs(self):
+        return []
+
+    def records_for_failure_report(self):
+        return [record for record in self.logs if record.levelno >= logging.ERROR]
+
+    def close(self):
+        self.closed = True
 
 
 def test_context_insert_results_batches_when_scan_reference_set():
@@ -28,13 +53,84 @@ def test_context_insert_results_batches_when_scan_reference_set():
 
 def test_context_insert_results_falls_back_to_sync_without_scan_reference():
     soda_cloud = MagicMock()
-    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id=None, scan_reference=None)
+    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id=None)
 
     context.insert_results(_payload())
 
     soda_cloud.insert_scan_results.assert_called_once_with(_payload())
     soda_cloud.insert_scan_data_batch.assert_not_called()
     context.logs.close()
+
+
+def test_start_scan_is_a_no_op_without_scan_id():
+    soda_cloud = MagicMock()
+    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id=None)
+
+    context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+
+    soda_cloud.scan_start.assert_not_called()
+    assert context.scan_reference is None
+    assert isinstance(context.logs.gatherer, LogsCollector)
+    context.logs.close()
+
+
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_start_scan_switches_to_streaming_and_replays_captured_records(mock_logs_queue_cls):
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    stub = _StreamingGathererStub()
+    mock_logs_queue_cls.return_value = stub
+
+    logs = Logs()
+    try:
+        soda_logger.info("captured before the scan started")
+        context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id="scan-123", stage="main")
+
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+
+        soda_cloud.scan_start.assert_called_once_with("scan-123", "my_scan", "postgres", DATA_TIMESTAMP)
+        mock_logs_queue_cls.assert_called_once_with(soda_cloud=soda_cloud, stage="main", scan_id="scan-123", dataset="")
+        assert context.scan_reference == "org/ref-1"
+        assert logs.gatherer is stub
+        # The pre-start history was replayed into the stream.
+        assert any("captured before the scan started" in record.getMessage() for record in stub.logs)
+        # From now on the payload log fill sites see no records: the stream is
+        # the single log channel.
+        assert logs.get_log_records() == []
+    finally:
+        logs.close()
+
+
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_start_scan_is_idempotent(mock_logs_queue_cls):
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    mock_logs_queue_cls.return_value = _StreamingGathererStub()
+    context = BatchedScanContext(logs=Logs(), soda_cloud=soda_cloud, scan_id="scan-123")
+
+    context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+    context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+
+    soda_cloud.scan_start.assert_called_once()
+    context.logs.close()
+
+
+def test_start_scan_rejected_stays_on_the_sync_path_with_in_memory_logs():
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = None
+    logs = Logs()
+    context = BatchedScanContext(logs=logs, soda_cloud=soda_cloud, scan_id="scan-123")
+
+    context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+    context.insert_results(_payload())
+
+    assert context.scan_reference is None
+    # In-memory logs survive a rejected start: the payload keeps carrying them
+    # (the backend would refuse batchV4 uploads for a never-started scan).
+    assert isinstance(logs.gatherer, LogsCollector)
+    soda_cloud.insert_scan_results.assert_called_once()
+    soda_cloud.insert_scan_data_batch.assert_not_called()
+    logs.close()
 
 
 def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
@@ -44,6 +140,7 @@ def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
 
     def command(context: BatchedScanContext) -> ExitCode:
         seen["context"] = context
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
         context.insert_results(_payload())
         return ExitCode.OK
 
@@ -55,38 +152,39 @@ def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
     soda_cloud.insert_scan_results.assert_called_once()
     soda_cloud.insert_scan_data_batch.assert_not_called()
     assert seen["context"].scan_id is None
-    assert seen["context"].scan_reference is None
     assert isinstance(seen["context"].logs.gatherer, LogsCollector)
 
 
-@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
-def test_run_batched_scan_happy_path_batches_then_ends(mock_build_streaming_logs, monkeypatch):
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_run_batched_scan_happy_path_starts_batches_then_ends(mock_logs_queue_cls, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
+    mock_logs_queue_cls.return_value = _StreamingGathererStub()
     order = []
     soda_cloud.insert_scan_data_batch.side_effect = lambda *args, **kwargs: order.append("insert") or True
     soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
 
     def command(context: BatchedScanContext) -> ExitCode:
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
         assert context.insert_results(_payload()) is True
         return ExitCode.OK
 
     exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
 
     assert exit_code == ExitCode.OK
-    soda_cloud.scan_start.assert_called_once_with("scan-123", None, None)
+    soda_cloud.scan_start.assert_called_once_with("scan-123", "my_scan", "postgres", DATA_TIMESTAMP)
     assert order == ["insert", "end"]
-    mock_build_streaming_logs.assert_called_once_with(soda_cloud, "main", "scan-123")
+    soda_cloud.scan_end_async.assert_called_once_with("org/ref-1")
 
 
-@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
-def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(mock_build_streaming_logs, monkeypatch):
+def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = None
 
     def command(context: BatchedScanContext) -> ExitCode:
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
         context.insert_results(_payload())
         return ExitCode.OK
 
@@ -98,59 +196,58 @@ def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(mock_build_stre
     soda_cloud.scan_end_async.assert_not_called()
 
 
-@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
-def test_run_batched_scan_failure_reports_then_ends(mock_build_streaming_logs, monkeypatch):
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_run_batched_scan_failure_after_start_reports_unsent_errors_then_ends(mock_logs_queue_cls, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
-    soda_cloud.mark_scan_as_failed.return_value = True
+    mock_logs_queue_cls.return_value = _StreamingGathererStub()
     order = []
     soda_cloud.mark_scan_as_failed.side_effect = lambda *args, **kwargs: order.append("mark") or True
     soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
 
     def command(context: BatchedScanContext) -> ExitCode:
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
         raise ValueError("boom")
 
     exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
 
     assert exit_code == ExitCode.LOG_ERRORS
     assert order == ["mark", "end"]
-    soda_cloud.scan_end_async.assert_called_once_with("org/ref-1")
+    # The report carries the streaming gatherer's selection: error records only.
+    reported = soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"]
+    assert reported and all(record.levelno >= logging.ERROR for record in reported)
+    assert any("boom" in record.getMessage() for record in reported)
 
 
-@patch("soda_core.cli.handlers.data_source.build_streaming_logs")
-def test_run_batched_scan_failure_report_attaches_gatherer_selected_records(mock_build_streaming_logs, monkeypatch):
+def test_run_batched_scan_failure_before_start_reports_the_full_record_list(monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
-    soda_cloud.scan_start.return_value = "org/ref-1"
     soda_cloud.mark_scan_as_failed.return_value = True
 
-    selected_records = [
-        logging.LogRecord(
-            name="soda", level=logging.ERROR, pathname=__file__, lineno=1, msg="unsent", args=(), exc_info=None
-        )
-    ]
-    gatherer = MagicMock()
-    gatherer.records_for_failure_report.return_value = selected_records
-    mock_build_streaming_logs.return_value = Logs(gatherer=gatherer)
-
     def command(context: BatchedScanContext) -> ExitCode:
-        raise ValueError("boom")
+        soda_logger.info("resolution progress")
+        raise ValueError("resolution failed")
 
-    run_batched_scan(soda_cloud, stage="main", command=command)
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
 
-    assert soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"] is selected_records
-    # The stream's final flush happens via the wrapper's close.
-    gatherer.close.assert_called_once()
+    assert exit_code == ExitCode.LOG_ERRORS
+    soda_cloud.scan_end_async.assert_not_called()
+    reported = soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"]
+    # Nothing was streamed: today's behavior — the full record list rides the report.
+    assert any("resolution progress" in record.getMessage() for record in reported)
 
 
-@patch("soda_core.cli.handlers.data_source.build_streaming_logs", return_value=None)
-def test_run_batched_scan_end_failure_is_not_fatal(mock_build_streaming_logs, monkeypatch):
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_run_batched_scan_end_failure_is_not_fatal(mock_logs_queue_cls, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
     soda_cloud.scan_end_async.return_value = False
+    mock_logs_queue_cls.return_value = _StreamingGathererStub()
 
-    exit_code = run_batched_scan(soda_cloud, stage="main", command=lambda context: ExitCode.OK)
+    def command(context: BatchedScanContext) -> ExitCode:
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+        return ExitCode.OK
 
-    assert exit_code == ExitCode.OK
+    assert run_batched_scan(soda_cloud, stage="main", command=command) == ExitCode.OK

--- a/soda-tests/tests/unit/test_batched_scan.py
+++ b/soda-tests/tests/unit/test_batched_scan.py
@@ -21,14 +21,15 @@ def _payload() -> dict:
 
 
 class _StreamingGathererStub(LogsCollector):
-    """LogsQueue stand-in with its streaming-mode contract: records preserved
-    on emit (via the collector base), get_all_logs empty, failure reports
-    select error records only."""
+    """LogsQueue stand-in with its streaming-mode contract: records preserved on emit (via the collector
+    base), get_all_logs empty, failure reports select error records only. ``on_close`` lets ordering tests
+    observe the final flush."""
 
-    def __init__(self):
+    def __init__(self, on_close=None):
         super().__init__()
         self.reset()
         self.closed = False
+        self._on_close = on_close
 
     def get_all_logs(self):
         return []
@@ -38,6 +39,8 @@ class _StreamingGathererStub(LogsCollector):
 
     def close(self):
         self.closed = True
+        if self._on_close is not None:
+            self._on_close()
 
 
 def test_context_insert_results_batches_when_scan_reference_set():
@@ -156,12 +159,12 @@ def test_run_batched_scan_without_scan_id_is_fully_sync(monkeypatch):
 
 
 @patch("soda_core.common.logs_queue.LogsQueue")
-def test_run_batched_scan_happy_path_starts_batches_then_ends(mock_logs_queue_cls, monkeypatch):
+def test_run_batched_scan_happy_path_starts_batches_flushes_then_ends(mock_logs_queue_cls, monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
-    mock_logs_queue_cls.return_value = _StreamingGathererStub()
     order = []
+    mock_logs_queue_cls.return_value = _StreamingGathererStub(on_close=lambda: order.append("flush"))
     soda_cloud.insert_scan_data_batch.side_effect = lambda *args, **kwargs: order.append("insert") or True
     soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
 
@@ -174,7 +177,8 @@ def test_run_batched_scan_happy_path_starts_batches_then_ends(mock_logs_queue_cl
 
     assert exit_code == ExitCode.OK
     soda_cloud.scan_start.assert_called_once_with("scan-123", "my_scan", "postgres", DATA_TIMESTAMP)
-    assert order == ["insert", "end"]
+    # The stream's final flush (gatherer close) happens BEFORE the scan is ended.
+    assert order == ["insert", "flush", "end"]
     soda_cloud.scan_end_async.assert_called_once_with("org/ref-1")
 
 
@@ -197,14 +201,14 @@ def test_run_batched_scan_degrades_to_sync_when_scan_start_fails(monkeypatch):
 
 
 @patch("soda_core.common.logs_queue.LogsQueue")
-def test_run_batched_scan_failure_after_start_reports_unsent_errors_then_ends(mock_logs_queue_cls, monkeypatch):
+def test_run_batched_scan_failure_after_start_reports_unsent_errors_and_leaves_the_scan_unended(
+    mock_logs_queue_cls, monkeypatch
+):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
     mock_logs_queue_cls.return_value = _StreamingGathererStub()
-    order = []
-    soda_cloud.mark_scan_as_failed.side_effect = lambda *args, **kwargs: order.append("mark") or True
-    soda_cloud.scan_end_async.side_effect = lambda *args, **kwargs: order.append("end") or True
+    soda_cloud.mark_scan_as_failed.return_value = True
 
     def command(context: BatchedScanContext) -> ExitCode:
         context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
@@ -213,7 +217,9 @@ def test_run_batched_scan_failure_after_start_reports_unsent_errors_then_ends(mo
     exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
 
     assert exit_code == ExitCode.LOG_ERRORS
-    assert order == ["mark", "end"]
+    soda_cloud.mark_scan_as_failed.assert_called_once()
+    # No results were delivered: the scan is NOT ended — the failure report owns its terminal state.
+    soda_cloud.scan_end_async.assert_not_called()
     # The report carries the streaming gatherer's selection: error records only.
     reported = soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"]
     assert reported and all(record.levelno >= logging.ERROR for record in reported)
@@ -243,11 +249,34 @@ def test_run_batched_scan_end_failure_is_not_fatal(mock_logs_queue_cls, monkeypa
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()
     soda_cloud.scan_start.return_value = "org/ref-1"
+    soda_cloud.insert_scan_data_batch.return_value = True
     soda_cloud.scan_end_async.return_value = False
     mock_logs_queue_cls.return_value = _StreamingGathererStub()
 
     def command(context: BatchedScanContext) -> ExitCode:
         context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+        assert context.insert_results(_payload()) is True
         return ExitCode.OK
 
     assert run_batched_scan(soda_cloud, stage="main", command=command) == ExitCode.OK
+    soda_cloud.scan_end_async.assert_called_once()
+
+
+@patch("soda_core.common.logs_queue.LogsQueue")
+def test_run_batched_scan_rejected_results_leave_the_scan_unended(mock_logs_queue_cls, monkeypatch):
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.scan_start.return_value = "org/ref-1"
+    soda_cloud.insert_scan_data_batch.return_value = False
+    mock_logs_queue_cls.return_value = _StreamingGathererStub()
+
+    def command(context: BatchedScanContext) -> ExitCode:
+        context.start_scan("my_scan", "postgres", DATA_TIMESTAMP)
+        return ExitCode.OK if context.insert_results(_payload()) else ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+    exit_code = run_batched_scan(soda_cloud, stage="main", command=command)
+
+    assert exit_code == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+    # Undelivered results: ending the scan would close it "cleanly" with nothing in it — the exit-code
+    # fallback (launcher) owns the terminal state instead.
+    soda_cloud.scan_end_async.assert_not_called()

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -89,6 +89,9 @@ class _FakeImpl(CheckCollectionImpl):
     yaml_class = _FakeYaml
     result_class = _FakeResult
 
+    # Instances the executor constructed, for tests asserting construction kwargs.
+    constructed_instances: list = []
+
     def __init__(
         self,
         yaml,
@@ -110,6 +113,8 @@ class _FakeImpl(CheckCollectionImpl):
         # ``None`` — no instance attribute needed.
         self.yaml = yaml
         self.logs = Logs()
+        self.batched_scan_context = kwargs.get("batched_scan_context")
+        _FakeImpl.constructed_instances.append(self)
         # ``raise_on_verify`` lives on the yaml_source for per-instance control;
         # the FakeYaml wrapper carries the source reference through.
         source = getattr(yaml, "yaml_source", None)
@@ -192,6 +197,20 @@ def test_execute_check_collections_runs_each_item_in_order():
     labels = [r.check_collection.dataset_name for r in session_result.results]
     assert labels == ["a", "b", "c"]
     assert all(r.status is CheckCollectionStatus.PASSED for r in session_result.results)
+
+
+def test_execute_check_collections_threads_batched_scan_context_into_impls():
+    _FakeImpl.constructed_instances.clear()
+    context_sentinel = object()
+
+    execute_check_collections(
+        yaml_sources=[_LabelledSource("a")],
+        data_source_impl=None,
+        batched_scan_context=context_sentinel,
+    )
+
+    assert len(_FakeImpl.constructed_instances) == 1
+    assert _FakeImpl.constructed_instances[0].batched_scan_context is context_sentinel
 
 
 def test_execute_check_collections_isolates_per_item_errors_by_default():

--- a/soda-tests/tests/unit/test_cli_data_source_handlers.py
+++ b/soda-tests/tests/unit/test_cli_data_source_handlers.py
@@ -292,6 +292,45 @@ def test_discover_results_send_rejected_exits_results_not_sent(mock_discover_dat
     soda_cloud.mark_scan_as_failed.assert_not_called()
 
 
+@patch("soda_core.discovery.discovery.discover_dataset_dqns")
+def test_discover_with_batched_context_routes_upload_through_it(mock_discover_dataset_dqns):
+    soda_cloud = MagicMock()
+    batched_scan_context = MagicMock()
+    batched_scan_context.insert_results.return_value = True
+    mock_discover_dataset_dqns.return_value = ["ds/schema/table"]
+
+    exit_code = handle_discover_data_source(
+        _data_source_impl_fake(),
+        soda_cloud,
+        scan_definition_name="my_scan",
+        batched_scan_context=batched_scan_context,
+    )
+
+    assert exit_code == ExitCode.OK
+    batched_scan_context.insert_results.assert_called_once()
+    (payload,), _ = batched_scan_context.insert_results.call_args
+    assert payload["type"] == "sodaCoreInsertScanResults"
+    soda_cloud.insert_scan_results.assert_not_called()
+
+
+@patch("soda_core.discovery.discovery.discover_dataset_dqns")
+def test_discover_with_batched_context_rejected_upload_exits_results_not_sent(mock_discover_dataset_dqns):
+    soda_cloud = MagicMock()
+    batched_scan_context = MagicMock()
+    batched_scan_context.insert_results.return_value = False
+    mock_discover_dataset_dqns.return_value = ["ds/schema/table"]
+
+    exit_code = handle_discover_data_source(
+        _data_source_impl_fake(),
+        soda_cloud,
+        scan_definition_name="my_scan",
+        batched_scan_context=batched_scan_context,
+    )
+
+    assert exit_code == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+    soda_cloud.mark_scan_as_failed.assert_not_called()
+
+
 @patch("soda_core.discovery.discovery_payload.build_discovery_payload")
 @patch("soda_core.discovery.discovery.discover_dataset_dqns")
 def test_discover_unexpected_post_query_exception_propagates(mock_discover_dataset_dqns, mock_build_discovery_payload):

--- a/soda-tests/tests/unit/test_cli_data_source_handlers.py
+++ b/soda-tests/tests/unit/test_cli_data_source_handlers.py
@@ -307,6 +307,13 @@ def test_discover_with_batched_context_routes_upload_through_it(mock_discover_da
     )
 
     assert exit_code == ExitCode.OK
+    # The handler opens the async bracket with the resolved scan coordinates
+    # before the discovery queries run, so their logs stream mid-run.
+    batched_scan_context.start_scan.assert_called_once()
+    start_kwargs = batched_scan_context.start_scan.call_args.kwargs
+    assert start_kwargs["definition_name"] == "my_scan"
+    assert start_kwargs["default_data_source"] == "test_ds"
+    assert start_kwargs["data_timestamp"] is not None
     batched_scan_context.insert_results.assert_called_once()
     (payload,), _ = batched_scan_context.insert_results.call_args
     assert payload["type"] == "sodaCoreInsertScanResults"

--- a/soda-tests/tests/unit/test_cli_data_source_handlers.py
+++ b/soda-tests/tests/unit/test_cli_data_source_handlers.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.data_source import (
+    build_streaming_logs,
     handle_create_data_source,
     handle_discover_data_source,
     handle_discover_data_source_locally,
@@ -101,8 +102,11 @@ def test_test_data_source_uploads_logs_when_scan_id_provided(
 
     assert exit_code == ExitCode.OK
     mock_logs_queue_cls.assert_called_once_with(
+        # Connection tests stream to the scan's main stage: the backend's
+        # CoreStageType has no test-connection value (the old "test_connection"
+        # string already degraded to MAIN server-side).
         soda_cloud=mock_soda_cloud,
-        stage="test_connection",
+        stage="main",
         scan_id="scan-id-123",
         dataset="",
     )
@@ -183,6 +187,47 @@ def test_test_data_source_uploader_captures_and_flushes_when_parsing_raises(
     # Uploader is attached before parsing, so an early parse failure is still captured and flushed.
     mock_logs_cls.assert_called_once_with(gatherer=mock_logs_queue)
     mock_logs.close.assert_called_once()
+
+
+# build_streaming_logs: the generalized scan-id-keyed streaming-Logs builder
+# (the test-connection uploader above is its file-path-resolving wrapper).
+
+
+@patch("soda_core.cli.handlers.data_source.EnvConfigHelper")
+def test_build_streaming_logs_returns_none_without_scan_id(mock_env_config_helper_cls):
+    mock_env_config_helper_cls.return_value.soda_scan_id = None
+
+    assert build_streaming_logs(soda_cloud=MagicMock(), stage="main") is None
+
+
+def test_build_streaming_logs_returns_none_without_soda_cloud():
+    assert build_streaming_logs(soda_cloud=None, stage="main", scan_id="scan-id-123") is None
+
+
+@patch("soda_core.cli.handlers.data_source.Logs")
+@patch("soda_core.cli.handlers.data_source.LogsQueue")
+def test_build_streaming_logs_builds_scan_id_keyed_queue(mock_logs_queue_cls, mock_logs_cls):
+    soda_cloud = MagicMock()
+
+    result = build_streaming_logs(soda_cloud=soda_cloud, stage="main", scan_id="scan-id-123")
+
+    mock_logs_queue_cls.assert_called_once_with(soda_cloud=soda_cloud, stage="main", scan_id="scan-id-123", dataset="")
+    mock_logs_cls.assert_called_once_with(gatherer=mock_logs_queue_cls.return_value)
+    assert result is mock_logs_cls.return_value
+
+
+@patch("soda_core.cli.handlers.data_source.EnvConfigHelper")
+@patch("soda_core.cli.handlers.data_source.Logs")
+@patch("soda_core.cli.handlers.data_source.LogsQueue")
+def test_build_streaming_logs_reads_scan_id_from_env_when_not_passed(
+    mock_logs_queue_cls, mock_logs_cls, mock_env_config_helper_cls
+):
+    mock_env_config_helper_cls.return_value.soda_scan_id = "scan-id-env"
+
+    build_streaming_logs(soda_cloud=MagicMock(), stage="diagnosticWarehouse")
+
+    assert mock_logs_queue_cls.call_args.kwargs["scan_id"] == "scan-id-env"
+    assert mock_logs_queue_cls.call_args.kwargs["stage"] == "diagnosticWarehouse"
 
 
 # Discovery handler tests. The handler receives fully resolved dependencies

--- a/soda-tests/tests/unit/test_cli_dependencies.py
+++ b/soda-tests/tests/unit/test_cli_dependencies.py
@@ -237,6 +237,31 @@ def test_run_with_command_raising_unexpected_exception_marks_scan_failed(monkeyp
     assert failure_records[0].exc_info is not None
 
 
+def test_run_with_prebuilt_logs_hands_them_to_the_command_and_reports_gatherer_selection(monkeypatch):
+    # A pre-built (e.g. streaming-backed) Logs may be handed in; the failure
+    # report then attaches whatever its gatherer selects — no mode branch here.
+    monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
+    soda_cloud = MagicMock()
+    soda_cloud.mark_scan_as_failed.return_value = True
+
+    selected_records = [MagicMock()]
+    gatherer = MagicMock()
+    gatherer.records_for_failure_report.return_value = selected_records
+    logs = Logs(gatherer=gatherer)
+    seen = {}
+
+    def command(inner_logs):
+        seen["logs"] = inner_logs
+        raise RuntimeError("boom")
+
+    exit_code = run_with_failure_reporting(soda_cloud, command, logs=logs)
+
+    assert exit_code == ExitCode.LOG_ERRORS
+    assert seen["logs"] is logs
+    assert soda_cloud.mark_scan_as_failed.call_args.kwargs["logs"] is selected_records
+    gatherer.close.assert_called_once()
+
+
 def test_run_with_rejected_mark_scan_as_failed_exits_results_not_sent(monkeypatch):
     monkeypatch.setenv("SODA_SCAN_ID", "scan-123")
     soda_cloud = MagicMock()

--- a/soda-tests/tests/unit/test_cli_discover.py
+++ b/soda-tests/tests/unit/test_cli_discover.py
@@ -5,25 +5,36 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from soda_core.cli.cli import create_cli_parser
 from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.batched_scan import BatchedScanContext
 from soda_core.cli.handlers.failure_reporting import ScanExecutionFailedException
 from soda_core.common.logs import Logs
 
 
+def _fake_batched_context(soda_cloud=None) -> BatchedScanContext:
+    return BatchedScanContext(
+        logs=Logs(), soda_cloud=soda_cloud if soda_cloud is not None else MagicMock(), scan_id=None, scan_reference=None
+    )
+
+
+def _run_command_with_fake_context(soda_cloud, stage, command, **_kwargs):
+    return command(_fake_batched_context(soda_cloud))
+
+
 @patch("soda_core.cli.cli.handle_discover_data_source")
-@patch("soda_core.cli.cli.run_with_failure_reporting")
+@patch("soda_core.cli.cli.run_batched_scan")
 @patch("soda_core.cli.cli.resolve_data_source")
 @patch("soda_core.cli.cli.resolve_soda_cloud")
 def test_cli_arg_mapping_for_data_source_discover(
-    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_with_failure_reporting, mock_handler
+    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_batched_scan, mock_handler
 ):
-    # The wiring resolves the reporting channel first, passes it to the wrapper,
-    # and resolves the data source inside the wrapped command; the fake wrapper
+    # The wiring resolves the reporting channel first, passes it to the bracket,
+    # and resolves the data source inside the wrapped command; the fake bracket
     # just runs the command so the handler call can be asserted.
     data_source_impl = MagicMock()
     soda_cloud = MagicMock()
     mock_resolve_soda_cloud.return_value = soda_cloud
     mock_resolve_data_source.return_value = data_source_impl
-    mock_run_with_failure_reporting.side_effect = lambda soda_cloud, command: command(Logs())
+    mock_run_batched_scan.side_effect = _run_command_with_fake_context
     mock_handler.return_value = ExitCode.OK
     sys.argv = [
         "soda",
@@ -46,19 +57,22 @@ def test_cli_arg_mapping_for_data_source_discover(
     assert e.value.code == ExitCode.OK
     mock_resolve_soda_cloud.assert_called_once_with("cloud.yaml")
     mock_resolve_data_source.assert_called_once_with("ds.yaml")
-    run_args, _ = mock_run_with_failure_reporting.call_args
+    run_args, run_kwargs = mock_run_batched_scan.call_args
     assert run_args[0] is soda_cloud
-    # The wrapper's Logs collector is threaded through to the handler so the
-    # success payload can carry the run's logs; ANY because the collector is
-    # constructed inside the wrapper.
+    assert run_kwargs["stage"] == "main"
+    # The bracket's Logs collector and context are threaded through to the
+    # handler; ANY because both are constructed inside the bracket.
     mock_handler.assert_called_once_with(
         data_source_impl,
         soda_cloud,
         include=["cust%"],
         exclude=["tmp%"],
         logs=ANY,
+        batched_scan_context=ANY,
         scan_definition_name="my_scan",
     )
+    handler_kwargs = mock_handler.call_args.kwargs
+    assert handler_kwargs["logs"] is handler_kwargs["batched_scan_context"].logs
 
 
 # Cloud-flow guard: the reporting channel resolves before the wrapper. When it
@@ -66,14 +80,14 @@ def test_cli_arg_mapping_for_data_source_discover(
 # the managed launcher's fallback marks the scan failed.
 
 
-@patch("soda_core.cli.cli.run_with_failure_reporting")
+@patch("soda_core.cli.cli.run_batched_scan")
 @patch("soda_core.cli.cli.resolve_data_source")
 @patch(
     "soda_core.cli.cli.resolve_soda_cloud",
     side_effect=ScanExecutionFailedException("A Soda Cloud configuration file (-sc) is required."),
 )
 def test_cli_discover_with_unusable_soda_cloud_exits_results_not_sent(
-    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_with_failure_reporting, caplog
+    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_batched_scan, caplog
 ):
     sys.argv = ["soda", "data-source", "discover", "-ds", "ds.yaml", "-sc", "cloud.yaml"]
     args = create_cli_parser().parse_args()
@@ -87,14 +101,14 @@ def test_cli_discover_with_unusable_soda_cloud_exits_results_not_sent(
     # Reorder proof: the reporting channel resolves first — the data source is
     # never resolved and the wrapper never runs.
     mock_resolve_data_source.assert_not_called()
-    mock_run_with_failure_reporting.assert_not_called()
+    mock_run_batched_scan.assert_not_called()
 
 
-@patch("soda_core.cli.cli.run_with_failure_reporting")
+@patch("soda_core.cli.cli.run_batched_scan")
 @patch("soda_core.cli.cli.resolve_data_source")
 @patch("soda_core.cli.cli.resolve_soda_cloud", side_effect=RuntimeError("boom"))
 def test_cli_discover_with_soda_cloud_resolution_raising_raw_exits_results_not_sent(
-    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_with_failure_reporting, caplog
+    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_batched_scan, caplog
 ):
     sys.argv = ["soda", "data-source", "discover", "-ds", "ds.yaml", "-sc", "cloud.yaml"]
     args = create_cli_parser().parse_args()
@@ -106,7 +120,7 @@ def test_cli_discover_with_soda_cloud_resolution_raising_raw_exits_results_not_s
     failure_records = [r for r in caplog.records if "boom" in r.getMessage()]
     assert len(failure_records) == 1
     assert failure_records[0].exc_info is not None
-    mock_run_with_failure_reporting.assert_not_called()
+    mock_run_batched_scan.assert_not_called()
 
 
 # Local flow wiring: without -sc, discovery runs locally — the data source is
@@ -206,10 +220,10 @@ def test_cli_discover_with_scan_id_but_without_soda_cloud_exits_results_not_sent
 
 
 @patch("soda_core.cli.cli.handle_discover_data_source")
-@patch("soda_core.cli.cli.run_with_failure_reporting", return_value=ExitCode.OK)
+@patch("soda_core.cli.cli.run_batched_scan", return_value=ExitCode.OK)
 @patch("soda_core.cli.cli.resolve_soda_cloud")
 def test_cli_discover_with_scan_id_and_soda_cloud_takes_cloud_flow(
-    mock_resolve_soda_cloud, mock_run_with_failure_reporting, mock_handler, monkeypatch
+    mock_resolve_soda_cloud, mock_run_batched_scan, mock_handler, monkeypatch
 ):
     # The misconfiguration guard only applies without -sc: a managed scan with a
     # cloud config goes through the regular Cloud flow.
@@ -221,7 +235,7 @@ def test_cli_discover_with_scan_id_and_soda_cloud_takes_cloud_flow(
         args.handler_func(args)
 
     assert e.value.code == ExitCode.OK
-    mock_run_with_failure_reporting.assert_called_once()
+    mock_run_batched_scan.assert_called_once()
 
 
 @patch("soda_core.cli.cli.handle_discover_data_source_locally", return_value=ExitCode.OK)
@@ -316,14 +330,14 @@ def test_cli_discover_cloud_flow_without_scan_definition_name_ad_hoc_exits_log_e
 
 
 @patch("soda_core.cli.cli.handle_discover_data_source", return_value=ExitCode.OK)
-@patch("soda_core.cli.cli.run_with_failure_reporting")
+@patch("soda_core.cli.cli.run_batched_scan")
 @patch("soda_core.cli.cli.resolve_data_source")
 @patch("soda_core.cli.cli.resolve_soda_cloud")
 def test_cli_discover_cloud_flow_resolves_scan_definition_name_from_env(
-    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_with_failure_reporting, mock_handler, monkeypatch
+    mock_resolve_soda_cloud, mock_resolve_data_source, mock_run_batched_scan, mock_handler, monkeypatch
 ):
     monkeypatch.setenv("SODA_SCAN_DEFINITION", "env_scan_def")
-    mock_run_with_failure_reporting.side_effect = lambda soda_cloud, command: command(Logs())
+    mock_run_batched_scan.side_effect = _run_command_with_fake_context
     sys.argv = ["soda", "data-source", "discover", "-ds", "ds.yaml", "-sc", "cloud.yaml"]
 
     args = create_cli_parser().parse_args()

--- a/soda-tests/tests/unit/test_data_source_connection_query_logging.py
+++ b/soda-tests/tests/unit/test_data_source_connection_query_logging.py
@@ -7,9 +7,11 @@ tabulate/truncation formatting on every query even when DEBUG is off. These
 tests pin: (a) exactly one DEBUG record with duration + row count per query
 (rows yielded/processed at completion for the streaming variants), (b) the
 public per-connection ``query_counters`` accumulator extensions read to build
-scan summaries, (c) that the expensive row-formatting helpers are skipped
-entirely above DEBUG, and (d) that streamed SQL is truncated the same way
-``execute_query`` truncates it.
+scan summaries — recorded even when the query fails, and snapshot-able for
+per-scan totals, (c) that the expensive row-formatting helpers are skipped
+entirely above DEBUG, (d) that streamed SQL is truncated the same way
+``execute_query`` truncates it, and (e) that ``log_query=False`` silences the
+new completion lines too, not just the pre-execution ones.
 
 Uses a real DuckDB connection (via ``DuckDBDataSourceImpl.from_existing_cursor``)
 rather than mocks, so `cursor.fetchall()`/`fetchone()` behavior is real.
@@ -18,12 +20,11 @@ rather than mocks, so `cursor.fetchall()`/`fetchone()` behavior is real.
 from __future__ import annotations
 
 import logging
-import re
 from unittest.mock import MagicMock
 
 import duckdb
 import pytest
-from soda_core.common.data_source_connection import DataSourceConnection
+from soda_core.common.data_source_connection import DataSourceConnection, QueryCounters
 from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBDataSourceImpl
 
 SODA_LOGGER_NAME = "soda"
@@ -79,6 +80,33 @@ class TestQueryCounters:
         assert connection.query_counters.query_count == 2
 
 
+class TestQueryCountersSnapshot:
+    """Task 4: no reset() (shared-connection footgun) — snapshot-and-subtract instead."""
+
+    def test_snapshot_is_an_independent_copy(self, connection):
+        connection.execute_query("SELECT * FROM t")
+        snapshot = connection.query_counters.snapshot()
+        assert snapshot is not connection.query_counters
+        assert isinstance(snapshot, QueryCounters)
+
+        connection.execute_query("SELECT * FROM t")
+
+        # Later queries don't retroactively mutate an already-taken snapshot.
+        assert snapshot.query_count == 1
+        assert connection.query_counters.query_count == 2
+
+    def test_snapshot_and_subtract_yields_per_scan_totals(self, connection):
+        connection.execute_query("SELECT * FROM t")  # pre-scan activity on a shared connection
+        before = connection.query_counters.snapshot()
+
+        connection.execute_query("SELECT * FROM t")
+        connection.execute_query("SELECT * FROM t")
+        after = connection.query_counters.snapshot()
+
+        assert after.query_count - before.query_count == 2
+        assert after.total_duration_seconds - before.total_duration_seconds >= 0.0
+
+
 class TestQueryTimingAndRowCountLogging:
     """Task 1: one DEBUG record per query carrying duration + row count."""
 
@@ -90,33 +118,45 @@ class TestQueryTimingAndRowCountLogging:
         records = _debug_records(caplog, "SQL query result")
         assert len(records) == 1
         message = records[0].getMessage()
-        assert re.search(r"\d+\.\d+s", message), f"no duration in: {message}"
         assert "3 rows" in message
+        assert any(part.endswith("s") and part[:-1].replace(".", "", 1).isdigit() for part in message.split())
 
     def test_execute_update_logs_duration_and_row_count(self, connection, caplog):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
 
         connection.execute_update("DELETE FROM t WHERE id = 1")
 
-        records = _debug_records(caplog, "SQL update")
         # First record is the pre-execution "about to run" log; the last one
         # carries the outcome (duration + affected-row count). DuckDB's cursor
         # doesn't report a reliable rowcount for DML (always -1, which
-        # ``_cursor_execute_update_and_commit`` normalizes to 0), so assert the
-        # count is present in the message rather than pinning a specific value.
-        assert len(records) >= 1
-        outcome_message = records[-1].getMessage()
-        assert re.search(r"\d+\.\d+s", outcome_message), f"no duration in: {outcome_message}"
-        assert re.search(r"\d+ rows?", outcome_message), f"no row count in: {outcome_message}"
+        # ``_cursor_execute_update_and_commit`` normalizes to 0) — the exact
+        # count is pinned separately below with a fake cursor.
+        records = _debug_records(caplog, "SQL update affected")
+        assert len(records) == 1
+        assert "0 rows" in records[0].getMessage()
+
+    def test_execute_update_logs_the_cursor_reported_row_count(self, connection, caplog, monkeypatch):
+        """Pins the count against a cursor.rowcount DuckDB can't produce (MINOR 8)."""
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        fake_cursor = MagicMock()
+        fake_cursor.rowcount = 2
+        fake_dbapi_connection = MagicMock()
+        fake_dbapi_connection.cursor.return_value = fake_cursor
+        monkeypatch.setattr(connection, "connection", fake_dbapi_connection)
+
+        rowcount = connection.execute_update("DELETE FROM t WHERE id IN (1, 2)")
+
+        assert rowcount == 2
+        records = _debug_records(caplog, "SQL update affected 2 rows")
+        assert len(records) == 1
 
     def test_execute_query_one_by_one_logs_rows_processed_at_completion(self, connection, caplog):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
 
         connection.execute_query_one_by_one("SELECT * FROM t", lambda row, desc: None)
 
-        records = _debug_records(caplog, "one-by-one")
-        completion_records = [r for r in records if "3" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
-        assert len(completion_records) == 1, f"expected one completion record, got: {[r.getMessage() for r in records]}"
+        records = _debug_records(caplog, "processed 3 rows")
+        assert len(records) == 1, f"expected one completion record, got: {[r.getMessage() for r in caplog.records]}"
 
     def test_execute_query_iterate_logs_rows_yielded_at_completion(self, connection, caplog):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
@@ -124,9 +164,8 @@ class TestQueryTimingAndRowCountLogging:
         with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
             list(result_iterator)
 
-        records = _debug_records(caplog, "iterate")
-        completion_records = [r for r in records if "3" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
-        assert len(completion_records) == 1, f"expected one completion record, got: {[r.getMessage() for r in records]}"
+        records = _debug_records(caplog, "yielded 3 rows")
+        assert len(records) == 1, f"expected one completion record, got: {[r.getMessage() for r in caplog.records]}"
 
     def test_execute_query_iterate_logs_partial_rows_yielded_when_caller_stops_early(self, connection, caplog):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
@@ -134,11 +173,112 @@ class TestQueryTimingAndRowCountLogging:
         with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
             next(result_iterator)  # only consume one of the three rows
 
-        records = _debug_records(caplog, "iterate")
-        completion_records = [r for r in records if "1" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
-        assert (
-            len(completion_records) == 1
-        ), f"expected a 1-row completion record, got: {[r.getMessage() for r in records]}"
+        records = _debug_records(caplog, "yielded 1 rows")
+        assert len(records) == 1, f"expected a 1-row completion record, got: {[r.getMessage() for r in caplog.records]}"
+
+
+class TestCountersAndCompletionLinesRecordedEvenOnFailure:
+    """Task/IMPORTANT-2: a query that ran a while then failed is exactly what a
+    timing summary should surface — counters (and, where the count is known
+    incrementally rather than only on success, the completion line) fire from
+    ``finally``, not just on the happy path."""
+
+    def test_execute_query_failure_still_counted(self, connection):
+        with pytest.raises(Exception):
+            connection.execute_query("SELECT * FROM this_table_does_not_exist")
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_update_failure_still_counted(self, connection):
+        with pytest.raises(Exception):
+            connection.execute_update("DELETE FROM this_table_does_not_exist")
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_one_by_one_failure_still_counted(self, connection):
+        def bad_callback(row, desc):
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            connection.execute_query_one_by_one("SELECT * FROM t", bad_callback)
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_one_by_one_completion_line_reports_partial_count_on_failure(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        def fail_on_second_row(row, desc):
+            fail_on_second_row.calls += 1
+            if fail_on_second_row.calls == 2:
+                raise RuntimeError("boom")
+
+        fail_on_second_row.calls = 0
+
+        with pytest.raises(RuntimeError):
+            connection.execute_query_one_by_one("SELECT * FROM t", fail_on_second_row)
+
+        # rows_processed is tracked incrementally (unlike execute_query's row
+        # count, which is only known on success), so the completion line still
+        # fires with the count reached before the failure.
+        records = _debug_records(caplog, "processed 2 rows")
+        assert len(records) == 1, f"got: {[r.getMessage() for r in caplog.records]}"
+
+    def test_execute_query_iterate_failure_still_counted(self, connection):
+        with pytest.raises(RuntimeError):
+            with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
+                next(result_iterator)
+                raise RuntimeError("boom")
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_iterate_completion_line_reports_partial_count_on_failure(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        with pytest.raises(RuntimeError):
+            with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
+                next(result_iterator)
+                raise RuntimeError("boom")
+
+        records = _debug_records(caplog, "yielded 1 rows")
+        assert len(records) == 1, f"got: {[r.getMessage() for r in caplog.records]}"
+
+
+class TestLogQueryFlagSilencesCompletionLines:
+    """MINOR 6: log_query=False must silence the new completion lines too, not
+    just the pre-execution ones — counting still happens either way."""
+
+    def test_execute_query_log_query_false_suppresses_all_debug_lines(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_query("SELECT * FROM t", log_query=False)
+
+        assert _debug_records(caplog, "SQL query") == []
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_update_log_query_false_suppresses_completion_line(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_update("CREATE TABLE u2 AS SELECT 1", log_query=False)
+
+        assert _debug_records(caplog, "SQL update") == []
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_one_by_one_log_query_false_suppresses_completion_line(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_query_one_by_one("SELECT * FROM t", lambda row, desc: None, log_query=False)
+
+        assert _debug_records(caplog, "one-by-one") == []
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_iterate_log_query_false_suppresses_completion_line(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        with connection.execute_query_iterate("SELECT * FROM t", log_query=False) as result_iterator:
+            list(result_iterator)
+
+        assert _debug_records(caplog, "iterate") == []
+        assert connection.query_counters.query_count == 1
 
 
 class TestDebugFormattingGuard:
@@ -182,6 +322,21 @@ class TestDebugFormattingGuard:
         # the debug-only truncate/tabulate formatting is skipped.
         assert len(result.rows) == 3
 
+    def test_debug_formatting_does_not_crash_when_cursor_description_is_none(self, connection, monkeypatch, caplog):
+        """MINOR 9: some drivers can return a None description; the DEBUG-only
+        header-building must not newly crash on that."""
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        fake_cursor = MagicMock()
+        fake_cursor.description = None
+        fake_cursor.fetchall.return_value = [(1,), (2,)]
+        fake_dbapi_connection = MagicMock()
+        fake_dbapi_connection.cursor.return_value = fake_cursor
+        monkeypatch.setattr(connection, "connection", fake_dbapi_connection)
+
+        result = connection.execute_query("SELECT 1")  # must not raise
+
+        assert len(result.rows) == 2
+
 
 class TestSqlTruncationOnStreamingPaths:
     """Task 4: one-by-one and iterate truncate logged SQL like execute_query does."""
@@ -201,6 +356,7 @@ class TestSqlTruncationOnStreamingPaths:
         assert len(pre_execution_records) == 1
         assert len(pre_execution_records[0].getMessage()) < len(sql)
         assert sql not in pre_execution_records[0].getMessage()
+        assert "TEST_DS" in pre_execution_records[0].getMessage()  # datasource name still present (IMPORTANT 5)
 
     def test_execute_query_iterate_truncates_logged_sql(self, connection, caplog):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
@@ -218,3 +374,4 @@ class TestSqlTruncationOnStreamingPaths:
         assert len(pre_execution_records) == 1
         assert len(pre_execution_records[0].getMessage()) < len(sql)
         assert sql not in pre_execution_records[0].getMessage()
+        assert "TEST_DS" in pre_execution_records[0].getMessage()  # datasource name still present (IMPORTANT 5)

--- a/soda-tests/tests/unit/test_data_source_connection_query_logging.py
+++ b/soda-tests/tests/unit/test_data_source_connection_query_logging.py
@@ -110,12 +110,16 @@ class TestQueryCountersSnapshot:
 class TestQueryTimingAndRowCountLogging:
     """Task 1: one DEBUG record per query carrying duration + row count."""
 
-    def test_execute_query_logs_duration_and_row_count(self, connection, caplog):
+    def test_execute_query_logs_duration_and_row_count(self, connection, caplog, monkeypatch):
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        # Pin against ambient SODA_LOG_PAYLOADS leaking in: with the payload dump
+        # on, a second "SQL query result rows (...)" line would also match a bare
+        # "SQL query result" substring.
+        monkeypatch.delenv("SODA_LOG_PAYLOADS", raising=False)
 
         connection.execute_query("SELECT * FROM t")
 
-        records = _debug_records(caplog, "SQL query result")
+        records = _debug_records(caplog, "SQL query result in")
         assert len(records) == 1
         message = records[0].getMessage()
         assert "3 rows" in message

--- a/soda-tests/tests/unit/test_data_source_connection_query_logging.py
+++ b/soda-tests/tests/unit/test_data_source_connection_query_logging.py
@@ -1,0 +1,220 @@
+"""Unit tests for query timing, per-connection counters, and DEBUG-formatting
+guards on ``DataSourceConnection``.
+
+Extension scans (metric monitoring, profiling) log through this engine but
+today get no query timing, no row-count logging, and pay the cost of
+tabulate/truncation formatting on every query even when DEBUG is off. These
+tests pin: (a) exactly one DEBUG record with duration + row count per query
+(rows yielded/processed at completion for the streaming variants), (b) the
+public per-connection ``query_counters`` accumulator extensions read to build
+scan summaries, (c) that the expensive row-formatting helpers are skipped
+entirely above DEBUG, and (d) that streamed SQL is truncated the same way
+``execute_query`` truncates it.
+
+Uses a real DuckDB connection (via ``DuckDBDataSourceImpl.from_existing_cursor``)
+rather than mocks, so `cursor.fetchall()`/`fetchone()` behavior is real.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+from soda_core.common.data_source_connection import DataSourceConnection
+from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBDataSourceImpl
+
+SODA_LOGGER_NAME = "soda"
+
+
+@pytest.fixture
+def connection() -> DataSourceConnection:
+    conn = duckdb.connect(":memory:")
+    conn.sql("CREATE TABLE t AS SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)")
+    data_source_impl = DuckDBDataSourceImpl.from_existing_cursor(conn, "TEST_DS")
+    data_source_impl.open_connection()
+    yield data_source_impl.data_source_connection
+    data_source_impl.close_connection()
+
+
+def _debug_records(caplog, substring: str) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == SODA_LOGGER_NAME and substring in r.getMessage()]
+
+
+class TestQueryCounters:
+    """Task 2: a small, dumb, public per-connection counters object."""
+
+    def test_starts_at_zero(self, connection):
+        assert connection.query_counters.query_count == 0
+        assert connection.query_counters.total_duration_seconds == 0.0
+
+    def test_execute_query_increments_counters(self, connection):
+        connection.execute_query("SELECT * FROM t")
+
+        assert connection.query_counters.query_count == 1
+        assert connection.query_counters.total_duration_seconds >= 0.0
+
+    def test_execute_update_increments_counters(self, connection):
+        connection.execute_update("CREATE TABLE u AS SELECT 1")
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_one_by_one_increments_counters(self, connection):
+        connection.execute_query_one_by_one("SELECT * FROM t", lambda row, desc: None)
+
+        assert connection.query_counters.query_count == 1
+
+    def test_execute_query_iterate_increments_counters(self, connection):
+        with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
+            list(result_iterator)
+
+        assert connection.query_counters.query_count == 1
+
+    def test_counters_accumulate_across_queries(self, connection):
+        connection.execute_query("SELECT * FROM t")
+        connection.execute_query("SELECT * FROM t")
+
+        assert connection.query_counters.query_count == 2
+
+
+class TestQueryTimingAndRowCountLogging:
+    """Task 1: one DEBUG record per query carrying duration + row count."""
+
+    def test_execute_query_logs_duration_and_row_count(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_query("SELECT * FROM t")
+
+        records = _debug_records(caplog, "SQL query result")
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert re.search(r"\d+\.\d+s", message), f"no duration in: {message}"
+        assert "3 rows" in message
+
+    def test_execute_update_logs_duration_and_row_count(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_update("DELETE FROM t WHERE id = 1")
+
+        records = _debug_records(caplog, "SQL update")
+        # First record is the pre-execution "about to run" log; the last one
+        # carries the outcome (duration + affected-row count). DuckDB's cursor
+        # doesn't report a reliable rowcount for DML (always -1, which
+        # ``_cursor_execute_update_and_commit`` normalizes to 0), so assert the
+        # count is present in the message rather than pinning a specific value.
+        assert len(records) >= 1
+        outcome_message = records[-1].getMessage()
+        assert re.search(r"\d+\.\d+s", outcome_message), f"no duration in: {outcome_message}"
+        assert re.search(r"\d+ rows?", outcome_message), f"no row count in: {outcome_message}"
+
+    def test_execute_query_one_by_one_logs_rows_processed_at_completion(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        connection.execute_query_one_by_one("SELECT * FROM t", lambda row, desc: None)
+
+        records = _debug_records(caplog, "one-by-one")
+        completion_records = [r for r in records if "3" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
+        assert len(completion_records) == 1, f"expected one completion record, got: {[r.getMessage() for r in records]}"
+
+    def test_execute_query_iterate_logs_rows_yielded_at_completion(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
+            list(result_iterator)
+
+        records = _debug_records(caplog, "iterate")
+        completion_records = [r for r in records if "3" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
+        assert len(completion_records) == 1, f"expected one completion record, got: {[r.getMessage() for r in records]}"
+
+    def test_execute_query_iterate_logs_partial_rows_yielded_when_caller_stops_early(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+
+        with connection.execute_query_iterate("SELECT * FROM t") as result_iterator:
+            next(result_iterator)  # only consume one of the three rows
+
+        records = _debug_records(caplog, "iterate")
+        completion_records = [r for r in records if "1" in r.getMessage() and re.search(r"\d+\.\d+s", r.getMessage())]
+        assert (
+            len(completion_records) == 1
+        ), f"expected a 1-row completion record, got: {[r.getMessage() for r in records]}"
+
+
+class TestDebugFormattingGuard:
+    """Task 3: tabulate/truncate must not run unless DEBUG is enabled."""
+
+    def test_tabulate_not_called_when_debug_disabled(self, connection, monkeypatch, caplog):
+        caplog.set_level(logging.INFO, logger=SODA_LOGGER_NAME)
+        tabulate_spy = MagicMock(side_effect=AssertionError("tabulate should not run above DEBUG"))
+        monkeypatch.setattr("soda_core.common.data_source_connection.tabulate", tabulate_spy)
+
+        connection.execute_query("SELECT * FROM t")  # must not raise
+
+        tabulate_spy.assert_not_called()
+
+    def test_truncate_rows_not_called_when_debug_disabled(self, connection, monkeypatch, caplog):
+        caplog.set_level(logging.INFO, logger=SODA_LOGGER_NAME)
+        truncate_spy = MagicMock(wraps=connection.truncate_rows)
+        monkeypatch.setattr(connection, "truncate_rows", truncate_spy)
+
+        connection.execute_query("SELECT * FROM t")
+
+        truncate_spy.assert_not_called()
+
+    def test_tabulate_called_when_debug_enabled(self, connection, monkeypatch, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        from tabulate import tabulate as real_tabulate
+
+        tabulate_spy = MagicMock(wraps=real_tabulate)
+        monkeypatch.setattr("soda_core.common.data_source_connection.tabulate", tabulate_spy)
+
+        connection.execute_query("SELECT * FROM t")
+
+        tabulate_spy.assert_called_once()
+
+    def test_returned_rows_unaffected_by_debug_level(self, connection, caplog):
+        caplog.set_level(logging.INFO, logger=SODA_LOGGER_NAME)
+
+        result = connection.execute_query("SELECT * FROM t")
+
+        # _format_rows() still runs (needed for the return value) even though
+        # the debug-only truncate/tabulate formatting is skipped.
+        assert len(result.rows) == 3
+
+
+class TestSqlTruncationOnStreamingPaths:
+    """Task 4: one-by-one and iterate truncate logged SQL like execute_query does."""
+
+    def test_execute_query_one_by_one_truncates_logged_sql(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        long_comment = "x" * (DataSourceConnection.MAX_CHARS_PER_SQL + 500)
+        sql = f"SELECT * FROM t -- {long_comment}"
+
+        connection.execute_query_one_by_one(sql, lambda row, desc: None)
+
+        pre_execution_records = [
+            r
+            for r in caplog.records
+            if r.name == SODA_LOGGER_NAME and "one-by-one" in r.getMessage() and "SELECT" in r.getMessage()
+        ]
+        assert len(pre_execution_records) == 1
+        assert len(pre_execution_records[0].getMessage()) < len(sql)
+        assert sql not in pre_execution_records[0].getMessage()
+
+    def test_execute_query_iterate_truncates_logged_sql(self, connection, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        long_comment = "x" * (DataSourceConnection.MAX_CHARS_PER_SQL + 500)
+        sql = f"SELECT * FROM t -- {long_comment}"
+
+        with connection.execute_query_iterate(sql) as result_iterator:
+            list(result_iterator)
+
+        pre_execution_records = [
+            r
+            for r in caplog.records
+            if r.name == SODA_LOGGER_NAME and "iterate" in r.getMessage() and "SELECT" in r.getMessage()
+        ]
+        assert len(pre_execution_records) == 1
+        assert len(pre_execution_records[0].getMessage()) < len(sql)
+        assert sql not in pre_execution_records[0].getMessage()

--- a/soda-tests/tests/unit/test_logs_queue.py
+++ b/soda-tests/tests/unit/test_logs_queue.py
@@ -125,7 +125,13 @@ def test_logs_records_for_failure_report_delegates_to_gatherer():
 
 
 def test_switch_gatherer_replays_history_and_closes_the_old_gatherer():
-    old_gatherer = LogsCollector()
+    class _ClosableCollector(LogsCollector):
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    old_gatherer = _ClosableCollector()
     old_gatherer.emit(_record(logging.INFO, "captured before the switch"))
     new_gatherer = MagicMock()
     logs = Logs(gatherer=old_gatherer)
@@ -135,5 +141,25 @@ def test_switch_gatherer_replays_history_and_closes_the_old_gatherer():
         assert logs.gatherer is new_gatherer
         (replayed_record,), _ = new_gatherer.emit.call_args
         assert replayed_record.getMessage() == "captured before the switch"
+        assert old_gatherer.closed
+    finally:
+        logs.close()
+
+
+@patch("soda_core.common.logs_queue._to_jsonl", return_value="")
+def test_streaming_gatherer_serves_error_status_determination(mock_to_jsonl):
+    # The status-determination surface (has_errors/get_errors) must work on a real LogsQueue: a streaming
+    # run's error records are preserved and reported exactly like the in-memory collector's.
+    logs_queue = _stopped_queue(scan_id="scan-id-123")
+    logs = Logs(gatherer=logs_queue)
+    try:
+        logs_queue.emit(_record(logging.INFO, "progress line"))
+        assert logs.has_errors is False
+
+        logs_queue.emit(_record(logging.ERROR, "error line"))
+
+        assert [record.getMessage() for record in logs_queue.get_error_logs()] == ["error line"]
+        assert logs.has_errors is True
+        assert logs.get_errors() == ["error line"]
     finally:
         logs.close()

--- a/soda-tests/tests/unit/test_logs_queue.py
+++ b/soda-tests/tests/unit/test_logs_queue.py
@@ -1,6 +1,9 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+from soda_core.common.logs import Logs
+from soda_core.common.logs_collector import LogsCollector
 from soda_core.common.logs_queue import LogsQueue
 
 
@@ -42,3 +45,80 @@ def test_flush_uses_batch_v3_when_only_scan_reference_set(mock_to_jsonl):
 
     logs_queue.soda_cloud.logs_batch.assert_called_once_with(scan_reference="scan-ref-abc", body="")
     logs_queue.soda_cloud.logs_batch_v4.assert_not_called()
+
+
+# Streaming-mode accessors: get_all_logs is empty (streamed records are not
+# re-gatherable — this is what keeps a streaming run's results payload `logs`
+# field empty), and failure reports attach only records not confirmed flushed.
+
+
+def _record(level: int, msg: str) -> logging.LogRecord:
+    return logging.LogRecord(name="soda", level=level, pathname=__file__, lineno=1, msg=msg, args=(), exc_info=None)
+
+
+def _flush_response(status_code: int) -> MagicMock:
+    response = MagicMock(status_code=status_code)
+    response.headers.get.return_value = None
+    return response
+
+
+@patch("soda_core.common.logs_queue._to_jsonl", return_value="")
+def test_get_all_logs_returns_empty_list_for_streaming_gatherer(mock_to_jsonl):
+    logs_queue = _stopped_queue(scan_id="scan-id-123")
+    logs_queue.emit(_record(logging.INFO, "streamed away"))
+
+    assert logs_queue.get_all_logs() == []
+
+
+@patch("soda_core.common.logs_queue._to_jsonl", return_value="")
+def test_confirmed_flushed_error_records_left_out_of_failure_report(mock_to_jsonl):
+    logs_queue = _stopped_queue(scan_id="scan-id-123")
+    logs_queue.soda_cloud.logs_batch_v4.return_value = _flush_response(200)
+    logs_queue.emit(_record(logging.ERROR, "flushed error"))
+    logs_queue._flush_logs(logs_queue.flush_interval)
+    logs_queue.emit(_record(logging.ERROR, "pending error"))
+
+    reported = logs_queue.records_for_failure_report()
+
+    assert [record.getMessage() for record in reported] == ["pending error"]
+
+
+@patch("soda_core.common.logs_queue._to_jsonl", return_value="")
+def test_non_2xx_flush_keeps_error_records_in_failure_report(mock_to_jsonl):
+    logs_queue = _stopped_queue(scan_id="scan-id-123")
+    logs_queue.soda_cloud.logs_batch_v4.return_value = _flush_response(500)
+    logs_queue.emit(_record(logging.ERROR, "rejected error"))
+
+    logs_queue._flush_logs(logs_queue.flush_interval)
+
+    assert [record.getMessage() for record in logs_queue.records_for_failure_report()] == ["rejected error"]
+    # The drop-after-response flush behavior itself is unchanged: the batch is consumed.
+    assert logs_queue.log_queue.empty()
+
+
+@patch("soda_core.common.logs_queue._to_jsonl", return_value="")
+def test_failure_report_only_carries_error_records(mock_to_jsonl):
+    logs_queue = _stopped_queue(scan_id="scan-id-123")
+    logs_queue.emit(_record(logging.INFO, "progress line"))
+    logs_queue.emit(_record(logging.ERROR, "error line"))
+
+    assert [record.getMessage() for record in logs_queue.records_for_failure_report()] == ["error line"]
+
+
+def test_logs_collector_failure_report_returns_all_records():
+    collector = LogsCollector()
+    collector.emit(_record(logging.INFO, "info line"))
+    collector.emit(_record(logging.ERROR, "error line"))
+
+    reported = collector.records_for_failure_report()
+
+    assert [record.getMessage() for record in reported] == ["info line", "error line"]
+
+
+def test_logs_records_for_failure_report_delegates_to_gatherer():
+    gatherer = MagicMock()
+    logs = Logs(gatherer=gatherer)
+    try:
+        assert logs.records_for_failure_report() is gatherer.records_for_failure_report.return_value
+    finally:
+        logs.close()

--- a/soda-tests/tests/unit/test_logs_queue.py
+++ b/soda-tests/tests/unit/test_logs_queue.py
@@ -122,3 +122,18 @@ def test_logs_records_for_failure_report_delegates_to_gatherer():
         assert logs.records_for_failure_report() is gatherer.records_for_failure_report.return_value
     finally:
         logs.close()
+
+
+def test_switch_gatherer_replays_history_and_closes_the_old_gatherer():
+    old_gatherer = LogsCollector()
+    old_gatherer.emit(_record(logging.INFO, "captured before the switch"))
+    new_gatherer = MagicMock()
+    logs = Logs(gatherer=old_gatherer)
+    try:
+        logs.switch_gatherer(new_gatherer)
+
+        assert logs.gatherer is new_gatherer
+        (replayed_record,), _ = new_gatherer.emit.call_args
+        assert replayed_record.getMessage() == "captured before the switch"
+    finally:
+        logs.close()

--- a/soda-tests/tests/unit/test_memory_optimized_query.py
+++ b/soda-tests/tests/unit/test_memory_optimized_query.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 from soda_core.common.data_source_connection import (
     DataSourceConnection,
+    QueryCounters,
     memory_optimized_driver_settings,
 )
 from soda_postgres.common.data_sources.postgres_data_source_connection import (
@@ -112,6 +113,10 @@ def _make_postgres_connection(autocommit: bool) -> PostgresDataSourceConnection:
     pg = PostgresDataSourceConnection.__new__(PostgresDataSourceConnection)
     pg.connection = MagicMock()
     pg.connection.autocommit = autocommit
+    # Bypassing __init__ skips the query_counters this connection's execute_*
+    # paths now record duration/count onto — set it explicitly, same as every
+    # other attribute this fixture stands up by hand.
+    pg.query_counters = QueryCounters()
     # Safeguard against runaway loops: the buffered base fetch loops on
     # `while cursor.fetchone()`, and a bare MagicMock.fetchone() returns a
     # truthy Mock endlessly. Bound the DEFAULT (non-context-manager) cursor's

--- a/soda-tests/tests/unit/test_memory_optimized_query.py
+++ b/soda-tests/tests/unit/test_memory_optimized_query.py
@@ -12,6 +12,7 @@ its pre-existing rollback-on-error wrapper as the base.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,6 +24,8 @@ from soda_core.common.data_source_connection import (
 from soda_postgres.common.data_sources.postgres_data_source_connection import (
     PostgresDataSourceConnection,
 )
+
+SODA_LOGGER_NAME = "soda"
 
 
 @pytest.fixture(autouse=True)
@@ -37,6 +40,9 @@ def _enable_memory_optimized_driver(monkeypatch):
 class _StubConnection(DataSourceConnection):
     def __init__(self):
         # Bypass DataSourceConnection.__init__ — only the method under test matters.
+        # Production log lines reference self.name, so stand it up explicitly rather
+        # than let test doubles shape what production code is allowed to log.
+        self.name = "STUB_DS"
         self.calls = []
 
     def _create_connection(self, config):  # pragma: no cover - never called
@@ -53,7 +59,7 @@ class _CapableButUnimplemented(DataSourceConnection):
 
     def __init__(self):
         # Bypass DataSourceConnection.__init__ — only the dispatch matters.
-        pass
+        self.name = "CAPABLE_DS"
 
     def _create_connection(self, config):  # pragma: no cover - never called
         return MagicMock()
@@ -117,6 +123,9 @@ def _make_postgres_connection(autocommit: bool) -> PostgresDataSourceConnection:
     # paths now record duration/count onto — set it explicitly, same as every
     # other attribute this fixture stands up by hand.
     pg.query_counters = QueryCounters()
+    # Same for self.name — production log lines reference it, so a test double
+    # must stand it up rather than let its absence shape production log content.
+    pg.name = "PG_TEST_DS"
     # Safeguard against runaway loops: the buffered base fetch loops on
     # `while cursor.fetchone()`, and a bare MagicMock.fetchone() returns a
     # truthy Mock endlessly. Bound the DEFAULT (non-context-manager) cursor's
@@ -300,3 +309,84 @@ class TestHeldCursorCloseAfterRollback:
         assert len(close_statements) == 1
         assert close_statements[0].startswith('CLOSE "soda_stream_')
         pg.connection.rollback.assert_called()  # transaction cleaned before the CLOSE
+
+
+class TestPostgresStreamingTimingAndCounters:
+    """CRITICAL 1 (review follow-up): the server-side streaming path is what
+    engages for the large-scan tenants that turn the Cloud ``useMemoryOptimized``
+    flag on — it must not escape the counters/timing/truncation the base class
+    now provides. Mirrors TestQueryTimingAndRowCountLogging /
+    TestCountersAndCompletionLinesRecordedEvenOnFailure in
+    test_data_source_connection_query_logging.py, but against the real
+    server-side-cursor code path instead of the base buffered one."""
+
+    def test_success_records_counters_and_completion_line(self, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        pg = _make_postgres_connection(autocommit=False)
+        fake_cursor = _FakeStreamCursor([("x",)] * 5)
+        pg.connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
+
+        assert pg.query_counters.query_count == 1
+        assert pg.query_counters.total_duration_seconds >= 0.0
+        completion_records = [
+            r for r in caplog.records if r.name == SODA_LOGGER_NAME and "processed 5 rows" in r.getMessage()
+        ]
+        assert len(completion_records) == 1, f"got: {[r.getMessage() for r in caplog.records]}"
+
+    def test_failure_still_records_counters_and_a_partial_completion_line(self, caplog):
+        import psycopg
+
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        pg = _make_postgres_connection(autocommit=False)
+
+        # Two rows delivered via row_callback, then the fetchmany that would
+        # deliver more raises — rows_processed must reflect only what was
+        # actually handed to the callback before the failure.
+        class _FailingAfterTwoRowsCursor(_FakeStreamCursor):
+            def fetchmany(self, n):
+                if self.fetch_sizes:  # already served the probe batch once
+                    raise psycopg.errors.QueryCanceled("boom")
+                return super().fetchmany(n)
+
+        fake_cursor = _FailingAfterTwoRowsCursor([("x",), ("y",)])
+        pg.connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        with pytest.raises(psycopg.errors.QueryCanceled):
+            pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None)
+
+        assert pg.query_counters.query_count == 1  # counted despite the failure
+        completion_records = [
+            r for r in caplog.records if r.name == SODA_LOGGER_NAME and "processed 1 rows" in r.getMessage()
+        ]
+        assert len(completion_records) == 1, f"got: {[r.getMessage() for r in caplog.records]}"
+
+    def test_log_query_false_suppresses_completion_line_but_still_counts(self, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        pg = _make_postgres_connection(autocommit=False)
+        fake_cursor = _FakeStreamCursor([("x",)] * 3)
+        pg.connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        pg.execute_query_one_by_one_prefer_streaming("SELECT 1", lambda r, d: None, log_query=False)
+
+        assert pg.query_counters.query_count == 1
+        assert [r for r in caplog.records if r.name == SODA_LOGGER_NAME and "processed" in r.getMessage()] == []
+
+    def test_truncates_the_logged_sql(self, caplog):
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        pg = _make_postgres_connection(autocommit=False)
+        fake_cursor = _FakeStreamCursor([("x",)] * 2)
+        pg.connection.cursor.return_value.__enter__.return_value = fake_cursor
+        long_sql = "SELECT 1 -- " + ("x" * (DataSourceConnection.MAX_CHARS_PER_SQL + 500))
+
+        pg.execute_query_one_by_one_prefer_streaming(long_sql, lambda r, d: None)
+
+        pre_execution_records = [
+            r
+            for r in caplog.records
+            if r.name == SODA_LOGGER_NAME and "server-side cursor" in r.getMessage() and "SELECT" in r.getMessage()
+        ]
+        assert len(pre_execution_records) == 1
+        assert len(pre_execution_records[0].getMessage()) < len(long_sql)
+        assert long_sql not in pre_execution_records[0].getMessage()

--- a/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
+++ b/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
@@ -1,11 +1,20 @@
 """Unit tests for the DEBUG-formatting guard on ``SodaCloud._execute_cqrs_request``.
 
-Building the request-body debug line costs a ``json.dumps(..., indent=2)`` plus
+Building the request-body debug *text* costs a ``json.dumps(..., indent=2)`` plus
 a token-masking regex substitution, run on *every* command/query request. Both
 must be skipped entirely above DEBUG, not just have their result discarded.
+
+``to_jsonnable(request_body)`` itself is a different matter: it mutates the body
+in place (datetime/Decimal/Enum -> JSON-safe values), which the subsequent
+``_http_post(json=request_body, ...)`` relies on to serialize at all — so unlike
+the debug text, it must run on *every* request regardless of DEBUG. (This was a
+real bug: an earlier version of this guard skipped ``to_jsonnable`` too when
+DEBUG was disabled, so a raw ``datetime`` field would reach ``_http_post`` and
+blow up in ``json.dumps`` outside of a debug/verbose run.)
 """
 
 import logging
+from datetime import datetime, timezone
 
 from soda_core.common.soda_cloud import SodaCloud
 
@@ -24,7 +33,9 @@ class _OkResponse:
     headers = {"X-Soda-Trace-Id": "trace-1"}
 
 
-def test_request_body_not_serialized_when_debug_disabled(monkeypatch, caplog):
+def test_request_body_still_sanitized_when_debug_disabled(monkeypatch, caplog):
+    """to_jsonnable's mutation is required for _http_post to serialize the request
+    at all, so it must still run even when nothing gets logged."""
     caplog.set_level(logging.INFO, logger="soda")
     soda_cloud = _soda_cloud()
     monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
@@ -36,7 +47,26 @@ def test_request_body_not_serialized_when_debug_disabled(monkeypatch, caplog):
 
     soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
 
-    assert to_jsonnable_spy_calls == []
+    assert len(to_jsonnable_spy_calls) == 1
+    assert [r for r in caplog.records if r.name == "soda" and "Sending command" in r.getMessage()] == []
+
+
+def test_datetime_field_reaches_http_post_as_a_string_when_debug_disabled(monkeypatch, caplog):
+    """Regression guard: _http_post's json= kwarg goes through plain json.dumps,
+    which can't serialize a raw datetime. to_jsonnable's mutation must reach the
+    outgoing body regardless of DEBUG."""
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    post_calls = []
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: post_calls.append(kwargs) or _OkResponse())
+
+    soda_cloud._execute_command(
+        {"type": "sodaCoreScanStart", "createdAt": datetime(2025, 1, 1, tzinfo=timezone.utc)},
+        request_log_name="scan_start",
+    )
+
+    assert len(post_calls) == 1
+    assert isinstance(post_calls[0]["json"]["createdAt"], str)
 
 
 def test_request_body_serialized_when_debug_enabled(monkeypatch, caplog):

--- a/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
+++ b/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
@@ -1,0 +1,74 @@
+"""Unit tests for the DEBUG-formatting guard on ``SodaCloud._execute_cqrs_request``.
+
+Building the request-body debug line costs a ``json.dumps(..., indent=2)`` plus
+a token-masking regex substitution, run on *every* command/query request. Both
+must be skipped entirely above DEBUG, not just have their result discarded.
+"""
+
+import logging
+
+from soda_core.common.soda_cloud import SodaCloud
+
+
+def _soda_cloud() -> SodaCloud:
+    # A pre-set token skips the login round-trip through _http_post, so only
+    # the request under test hits the (patched) transport.
+    return SodaCloud(
+        host="cloud.soda.io", api_key_id="id", api_key_secret="secret", token="preset-token", port=None, scheme="https"
+    )
+
+
+class _OkResponse:
+    ok = True
+    status_code = 200
+    headers = {"X-Soda-Trace-Id": "trace-1"}
+
+
+def test_request_body_not_serialized_when_debug_disabled(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
+    to_jsonnable_spy_calls = []
+    monkeypatch.setattr(
+        "soda_core.common.soda_cloud.to_jsonnable",
+        lambda *args, **kwargs: to_jsonnable_spy_calls.append((args, kwargs)) or {},
+    )
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    assert to_jsonnable_spy_calls == []
+
+
+def test_request_body_serialized_when_debug_enabled(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG, logger="soda")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
+    to_jsonnable_spy_calls = []
+
+    def spy(*args, **kwargs):
+        to_jsonnable_spy_calls.append((args, kwargs))
+        return {}
+
+    monkeypatch.setattr("soda_core.common.soda_cloud.to_jsonnable", spy)
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    assert len(to_jsonnable_spy_calls) == 1
+    debug_records = [r for r in caplog.records if r.name == "soda" and "Sending command scan_start" in r.getMessage()]
+    assert len(debug_records) == 1
+
+
+def test_token_masking_regex_not_run_when_debug_disabled(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
+    clean_spy_calls = []
+    monkeypatch.setattr(
+        SodaCloud,
+        "_clean_request_from_private_info",
+        lambda self, json_str: clean_spy_calls.append(json_str) or json_str,
+    )
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    assert clean_spy_calls == []

--- a/soda-tests/tests/unit/test_soda_cloud_scan_lifecycle.py
+++ b/soda-tests/tests/unit/test_soda_cloud_scan_lifecycle.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from soda_core.common.soda_cloud import SodaCloud
@@ -13,47 +14,66 @@ def _soda_cloud() -> SodaCloud:
     )
 
 
+def _scan_start(soda_cloud: SodaCloud, **overrides):
+    kwargs = {
+        "scan_id": "scan-123",
+        "definition_name": "my_scan",
+        "default_data_source": "postgres",
+        "data_timestamp": datetime(2026, 7, 13, 8, 30, tzinfo=timezone.utc),
+    }
+    kwargs.update(overrides)
+    return soda_cloud.scan_start(**kwargs)
+
+
 @patch.object(SodaCloud, "_execute_command")
-def test_scan_start_sends_scan_id_and_version_and_returns_scan_reference(mock_execute_command):
+def test_scan_start_sends_the_backend_mandatory_fields_and_returns_scan_reference(mock_execute_command):
     mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {"scanReference": "org/ref-1"})
 
-    assert _soda_cloud().scan_start("scan-123") == "org/ref-1"
+    assert _scan_start(_soda_cloud()) == "org/ref-1"
 
     command = mock_execute_command.call_args.kwargs["command_json_dict"]
-    assert command == {"type": "sodaCoreScanStart", "scanId": "scan-123", "version": "4"}
+    # definitionName / defaultDataSource / dataTimestamp are backend-mandatory
+    # (bean validation on SodaCoreScanStartCommand); version routes v4 handling.
+    assert command == {
+        "type": "sodaCoreScanStart",
+        "scanId": "scan-123",
+        "version": "4",
+        "definitionName": "my_scan",
+        "defaultDataSource": "postgres",
+        "dataTimestamp": "2026-07-13T08:30:00+00:00",
+    }
     assert mock_execute_command.call_args.kwargs["request_log_name"] == "scan_start"
 
 
 @patch.object(SodaCloud, "_execute_command")
-def test_scan_start_includes_optional_fields_when_given(mock_execute_command):
+def test_scan_start_defaults_data_timestamp_to_now(mock_execute_command):
     mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {"scanReference": "org/ref-1"})
 
-    _soda_cloud().scan_start("scan-123", definition_name="my_scan", default_data_source="postgres")
+    _scan_start(_soda_cloud(), data_timestamp=None)
 
     command = mock_execute_command.call_args.kwargs["command_json_dict"]
-    assert command["definitionName"] == "my_scan"
-    assert command["defaultDataSource"] == "postgres"
+    assert command["dataTimestamp"]  # stamped, never omitted: the backend rejects a null
 
 
 @patch.object(SodaCloud, "_execute_command")
 def test_scan_start_returns_none_on_rejection(mock_execute_command):
     mock_execute_command.return_value = MagicMock(ok=False)
 
-    assert _soda_cloud().scan_start("scan-123") is None
+    assert _scan_start(_soda_cloud()) is None
 
 
 @patch.object(SodaCloud, "_execute_command")
 def test_scan_start_returns_none_without_response(mock_execute_command):
     mock_execute_command.return_value = None
 
-    assert _soda_cloud().scan_start("scan-123") is None
+    assert _scan_start(_soda_cloud()) is None
 
 
 @patch.object(SodaCloud, "_execute_command")
 def test_scan_start_returns_none_when_response_lacks_scan_reference(mock_execute_command):
     mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {})
 
-    assert _soda_cloud().scan_start("scan-123") is None
+    assert _scan_start(_soda_cloud()) is None
 
 
 @patch.object(SodaCloud, "_execute_command")
@@ -62,7 +82,7 @@ def test_scan_start_returns_none_on_unparsable_body(mock_execute_command):
     response.json.side_effect = ValueError("not json")
     mock_execute_command.return_value = response
 
-    assert _soda_cloud().scan_start("scan-123") is None
+    assert _scan_start(_soda_cloud()) is None
 
 
 @patch.object(SodaCloud, "_execute_command")

--- a/soda-tests/tests/unit/test_soda_cloud_scan_lifecycle.py
+++ b/soda-tests/tests/unit/test_soda_cloud_scan_lifecycle.py
@@ -1,0 +1,122 @@
+from unittest.mock import MagicMock, patch
+
+from soda_core.common.soda_cloud import SodaCloud
+
+# SodaCloud.scan_start / insert_scan_data_batch / scan_end_async: the async
+# batched-ingestion bracket. Same bool/None-on-failure contracts as
+# insert_scan_results / mark_scan_as_failed — no exceptions on non-200.
+
+
+def _soda_cloud() -> SodaCloud:
+    return SodaCloud(
+        host="cloud.soda.io", api_key_id="id", api_key_secret="secret", token=None, port=None, scheme="https"
+    )
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_sends_scan_id_and_version_and_returns_scan_reference(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {"scanReference": "org/ref-1"})
+
+    assert _soda_cloud().scan_start("scan-123") == "org/ref-1"
+
+    command = mock_execute_command.call_args.kwargs["command_json_dict"]
+    assert command == {"type": "sodaCoreScanStart", "scanId": "scan-123", "version": "4"}
+    assert mock_execute_command.call_args.kwargs["request_log_name"] == "scan_start"
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_includes_optional_fields_when_given(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {"scanReference": "org/ref-1"})
+
+    _soda_cloud().scan_start("scan-123", definition_name="my_scan", default_data_source="postgres")
+
+    command = mock_execute_command.call_args.kwargs["command_json_dict"]
+    assert command["definitionName"] == "my_scan"
+    assert command["defaultDataSource"] == "postgres"
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_returns_none_on_rejection(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=False)
+
+    assert _soda_cloud().scan_start("scan-123") is None
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_returns_none_without_response(mock_execute_command):
+    mock_execute_command.return_value = None
+
+    assert _soda_cloud().scan_start("scan-123") is None
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_returns_none_when_response_lacks_scan_reference(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=True, json=lambda: {})
+
+    assert _soda_cloud().scan_start("scan-123") is None
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_start_returns_none_on_unparsable_body(mock_execute_command):
+    response = MagicMock(ok=True)
+    response.json.side_effect = ValueError("not json")
+    mock_execute_command.return_value = response
+
+    assert _soda_cloud().scan_start("scan-123") is None
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_insert_scan_data_batch_stamps_type_and_scan_reference_without_mutating_payload(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=True)
+    payload = {"type": "sodaCoreInsertScanResults", "definitionName": "my_scan", "version": "4"}
+
+    assert _soda_cloud().insert_scan_data_batch(payload, scan_reference="org/ref-1") is True
+
+    command = mock_execute_command.call_args.kwargs["command_json_dict"]
+    assert command["type"] == "sodaCoreInsertScanDataBatch"
+    assert command["scanReference"] == "org/ref-1"
+    assert command["definitionName"] == "my_scan"
+    assert command["version"] == "4"
+    assert mock_execute_command.call_args.kwargs["request_log_name"] == "insert_scan_data_batch"
+    # The caller's DTO is untouched: the batch stamps land on a copy.
+    assert payload["type"] == "sodaCoreInsertScanResults"
+    assert "scanReference" not in payload
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_insert_scan_data_batch_returns_false_when_rejected(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=False)
+
+    assert _soda_cloud().insert_scan_data_batch({"type": "sodaCoreInsertScanResults"}, scan_reference="r") is False
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_insert_scan_data_batch_returns_false_without_response(mock_execute_command):
+    mock_execute_command.return_value = None
+
+    assert _soda_cloud().insert_scan_data_batch({"type": "sodaCoreInsertScanResults"}, scan_reference="r") is False
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_end_async_sends_scan_reference(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=True)
+
+    assert _soda_cloud().scan_end_async("org/ref-1") is True
+
+    command = mock_execute_command.call_args.kwargs["command_json_dict"]
+    assert command == {"type": "sodaCoreScanEndAsync", "scanReference": "org/ref-1"}
+    assert mock_execute_command.call_args.kwargs["request_log_name"] == "scan_end_async"
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_end_async_returns_false_when_rejected(mock_execute_command):
+    mock_execute_command.return_value = MagicMock(ok=False)
+
+    assert _soda_cloud().scan_end_async("org/ref-1") is False
+
+
+@patch.object(SodaCloud, "_execute_command")
+def test_scan_end_async_returns_false_without_response(mock_execute_command):
+    mock_execute_command.return_value = None
+
+    assert _soda_cloud().scan_end_async("org/ref-1") is False


### PR DESCRIPTION
## Problem

The engine gives scan operators nothing to answer "which query was slow": no query is timed at any level, row counts are computed and discarded, and the extension packages (metric monitoring, profiling) cannot report scan-level query totals because no counters exist. Meanwhile every query in a normal INFO-level run pays for DEBUG-only formatting that is thrown away — result rows are tabulated and Cloud request bodies are JSON-pretty-printed before an unguarded `logger.debug` call — and the streaming query paths log their SQL untruncated.

## Change

Every execute path (including the postgres server-side streaming variant) now times its query with `perf_counter` and emits one DEBUG completion line with duration and row count, recorded in `finally` so failed queries are counted too. A public `connection.query_counters` (count + cumulative duration, with `snapshot()` for per-scan deltas) lets consumers report totals like "11 warehouse queries in 8.4s" in scan summaries. DEBUG-only formatting is now guarded by `isEnabledFor`, and streaming-path SQL is truncated like the buffered path. Part of the scan-log improvement stack ([R-656](https://linear.app/sodadata/issue/R-656/soda-core-query-timing-row-counts-debug-formatting-guards), parent [R-649](https://linear.app/sodadata/issue/R-649/improve-mm-logs)); the verbose-tier split and INFO hygiene follow in a stacked PR (R-657).

Based on `batched-scan-ingestion` because it reworks the same soda_cloud/connection files.

## Testing

53 unit tests across the three affected areas (timing/counters incl. failure paths and the postgres streaming variant, log_query gating, guard behavior); full unit lane 1275 passed. Note: `soda-tests` collection inside git worktrees needs `-p no:helpers.memory_container_plugin` (pre-existing path assumption in that plugin, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT7YDeTVhze62GgefgBZcw