### PR TITLE
feat(logs): usable --verbose, INFO hygiene, console timestamps, warnings policy

### DIFF
--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -872,7 +872,9 @@ class CheckCollectionImpl:
                 # Evaluate the checks
                 for check_impl in self.all_check_impls:
                     if check_impl.skip:
-                        logger.info(f"Skipping evaluation of check at path '{check_impl.relative_path}'")
+                        # The summary table's "Excluded" count already carries this at
+                        # INFO; a per-check line here is DEBUG-only trace detail.
+                        logger.debug(f"Skipping evaluation of check at path '{check_impl.relative_path}'")
                         check_result: CheckResult = CheckResult(
                             check=check_impl._build_check_info(), outcome=CheckOutcome.EXCLUDED
                         )

--- a/soda-core/src/soda_core/common/data_source_connection.py
+++ b/soda-core/src/soda_core/common/data_source_connection.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator
+from soda_core.common.logging_configuration import is_log_payloads_enabled
 from soda_core.common.logging_constants import soda_logger
 
 logger: logging.Logger = soda_logger
@@ -372,32 +373,37 @@ class DataSourceConnection(ABC):
             duration_seconds: float = time.perf_counter() - start_time
             self.query_counters.record(duration_seconds)
 
-            # Truncating/tabulating the result set is purely for DEBUG-level
-            # logging, so skip that work entirely when DEBUG is disabled — and
-            # only attempt it once the query actually produced rows.
+            # Duration + row count is a plain DEBUG line — cheap, and useful as a
+            # trace even without the payload firehose below.
             if log_query and formatted_rows is not None and logger.isEnabledFor(logging.DEBUG):
-                truncated_rows = self.truncate_rows(formatted_rows)
-                headers = [self._execute_query_get_result_row_column_name(c) for c in (cursor.description or [])]
-                # The tabulate can crash if the rows contain non-ASCII characters.
-                # This is purely for debugging/logging purposes, so we can try/catch this.
-                try:
-                    table_text: str = tabulate(
-                        truncated_rows,
-                        headers=headers,
-                        tablefmt="github",
-                    )
-                except UnicodeDecodeError as e:
-                    logger.debug(f"Error formatting rows. These may contain non-ASCII characters. {e}")
-                    table_text = "Error formatting rows. These may contain non-ASCII characters."
-                except Exception as e:
-                    logger.debug(f"Error formatting rows. {e}")
-                    table_text = (
-                        f"Error formatting rows. This may be due to the rows containing non-ASCII characters.\n{e}"
-                    )
+                logger.debug(f"SQL query result in {duration_seconds:.3f}s ({len(formatted_rows)} rows)")
 
-                logger.debug(
-                    f"SQL query result in {duration_seconds:.3f}s ({len(formatted_rows)} rows, max {self.MAX_ROWS} shown, {self.MAX_CHARS_PER_STRING} chars per string):\n{table_text}"
-                )
+                # The rendered result-row TABLE is the firehose: truncating/tabulating
+                # is purely for this dump, so skip the work entirely unless the
+                # opt-in flag is set, even though DEBUG is already on.
+                if is_log_payloads_enabled():
+                    truncated_rows = self.truncate_rows(formatted_rows)
+                    headers = [self._execute_query_get_result_row_column_name(c) for c in (cursor.description or [])]
+                    # The tabulate can crash if the rows contain non-ASCII characters.
+                    # This is purely for debugging/logging purposes, so we can try/catch this.
+                    try:
+                        table_text: str = tabulate(
+                            truncated_rows,
+                            headers=headers,
+                            tablefmt="github",
+                        )
+                    except UnicodeDecodeError as e:
+                        logger.debug(f"Error formatting rows. These may contain non-ASCII characters. {e}")
+                        table_text = "Error formatting rows. These may contain non-ASCII characters."
+                    except Exception as e:
+                        logger.debug(f"Error formatting rows. {e}")
+                        table_text = (
+                            f"Error formatting rows. This may be due to the rows containing non-ASCII characters.\n{e}"
+                        )
+
+                    logger.debug(
+                        f"SQL query result rows (max {self.MAX_ROWS} shown, {self.MAX_CHARS_PER_STRING} chars per string):\n{table_text}"
+                    )
             cursor.close()
 
     def _format_rows(self, rows: list[tuple]) -> list[tuple]:

--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -31,6 +31,8 @@ def configure_logging(
 
     _prepare_masked_file()
 
+    configure_library_warning_capture(verbose)
+
     sys.stderr = sys.stdout
     for logger_to_mute in [
         "urllib3",
@@ -61,6 +63,32 @@ def configure_logging(
     from soda_core.common.logs import _ensure_root_capturer
 
     _ensure_root_capturer()
+
+
+def configure_library_warning_capture(verbose: bool) -> None:
+    """Route python ``warnings.warn(...)`` calls through logging instead of letting
+    them leak straight to raw stderr, bypassing our formatter/Cloud upload entirely.
+
+    Numeric libraries pulled in by extensions (pandas/numpy/sklearn, heavily used by
+    soda-rad) are frequent offenders (FutureWarning/RuntimeWarning). ``captureWarnings``
+    logs them via the ``py.warnings`` logger at WARNING — which, left alone, would
+    *add* user-visible noise to default (non-verbose) runs. So ``py.warnings`` is
+    silenced to ERROR unless ``--verbose`` is set, in which case captured warnings
+    pass through (DEBUG threshold) and show up in the verbose trace, same stream as
+    everything else.
+
+    Split out of ``configure_logging`` so it can be exercised without going through
+    ``logging.basicConfig(force=True, ...)``, which tears down any handler (including
+    pytest's caplog) already attached to the root logger.
+    """
+    # captureWarnings(True) is a no-op if the process already believes it's capturing
+    # (module-level state in the stdlib ``logging`` package) — e.g. a prior
+    # configure_logging() call, or a test framework that installed its own
+    # ``warnings.showwarning`` afterwards. Toggling off then on forces a fresh
+    # install so ours wins over whatever currently holds ``showwarning``.
+    logging.captureWarnings(False)
+    logging.captureWarnings(True)
+    logging.getLogger("py.warnings").setLevel(DEBUG if verbose else ERROR)
 
 
 _masked_values = set()
@@ -156,6 +184,16 @@ def is_verbose() -> bool:
     return verbose_mode
 
 
+def is_log_payloads_enabled() -> bool:
+    """SODA_LOG_PAYLOADS opt-in: gates the DEBUG-level payload firehose (rendered
+    result-row tables in ``data_source_connection.py``; full Cloud request/response
+    bodies in ``soda_cloud.py``) behind an explicit flag, additional to the existing
+    ``isEnabledFor(DEBUG)`` guards. Read at call time (not cached) so it can be
+    toggled without a process restart.
+    """
+    return os.environ.get("SODA_LOG_PAYLOADS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 class SodaConsoleHandler(StreamHandler):
     def __init__(self):
         super().__init__(sys.stdout)
@@ -168,8 +206,8 @@ class SodaConsoleFormatter(Formatter):
 
     def format(self, record) -> str:
         parts: list[str] = [
-            # self.format_timestamp(record),
-            # self.format_level(record),
+            self.format_timestamp(record),
+            self.format_level(record),
             self.format_message(record),
             self.format_location(record),
             self.format_doc(record),

--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -82,10 +82,17 @@ def configure_library_warning_capture(verbose: bool) -> None:
     pytest's caplog) already attached to the root logger.
     """
     # captureWarnings(True) is a no-op if the process already believes it's capturing
-    # (module-level state in the stdlib ``logging`` package) — e.g. a prior
-    # configure_logging() call, or a test framework that installed its own
-    # ``warnings.showwarning`` afterwards. Toggling off then on forces a fresh
-    # install so ours wins over whatever currently holds ``showwarning``.
+    # (module-level state in the stdlib ``logging`` package): it only installs its
+    # ``_showwarning`` hook when its internal "already capturing" flag is unset. A
+    # test framework (pytest's own warnings plugin wraps every test in its own
+    # ``warnings.catch_warnings(record=True)``) can install a *different*
+    # ``warnings.showwarning`` afterwards without clearing that flag, leaving our
+    # hook shadowed even though the module still thinks it's in charge. Toggling
+    # off then on forces a fresh install so ours wins over whatever currently holds
+    # ``showwarning``. In production this double-toggle is a functional no-op the
+    # first time configure_logging() runs (nothing else has touched showwarning
+    # yet) — it only matters when something else installed its own warnings host
+    # handler afterwards, which is exactly the pytest case above.
     logging.captureWarnings(False)
     logging.captureWarnings(True)
     logging.getLogger("py.warnings").setLevel(DEBUG if verbose else ERROR)
@@ -185,11 +192,14 @@ def is_verbose() -> bool:
 
 
 def is_log_payloads_enabled() -> bool:
-    """SODA_LOG_PAYLOADS opt-in: gates the DEBUG-level payload firehose (rendered
-    result-row tables in ``data_source_connection.py``; full Cloud request/response
-    bodies in ``soda_cloud.py``) behind an explicit flag, additional to the existing
-    ``isEnabledFor(DEBUG)`` guards. Read at call time (not cached) so it can be
-    toggled without a process restart.
+    """Whether the ``SODA_LOG_PAYLOADS`` env var opts into the DEBUG-level payload
+    firehose: rendered result-row tables (``data_source_connection.py``) and full
+    Cloud request/response bodies (``soda_cloud.py``). Default is off — ``--verbose``
+    alone shows SQL/request names plus durations and row counts, not the payloads
+    themselves; set ``SODA_LOG_PAYLOADS=true`` (or 1/yes/on) on top of ``--verbose``
+    to unlock them. This is an additional gate on top of the existing
+    ``isEnabledFor(DEBUG)`` guards, not a replacement for them. Read at call time
+    (not cached) so it can be toggled without a process restart.
     """
     return os.environ.get("SODA_LOG_PAYLOADS", "").strip().lower() in ("1", "true", "yes", "on")
 
@@ -234,6 +244,9 @@ class SodaConsoleFormatter(Formatter):
             return record.getMessage()
 
     def format_timestamp(self, record: LogRecord) -> Optional[str]:
+        # Naive local time, for a human reading their own console — Cloud stores
+        # (and receives, via build_log_cloud_json_dict) UTC separately; this is
+        # console-only display and doesn't change what's uploaded.
         timestamp: datetime = datetime.fromtimestamp(record.created)
         # Format the time part (without milliseconds)
         time_part = timestamp.strftime("%Y-%m-%d %H:%M:%S")

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -1528,9 +1528,12 @@ class SodaCloud:
                 f"X-Soda-Trace-Id:{trace_id}"
             )
         elif not response.ok:
+            # First 500 chars only — same truncation as the non-JSON-body warning
+            # in _parse_json_body; the full body is payload-firehose territory,
+            # not a plain WARNING line.
             logger.warning(
                 f"Soda Cloud error for {request_log_name} | status_code:{response.status_code} | "
-                f"X-Soda-Trace-Id:{trace_id} | response_text:{response.text}"
+                f"X-Soda-Trace-Id:{trace_id} | response_text:{response.text[:500]}"
             )
         else:
             logger.debug(f"{Emoticons.OK_HAND} Soda Cloud {request_log_name} OK | X-Soda-Trace-Id:{trace_id}")

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -30,6 +30,7 @@ from soda_core.common.exceptions import (
     SodaCloudAuthenticationFailedException,
     SodaCloudException,
 )
+from soda_core.common.logging_configuration import is_log_payloads_enabled
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.soda_cloud_dto import (
@@ -958,7 +959,7 @@ class SodaCloud:
             assumed_configuration = configs.dataset_configurations[0]
             if assumed_configuration.dataset_qualified_name != dataset_identifier.to_string():
                 raise SodaCloudException(
-                    f"Expected to receive configuration for dataset '{dataset_identifier}' but received configuration for dataset '{assumed_configuration.dataset_qualified_name}'"
+                    f"Expected to receive configuration for dataset '{dataset_identifier.to_string()}' but received configuration for dataset '{assumed_configuration.dataset_qualified_name}'"
                 )
             return assumed_configuration
         return None
@@ -969,7 +970,8 @@ class SodaCloud:
         Returns:
             DatasetConfigurationsDTO
         """
-        logger.info(f"Fetching datasets configurations from Soda Cloud for datasets '{dataset_identifiers}'")
+        dataset_identifiers_text = ", ".join(d.to_string() for d in dataset_identifiers)
+        logger.info(f"Fetching datasets configurations from Soda Cloud for datasets '{dataset_identifiers_text}'")
         datasets_request_list = []
         for dataset_identifier in dataset_identifiers:
             datasets_request_list.append(
@@ -988,7 +990,7 @@ class SodaCloud:
 
         if not response.ok:
             raise SodaCloudException(
-                f"Failed to retrieve datasets configurations for datasets '{dataset_identifiers}': {response_dict['message']}"
+                f"Failed to retrieve datasets configurations for datasets '{dataset_identifiers_text}': {response_dict['message']}"
             )
 
         try:
@@ -999,7 +1001,7 @@ class SodaCloud:
             return dataset_configs
         except ValidationError as e:
             raise SodaCloudException(
-                f"Failed to parse datasets configurations for datasets '{dataset_identifiers}': {str(e)}"
+                f"Failed to parse datasets configurations for datasets '{dataset_identifiers_text}': {str(e)}"
             ) from e
 
     def get_historic_measurements(
@@ -1434,16 +1436,20 @@ class SodaCloud:
             request_body["token"] = self._get_token()
             # to_jsonnable(...) mutates request_body in place (datetime/Decimal/Enum/...
             # -> JSON-safe values) and is required for the upcoming _http_post(json=...)
-            # to serialize at all — it must run unconditionally, not just when DEBUG is
-            # enabled. Only the pretty-print (json.dumps(..., indent=2)) and the
-            # token-masking regex substitution are built purely for the DEBUG line below,
-            # so only those stay behind the isEnabledFor guard.
+            # to serialize at all — unlike the debug-only rendering below, this must run
+            # unconditionally, not just when DEBUG/the payloads flag are on.
             to_jsonnable(request_body)
             if logger.isEnabledFor(logging.DEBUG):
-                log_body_text: str = json.dumps(request_body, indent=2)
-                logger.debug(
-                    f"Sending {request_type} {request_log_name} to Soda Cloud with body: {self._clean_request_from_private_info(log_body_text)}"
-                )
+                # Request name only by default — cheap, and enough to trace what's
+                # happening. The full body (json.dumps(..., indent=2) plus the
+                # token-masking regex, built per request) is the payload firehose:
+                # skip building it entirely unless the opt-in flag is set.
+                logger.debug(f"Sending {request_type} {request_log_name} to Soda Cloud")
+                if is_log_payloads_enabled():
+                    log_body_text: str = json.dumps(request_body, indent=2)
+                    logger.debug(
+                        f"{request_type} {request_log_name} request body: {self._clean_request_from_private_info(log_body_text)}"
+                    )
             response: Response = self._http_post(
                 url=f"{self.api_url}/{request_type}",
                 headers=self.headers,
@@ -1479,7 +1485,8 @@ class SodaCloud:
                     f"Status Code: {response.status_code}\n"
                     f"Message: '{message}' | Response Code: '{code}' | Trace Id: {trace_id}"
                 )
-                logger.debug(f"Response_text:\n{response.text}")
+                if is_log_payloads_enabled():
+                    logger.debug(f"Response_text:\n{response.text}")
             else:
                 logger.debug(
                     f"{Emoticons.OK_HAND} Soda Cloud {request_type} {request_log_name} OK | X-Soda-Trace-Id:{trace_id}"
@@ -1696,7 +1703,9 @@ class SodaCloud:
         error: Optional[str] = None,
         records_written: Optional[int] = None,
     ):
-        logger.info(f"Updating post processing stage '{stage}' to state '{state.value}' for scan {scan_id}")
+        # The pre-announcement stays DEBUG-only: the completed form below ("Updated
+        # ... to state ...") is the one line per transition users need at INFO.
+        logger.debug(f"Updating post processing stage '{stage}' to state '{state.value}' for scan {scan_id}")
 
         request = {
             "type": "sodaCorePostProcessingUpdate",

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -457,3 +457,44 @@ def test_subtype_impl_extension_stays_isolated():
         assert "xtest_iso" not in ContractImpl._resolve_impl_extensions()
     finally:
         _IsoKindImpl.impl_extensions.pop("xtest_iso", None)
+
+
+def test_skipped_check_logs_at_debug_not_info(data_source_test_helper, caplog):
+    """R-657 task 2: per-skipped-check spam moves to DEBUG — the summary table's
+    Excluded count already carries this at INFO."""
+
+    from helpers.mock_soda_cloud import MockResponse
+    from helpers.test_table import TestTableSpecification
+    from soda_core.contracts.impl.check_selector import CheckSelector
+
+    test_table_specification = (
+        TestTableSpecification.builder()
+        .table_purpose("skip_check_debug_logging")
+        .column_integer("id")
+        .rows(rows=[(1,), (2,), (3,)])
+        .build()
+    )
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+    data_source_test_helper.enable_soda_cloud_mock(
+        [MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"})]
+    )
+    caplog.set_level(logging.DEBUG, logger="soda")
+
+    # Selecting only "missing" checks forces the "invalid" check onto the
+    # skip path this test pins.
+    data_source_test_helper.verify_contract(
+        test_table=test_table,
+        check_selectors=[CheckSelector.parse("type=missing")],
+        contract_yaml_str="""
+        columns:
+            - name: id
+              checks:
+                - missing:
+                - invalid:
+                    valid_values: [1, 2, 3]
+        """,
+    )
+
+    skip_records = [r for r in caplog.records if r.name == "soda" and "Skipping evaluation of check" in r.getMessage()]
+    assert len(skip_records) >= 1
+    assert all(r.levelno == logging.DEBUG for r in skip_records)

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -496,5 +496,6 @@ def test_skipped_check_logs_at_debug_not_info(data_source_test_helper, caplog):
     )
 
     skip_records = [r for r in caplog.records if r.name == "soda" and "Skipping evaluation of check" in r.getMessage()]
-    assert len(skip_records) >= 1
+    # Exactly one check ("invalid") is excluded by the selector above.
+    assert len(skip_records) == 1
     assert all(r.levelno == logging.DEBUG for r in skip_records)

--- a/soda-tests/tests/unit/test_data_source_connection_query_logging.py
+++ b/soda-tests/tests/unit/test_data_source_connection_query_logging.py
@@ -306,8 +306,11 @@ class TestDebugFormattingGuard:
 
         truncate_spy.assert_not_called()
 
-    def test_tabulate_called_when_debug_enabled(self, connection, monkeypatch, caplog):
+    def test_tabulate_called_when_debug_enabled_and_payloads_flag_on(self, connection, monkeypatch, caplog):
+        """R-657 task 1: the table dump is the payload firehose — DEBUG alone is no
+        longer enough, SODA_LOG_PAYLOADS must also be set."""
         caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        monkeypatch.setenv("SODA_LOG_PAYLOADS", "true")
         from tabulate import tabulate as real_tabulate
 
         tabulate_spy = MagicMock(wraps=real_tabulate)
@@ -316,6 +319,21 @@ class TestDebugFormattingGuard:
         connection.execute_query("SELECT * FROM t")
 
         tabulate_spy.assert_called_once()
+
+    def test_tabulate_not_called_when_debug_enabled_but_payloads_flag_off(self, connection, monkeypatch, caplog):
+        """R-657 task 1: default (flag off) — DEBUG shows SQL + duration/row-count
+        only, not the rendered result-row table."""
+        caplog.set_level(logging.DEBUG, logger=SODA_LOGGER_NAME)
+        monkeypatch.delenv("SODA_LOG_PAYLOADS", raising=False)
+        tabulate_spy = MagicMock(side_effect=AssertionError("tabulate should not run with the payloads flag off"))
+        monkeypatch.setattr("soda_core.common.data_source_connection.tabulate", tabulate_spy)
+
+        connection.execute_query("SELECT * FROM t")  # must not raise
+
+        tabulate_spy.assert_not_called()
+        duration_records = _debug_records(caplog, "SQL query result in")
+        assert len(duration_records) == 1
+        assert "3 rows" in duration_records[0].getMessage()
 
     def test_returned_rows_unaffected_by_debug_level(self, connection, caplog):
         caplog.set_level(logging.INFO, logger=SODA_LOGGER_NAME)

--- a/soda-tests/tests/unit/test_logging.py
+++ b/soda-tests/tests/unit/test_logging.py
@@ -1,5 +1,12 @@
+import logging
 import os
+import warnings
 
+from soda_core.common.logging_configuration import (
+    SodaConsoleFormatter,
+    configure_library_warning_capture,
+)
+from soda_core.common.logging_constants import Emoticons
 from soda_core.common.logs import Logs
 
 MAX_CHARS_PER_STRING = int(os.environ.get("SODA_DEBUG_PRINT_VALUE_MAX_CHARS", 256))
@@ -7,8 +14,13 @@ MAX_ROWS = int(os.environ.get("SODA_DEBUG_PRINT_RESULT_MAX_ROWS", 20))
 MAX_CHARS_PER_SQL = int(os.environ.get("SODA_DEBUG_PRINT_SQL_MAX_CHARS", 1024))
 
 
-def test_logging_debug_prints(data_source_test_helper):
-    """Test that query results are correctly truncated."""
+def test_logging_debug_prints(data_source_test_helper, monkeypatch):
+    """Test that query results are correctly truncated.
+
+    The rendered table is the payload firehose (R-657 task 1): opt in via
+    SODA_LOG_PAYLOADS to get the truncation behaviour under test here.
+    """
+    monkeypatch.setenv("SODA_LOG_PAYLOADS", "true")
 
     multi_row_sql = """
         with t0 as (
@@ -44,7 +56,7 @@ def test_logging_debug_prints(data_source_test_helper):
         truncated_sql = multi_row_sql[: MAX_CHARS_PER_SQL - 3] + "..."
         assert truncated_sql in sql_print_log
 
-    query_result_log = [l for l in log_lines if l.startswith("SQL query result")][0]
+    query_result_log = [l for l in log_lines if l.startswith("SQL query result rows")][0]
     assert str(MAX_ROWS) in query_result_log
     if MAX_ROWS < 99:
         assert str(MAX_ROWS + 1) not in query_result_log
@@ -55,10 +67,90 @@ def test_logging_debug_prints(data_source_test_helper):
     data_source_test_helper.data_source_impl.execute_query(sql_long_string)
     log_lines = logs.get_logs()
 
-    query_result_log = [l for l in log_lines if l.startswith("SQL query result")][0]
+    query_result_log = [l for l in log_lines if l.startswith("SQL query result rows")][0]
     if len(long_string) > MAX_CHARS_PER_STRING:
         assert long_string[: MAX_CHARS_PER_STRING - 3] + "..." in query_result_log
     else:
         assert long_string in query_result_log
     assert "bbb" in query_result_log
     assert "ccc" in query_result_log
+
+
+def _make_record(level: int, message: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="soda",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+class TestSodaConsoleFormatterTimestampAndLevel:
+    """R-657 task 3: console-only gap — Cloud already receives timestamp/level as
+    structured fields, but the console formatter used to comment these out."""
+
+    def test_format_leads_with_timestamp_then_level_then_message(self):
+        formatter = SodaConsoleFormatter()
+        record = _make_record(logging.INFO, "hello")
+
+        parts = formatter.format(record).split(" | ")
+
+        assert parts[0] == formatter.format_timestamp(record)
+        assert parts[1] == "INF"
+        assert parts[2] == "hello"
+
+    def test_error_level_keeps_police_car_prefix_on_the_message_part(self):
+        formatter = SodaConsoleFormatter()
+        record = _make_record(logging.ERROR, "boom")
+
+        parts = formatter.format(record).split(" | ")
+
+        assert parts[1] == "ERR"
+        assert parts[2] == f"{Emoticons.POLICE_CAR_LIGHT} boom"
+
+    def test_debug_level_renders_as_deb(self):
+        formatter = SodaConsoleFormatter()
+        record = _make_record(logging.DEBUG, "trace")
+
+        parts = formatter.format(record).split(" | ")
+
+        assert parts[1] == "DEB"
+
+
+class TestLibraryWarningCapturePolicy:
+    """R-657 task 4: library warnings (pandas/numpy/sklearn FutureWarning/
+    RuntimeWarning, heavily used by the soda-rad extension) are routed through
+    ``py.warnings`` instead of leaking straight to stderr, and are silenced under
+    default (non-verbose) runs so they don't add user-visible noise."""
+
+    def teardown_method(self):
+        logging.captureWarnings(False)
+
+    def test_library_warning_reaches_the_stream_when_verbose(self, caplog):
+        configure_library_warning_capture(verbose=True)
+        # Deliberately not scoped to "py.warnings": that would override the level
+        # configure_library_warning_capture just set, defeating the test. This only
+        # lowers the root logger + caplog's own handler threshold so a record that
+        # does get past "py.warnings" is captured.
+        caplog.set_level(logging.DEBUG)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn("numeric library noise", FutureWarning)
+
+        py_warning_records = [r for r in caplog.records if r.name == "py.warnings"]
+        assert len(py_warning_records) == 1
+        assert "numeric library noise" in py_warning_records[0].getMessage()
+
+    def test_library_warning_does_not_reach_the_stream_when_not_verbose(self, caplog):
+        configure_library_warning_capture(verbose=False)
+        caplog.set_level(logging.DEBUG)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn("numeric library noise", FutureWarning)
+
+        assert [r for r in caplog.records if r.name == "py.warnings"] == []

--- a/soda-tests/tests/unit/test_logging.py
+++ b/soda-tests/tests/unit/test_logging.py
@@ -5,6 +5,7 @@ import warnings
 from soda_core.common.logging_configuration import (
     SodaConsoleFormatter,
     configure_library_warning_capture,
+    configure_logging,
 )
 from soda_core.common.logging_constants import Emoticons
 from soda_core.common.logs import Logs
@@ -120,14 +121,47 @@ class TestSodaConsoleFormatterTimestampAndLevel:
         assert parts[1] == "DEB"
 
 
+def test_configure_logging_invokes_warning_capture_policy(monkeypatch):
+    """IMPORTANT: nothing else pins that configure_logging actually wires up the
+    warning-capture policy — deleting the call would leave the rest of the suite
+    green (configure_library_warning_capture is only exercised directly elsewhere).
+    Spy on the call itself."""
+    calls = []
+    monkeypatch.setattr(
+        "soda_core.common.logging_configuration.configure_library_warning_capture",
+        lambda verbose: calls.append(verbose),
+    )
+
+    try:
+        configure_logging(verbose=True)
+        assert calls == [True]
+
+        calls.clear()
+        configure_logging(verbose=False)
+        assert calls == [False]
+    finally:
+        # configure_logging mutates global logging state (root level/handlers via
+        # basicConfig(force=True)); undo the spy first so this restores the real
+        # policy, matching what conftest's session-start call configured.
+        monkeypatch.undo()
+        configure_logging(verbose=True)
+
+
 class TestLibraryWarningCapturePolicy:
     """R-657 task 4: library warnings (pandas/numpy/sklearn FutureWarning/
     RuntimeWarning, heavily used by the soda-rad extension) are routed through
     ``py.warnings`` instead of leaking straight to stderr, and are silenced under
     default (non-verbose) runs so they don't add user-visible noise."""
 
+    def setup_method(self):
+        # The session (conftest) runs configure_logging(verbose=True) once up
+        # front, which leaves py.warnings at DEBUG. Save that so teardown restores
+        # it instead of leaking whichever level the last test in this class set.
+        self._original_py_warnings_level = logging.getLogger("py.warnings").level
+
     def teardown_method(self):
         logging.captureWarnings(False)
+        logging.getLogger("py.warnings").setLevel(self._original_py_warnings_level)
 
     def test_library_warning_reaches_the_stream_when_verbose(self, caplog):
         configure_library_warning_capture(verbose=True)

--- a/soda-tests/tests/unit/test_soda_cloud_info_hygiene.py
+++ b/soda-tests/tests/unit/test_soda_cloud_info_hygiene.py
@@ -1,0 +1,134 @@
+"""Unit tests for R-657 task 2 (INFO hygiene) fixes on ``SodaCloud``.
+
+- ``fetch_dataset_configuration`` / ``fetch_datasets_configurations`` interpolate
+  ``DatasetIdentifier`` via ``.to_string()`` rather than the object directly — the
+  object has no ``__str__``, so bare interpolation falls back to ``__repr__`` and
+  leaks the internal ``DatasetIdentifier(data_source=..., prefixes=..., dataset=...)``
+  shape into user-facing log/exception text.
+- ``post_processing_update`` logs one INFO line per transition (the completed
+  form); the pre-announcement is DEBUG-only.
+"""
+
+import logging
+
+import pytest
+from soda_core.common.dataset_identifier import DatasetIdentifier
+from soda_core.common.exceptions import SodaCloudException
+from soda_core.common.soda_cloud import SodaCloud
+from soda_core.contracts.contract_verification import PostProcessingStageState
+
+
+def _soda_cloud() -> SodaCloud:
+    return SodaCloud(
+        host="cloud.soda.io", api_key_id="id", api_key_secret="secret", token="preset-token", port=None, scheme="https"
+    )
+
+
+class _ConfigsResponse:
+    ok = True
+    status_code = 200
+
+    def __init__(self, results):
+        self._results = results
+
+    def json(self):
+        return {"results": self._results}
+
+
+class _FailedConfigsResponse:
+    ok = False
+    status_code = 400
+
+    def json(self):
+        return {"message": "boom"}
+
+
+def test_fetch_datasets_configurations_info_line_uses_to_string_not_repr(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    identifier = DatasetIdentifier(data_source_name="ds", prefixes=["schema"], dataset_name="table")
+    monkeypatch.setattr(soda_cloud, "_execute_query", lambda *args, **kwargs: _ConfigsResponse([]))
+
+    soda_cloud.fetch_datasets_configurations([identifier])
+
+    info_records = [
+        r for r in caplog.records if r.name == "soda" and "Fetching datasets configurations" in r.getMessage()
+    ]
+    assert len(info_records) == 1
+    message = info_records[0].getMessage()
+    assert "ds/schema/table" in message
+    assert "DatasetIdentifier(" not in message
+
+
+def test_fetch_datasets_configurations_failure_message_uses_to_string_not_repr(monkeypatch):
+    soda_cloud = _soda_cloud()
+    identifier = DatasetIdentifier(data_source_name="ds", prefixes=[], dataset_name="table")
+    monkeypatch.setattr(soda_cloud, "_execute_query", lambda *args, **kwargs: _FailedConfigsResponse())
+
+    with pytest.raises(SodaCloudException) as exc_info:
+        soda_cloud.fetch_datasets_configurations([identifier])
+
+    assert "ds/table" in str(exc_info.value)
+    assert "DatasetIdentifier(" not in str(exc_info.value)
+
+
+def test_fetch_dataset_configuration_mismatch_message_uses_to_string_not_repr(monkeypatch):
+    soda_cloud = _soda_cloud()
+    identifier = DatasetIdentifier(data_source_name="ds", prefixes=[], dataset_name="table")
+    # Backend returns a configuration for a different dataset than requested,
+    # forcing the mismatch branch that raises with the identifier interpolated.
+    monkeypatch.setattr(
+        soda_cloud,
+        "_execute_query",
+        lambda *args, **kwargs: _ConfigsResponse([{"datasetQualifiedName": "ds/other-table"}]),
+    )
+
+    with pytest.raises(SodaCloudException) as exc_info:
+        soda_cloud.fetch_dataset_configuration(identifier)
+
+    assert "ds/table" in str(exc_info.value)
+    assert "DatasetIdentifier(" not in str(exc_info.value)
+
+
+class _PostProcessingOkResponse:
+    ok = True
+    status_code = 200
+
+    def json(self):
+        return {}
+
+
+def test_post_processing_update_logs_updating_at_debug_and_updated_at_info(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG, logger="soda")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_execute_command", lambda *args, **kwargs: _PostProcessingOkResponse())
+
+    soda_cloud.post_processing_update(stage="my-stage", scan_id="scan-1", state=PostProcessingStageState.COMPLETED)
+
+    updating_records = [
+        r for r in caplog.records if r.name == "soda" and "Updating post processing stage" in r.getMessage()
+    ]
+    updated_records = [
+        r for r in caplog.records if r.name == "soda" and "Updated post processing stage" in r.getMessage()
+    ]
+    assert len(updating_records) == 1
+    assert updating_records[0].levelno == logging.DEBUG
+    assert len(updated_records) == 1
+    assert updated_records[0].levelno == logging.INFO
+
+
+def test_post_processing_update_updating_line_absent_above_debug(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_execute_command", lambda *args, **kwargs: _PostProcessingOkResponse())
+
+    soda_cloud.post_processing_update(stage="my-stage", scan_id="scan-1", state=PostProcessingStageState.COMPLETED)
+
+    updating_records = [
+        r for r in caplog.records if r.name == "soda" and "Updating post processing stage" in r.getMessage()
+    ]
+    updated_records = [
+        r for r in caplog.records if r.name == "soda" and "Updated post processing stage" in r.getMessage()
+    ]
+    assert updating_records == []
+    assert len(updated_records) == 1

--- a/soda-tests/tests/unit/test_soda_cloud_info_hygiene.py
+++ b/soda-tests/tests/unit/test_soda_cloud_info_hygiene.py
@@ -7,6 +7,9 @@
   shape into user-facing log/exception text.
 - ``post_processing_update`` logs one INFO line per transition (the completed
   form); the pre-announcement is DEBUG-only.
+- ``_execute_rest_get``'s non-ok WARNING truncates ``response_text`` to the first
+  500 chars — same pattern as the existing non-JSON-body warning in
+  ``_parse_json_body`` — instead of dumping an ungated full body at WARNING.
 """
 
 import logging
@@ -132,3 +135,30 @@ def test_post_processing_update_updating_line_absent_above_debug(monkeypatch, ca
     ]
     assert updating_records == []
     assert len(updated_records) == 1
+
+
+class _RestGetFailResponse:
+    ok = False
+    status_code = 500
+    headers = {}
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+def test_execute_rest_get_warning_truncates_response_text_to_500_chars(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger="soda")
+    soda_cloud = _soda_cloud()
+    long_body = "x" * 2000
+    monkeypatch.setattr(soda_cloud, "_http_get", lambda **kwargs: _RestGetFailResponse(long_body))
+
+    soda_cloud._execute_rest_get(relative_url_path="scans/scan-1", request_log_name="get_scan_status")
+
+    warning_records = [
+        r for r in caplog.records if r.name == "soda" and "Soda Cloud error for get_scan_status" in r.getMessage()
+    ]
+    assert len(warning_records) == 1
+    assert warning_records[0].levelno == logging.WARNING
+    message = warning_records[0].getMessage()
+    assert long_body[:500] in message
+    assert long_body not in message

--- a/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
+++ b/soda-tests/tests/unit/test_soda_cloud_request_debug_logging.py
@@ -7,10 +7,16 @@ must be skipped entirely above DEBUG, not just have their result discarded.
 ``to_jsonnable(request_body)`` itself is a different matter: it mutates the body
 in place (datetime/Decimal/Enum -> JSON-safe values), which the subsequent
 ``_http_post(json=request_body, ...)`` relies on to serialize at all — so unlike
-the debug text, it must run on *every* request regardless of DEBUG. (This was a
-real bug: an earlier version of this guard skipped ``to_jsonnable`` too when
-DEBUG was disabled, so a raw ``datetime`` field would reach ``_http_post`` and
-blow up in ``json.dumps`` outside of a debug/verbose run.)
+the debug text, it must run on *every* request regardless of DEBUG/the flag below.
+(This was a real bug: an earlier version of this guard skipped ``to_jsonnable``
+too when DEBUG was disabled, so a raw ``datetime`` field would reach
+``_http_post`` and blow up in ``json.dumps`` outside of a debug/verbose run —
+fixed on the base branch, ahead of this one.)
+
+R-657 task 1 adds a second gate on top of DEBUG for the debug *text* only: the
+full request body (and, on failure, the full ``Response_text``) is the payload
+firehose and only builds/logs when ``SODA_LOG_PAYLOADS`` is also set — DEBUG
+alone now only gets the request name.
 """
 
 import logging
@@ -33,6 +39,16 @@ class _OkResponse:
     headers = {"X-Soda-Trace-Id": "trace-1"}
 
 
+class _FailResponse:
+    ok = False
+    status_code = 400
+    headers = {"X-Soda-Trace-Id": "trace-1"}
+    text = "full failure body text"
+
+    def json(self):
+        return {"message": "bad request", "code": "invalid"}
+
+
 def test_request_body_still_sanitized_when_debug_disabled(monkeypatch, caplog):
     """to_jsonnable's mutation is required for _http_post to serialize the request
     at all, so it must still run even when nothing gets logged."""
@@ -51,26 +67,30 @@ def test_request_body_still_sanitized_when_debug_disabled(monkeypatch, caplog):
     assert [r for r in caplog.records if r.name == "soda" and "Sending command" in r.getMessage()] == []
 
 
-def test_datetime_field_reaches_http_post_as_a_string_when_debug_disabled(monkeypatch, caplog):
-    """Regression guard: _http_post's json= kwarg goes through plain json.dumps,
-    which can't serialize a raw datetime. to_jsonnable's mutation must reach the
-    outgoing body regardless of DEBUG."""
-    caplog.set_level(logging.INFO, logger="soda")
+def test_request_name_logged_when_debug_enabled_but_payloads_flag_off(monkeypatch, caplog):
+    """Default (flag off): DEBUG shows the request name only, not the body — but
+    sanitization (to_jsonnable) still runs since it's required for serialization."""
+    caplog.set_level(logging.DEBUG, logger="soda")
+    monkeypatch.delenv("SODA_LOG_PAYLOADS", raising=False)
     soda_cloud = _soda_cloud()
-    post_calls = []
-    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: post_calls.append(kwargs) or _OkResponse())
-
-    soda_cloud._execute_command(
-        {"type": "sodaCoreScanStart", "createdAt": datetime(2025, 1, 1, tzinfo=timezone.utc)},
-        request_log_name="scan_start",
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
+    to_jsonnable_spy_calls = []
+    monkeypatch.setattr(
+        "soda_core.common.soda_cloud.to_jsonnable",
+        lambda *args, **kwargs: to_jsonnable_spy_calls.append((args, kwargs)) or {},
     )
 
-    assert len(post_calls) == 1
-    assert isinstance(post_calls[0]["json"]["createdAt"], str)
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    assert len(to_jsonnable_spy_calls) == 1
+    debug_records = [r for r in caplog.records if r.name == "soda" and "Sending command scan_start" in r.getMessage()]
+    assert len(debug_records) == 1
+    assert [r for r in caplog.records if r.name == "soda" and "request body:" in r.getMessage()] == []
 
 
-def test_request_body_serialized_when_debug_enabled(monkeypatch, caplog):
+def test_request_body_serialized_when_debug_enabled_and_payloads_flag_on(monkeypatch, caplog):
     caplog.set_level(logging.DEBUG, logger="soda")
+    monkeypatch.setenv("SODA_LOG_PAYLOADS", "true")
     soda_cloud = _soda_cloud()
     monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
     to_jsonnable_spy_calls = []
@@ -86,6 +106,8 @@ def test_request_body_serialized_when_debug_enabled(monkeypatch, caplog):
     assert len(to_jsonnable_spy_calls) == 1
     debug_records = [r for r in caplog.records if r.name == "soda" and "Sending command scan_start" in r.getMessage()]
     assert len(debug_records) == 1
+    body_records = [r for r in caplog.records if r.name == "soda" and "request body:" in r.getMessage()]
+    assert len(body_records) == 1
 
 
 def test_token_masking_regex_not_run_when_debug_disabled(monkeypatch, caplog):
@@ -102,3 +124,63 @@ def test_token_masking_regex_not_run_when_debug_disabled(monkeypatch, caplog):
     soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
 
     assert clean_spy_calls == []
+
+
+def test_token_masking_regex_not_run_when_debug_enabled_but_payloads_flag_off(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG, logger="soda")
+    monkeypatch.delenv("SODA_LOG_PAYLOADS", raising=False)
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _OkResponse())
+    clean_spy_calls = []
+    monkeypatch.setattr(
+        SodaCloud,
+        "_clean_request_from_private_info",
+        lambda self, json_str: clean_spy_calls.append(json_str) or json_str,
+    )
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    assert clean_spy_calls == []
+
+
+def test_response_text_not_dumped_on_failure_when_payloads_flag_off(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG, logger="soda")
+    monkeypatch.delenv("SODA_LOG_PAYLOADS", raising=False)
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _FailResponse())
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    response_text_records = [r for r in caplog.records if r.name == "soda" and "Response_text:" in r.getMessage()]
+    assert response_text_records == []
+
+
+def test_datetime_field_reaches_http_post_as_a_string_when_debug_disabled(monkeypatch, caplog):
+    """Regression guard: _http_post's json= kwarg goes through plain json.dumps,
+    which can't serialize a raw datetime. to_jsonnable's mutation must reach the
+    outgoing body regardless of DEBUG/the payloads flag."""
+    caplog.set_level(logging.INFO, logger="soda")
+    soda_cloud = _soda_cloud()
+    post_calls = []
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: post_calls.append(kwargs) or _OkResponse())
+
+    soda_cloud._execute_command(
+        {"type": "sodaCoreScanStart", "createdAt": datetime(2025, 1, 1, tzinfo=timezone.utc)},
+        request_log_name="scan_start",
+    )
+
+    assert len(post_calls) == 1
+    assert isinstance(post_calls[0]["json"]["createdAt"], str)
+
+
+def test_response_text_dumped_on_failure_when_payloads_flag_on(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG, logger="soda")
+    monkeypatch.setenv("SODA_LOG_PAYLOADS", "true")
+    soda_cloud = _soda_cloud()
+    monkeypatch.setattr(soda_cloud, "_http_post", lambda **kwargs: _FailResponse())
+
+    soda_cloud._execute_command({"type": "sodaCoreScanStart"}, request_log_name="scan_start")
+
+    response_text_records = [r for r in caplog.records if r.name == "soda" and "Response_text:" in r.getMessage()]
+    assert len(response_text_records) == 1
+    assert "full failure body text" in response_text_records[0].getMessage()


### PR DESCRIPTION
## Problem

`--verbose` is unusable as a trace: every query dumps a rendered result-row table and every Soda Cloud request dumps its full body as indented JSON, burying the SQL and durations the operator actually wants — which in turn makes DEBUG useless as a destination for demoted per-item lines in the scan-log improvement stack. Separately: a few INFO lines print Python reprs or fire twice per event, the console shows neither timestamps nor levels (the Cloud upload already carries both as structured fields), and python `warnings` from numeric libraries bypass logging to raw stderr — visible on the console, absent from Cloud, unfilterable.

## Change

Payload dumps (result-row tables, full request bodies, failure response bodies) move behind an opt-in `SODA_LOG_PAYLOADS` env flag, so plain `--verbose` shows SQL, durations, and request names only. INFO hygiene: dataset identifiers render via `to_string()`, post-processing transitions log once, per-skipped-check lines drop to DEBUG behind the summary count. The console formatter regains `timestamp | level | message` (🚨 kept on ERROR+; Cloud wire format untouched). `configure_logging` now routes library warnings through `logging.captureWarnings` with an explicit policy — suppressed below ERROR on normal runs, visible under `--verbose` — closing the raw-stderr leak.

Stacked on #2839 (whose sanitization regression fix this stack surfaced — it now lives in that PR so each merges safely alone). Linear: [R-657](https://linear.app/sodadata/issue/R-657/soda-core-usable-verbose-info-hygiene-console-timestamps-warnings) (parent [R-649](https://linear.app/sodadata/issue/R-649/improve-mm-logs)).

## Testing

Full unit lane on this tip: 1290 passed. Mutation-verified in review: flag forced on/off, warnings-policy level pins, formatter part removal, and the wiring spy (configure_logging → warning capture) each fail their pinned test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT7YDeTVhze62GgefgBZcw