### PR TITLE
fix(sql-dialect): escape regex patterns as string literals

### DIFF
--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -264,7 +264,11 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
 
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
         expression: str = self.build_expression_sql(matches.expression)
-        return f"REGEXP_CONTAINS({expression}, r'{matches.regex_pattern}')"
+        # literal_string() below is BigQuery's own triple-quoted form, which escapes
+        # the backslash as \\ -- so the pattern reaches the regex engine exactly as the
+        # r'' prefix used to deliver it, and an apostrophe is escaped as \' instead of
+        # terminating the literal. See SCS-1413.
+        return f"REGEXP_CONTAINS({expression}, {self.literal_string(matches.regex_pattern)})"
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """BigQuery has no ordered-set aggregates; render as

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -5,7 +5,7 @@ from soda_bigquery.common.data_sources.bigquery_data_source import (
 )
 from soda_core.common.metadata_types import SqlDataType
 from soda_core.common.sql_ast import CREATE_TABLE, CREATE_TABLE_COLUMN
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
 
 
 def test_random():
@@ -398,3 +398,17 @@ def test_time_delta_single_week_still_floors_by_seven_days():
     )
     assert "WEEK" not in sql
     assert sql.endswith("DAY) / 7) AS INT)")
+
+
+def test_regex_like_pattern_goes_through_literal_string():
+    """BigQuerySqlDialect overrides _build_regex_like_sql, so it needs its own copy of
+    the base-dialect guarantee. Its literal_string() is the triple-quoted form, which
+    escapes the backslash as `\\\\` -- so the pattern reaches the regex engine exactly as
+    the old r'' prefix delivered it -- and escapes an apostrophe as `\\'` rather than
+    letting it terminate the literal. See SCS-1413.
+    """
+    sql_dialect = BigQuerySqlDialect()
+    assert (
+        sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^1\.5$")) == "REGEXP_CONTAINS(`c`, '''^1\\\\.5$''')"
+    )
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == "REGEXP_CONTAINS(`c`, '''^it\\'s$''')"

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -416,9 +416,6 @@ class SqlDialect:
         string_literal: str = value.replace("'", "''")
         return string_literal
 
-    def escape_regex(self, value: str):
-        return value
-
     def apply_default_add_semicolon(self, add_semicolon: Optional[bool]) -> bool:
         return add_semicolon if add_semicolon is not None else self.USES_SEMICOLONS_BY_DEFAULT
 
@@ -1250,7 +1247,13 @@ class SqlDialect:
 
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
         expression: str = self.build_expression_sql(matches.expression)
-        return f"REGEXP_LIKE({expression}, '{matches.regex_pattern}')"
+        # The pattern is a string literal like any other, so it goes through
+        # literal_string(). Data sources whose parser consumes backslashes in
+        # string literals (Snowflake, Databricks, Redshift) would otherwise
+        # hand the regex engine `d` where the user wrote `\d`, silently
+        # matching nothing, and an apostrophe in a pattern would break the
+        # query outright.
+        return f"REGEXP_LIKE({expression}, {self.literal_string(matches.regex_pattern)})"
 
     def _build_lower_sql(self, lower: LOWER) -> str:
         return f"LOWER({self.build_expression_sql(lower.expression)})"

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -121,7 +121,7 @@ class DuckDBSqlDialect(SqlDialect, sqlglot_dialect="duckdb"):
 
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
         expression: str = self.build_expression_sql(matches.expression)
-        return f"REGEXP_MATCHES({expression}, '{matches.regex_pattern}')"
+        return f"REGEXP_MATCHES({expression}, {self.literal_string(matches.regex_pattern)})"
 
     def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: bool = True) -> str:
         schema_name: str = prefixes[0]

--- a/soda-duckdb/tests/unit/test_duckdb_dialect.py
+++ b/soda-duckdb/tests/unit/test_duckdb_dialect.py
@@ -1,4 +1,4 @@
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
 from soda_core.common.statements.metadata_primary_keys_query import (
     MetadataPrimaryKeysQuery,
 )
@@ -21,3 +21,14 @@ def test_primary_keys_query_uses_ansi_key_column_usage():
     assert '"information_schema"."table_constraints"' in sql
     assert '"information_schema"."key_column_usage"' in sql
     assert "ordinal_position" in sql
+
+
+def test_regex_like_pattern_goes_through_literal_string():
+    """DuckDBSqlDialect overrides _build_regex_like_sql (REGEXP_MATCHES), so it needs
+    its own copy of the base-dialect guarantee. DuckDB literals are standard
+    conforming, so the backslash passes through unchanged -- but an apostrophe in a
+    user pattern still breaks the query unless it is escaped. See SCS-1413.
+    """
+    sql_dialect = DuckDBSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^1\.5$")) == "REGEXP_MATCHES(\"c\", '^1\\.5$')"
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == "REGEXP_MATCHES(\"c\", '^it''s$')"

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -107,7 +107,7 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
 
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
         expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ '{matches.regex_pattern}'"
+        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
 
     def supports_sampler(self, sampler_type: SamplerType) -> bool:
         return sampler_type is SamplerType.PERCENTAGE

--- a/soda-postgres/tests/unit/test_postgres_dialect.py
+++ b/soda-postgres/tests/unit/test_postgres_dialect.py
@@ -1,5 +1,13 @@
 import pytest
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
+from soda_core.common.sql_dialect import (
+    COLUMN,
+    FROM,
+    RANDOM,
+    REGEX_LIKE,
+    SELECT,
+    STAR,
+    SamplerType,
+)
 from soda_postgres.common.data_sources.postgres_data_source import PostgresSqlDialect
 
 
@@ -92,3 +100,14 @@ def test_primary_keys_query_reads_pg_catalog_not_information_schema():
     # Schema filter is case-insensitive (mirrors PostgresMetadataTablesQuery), so a schema
     # spelled in a different case doesn't silently match nothing.
     assert 'LOWER("schemas"."nspname") = \'myschema\'' in sql
+
+
+def test_regex_like_pattern_goes_through_literal_string():
+    """PostgresSqlDialect overrides _build_regex_like_sql (it renders `~`), so it needs
+    its own copy of the base-dialect guarantee. Postgres literals are standard
+    conforming, so the backslash passes through unchanged -- but an apostrophe in a
+    user pattern still breaks the query unless it is escaped. See SCS-1413.
+    """
+    sql_dialect = PostgresSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^1\.5$")) == "\"c\" ~ '^1\\.5$'"
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == "\"c\" ~ '^it''s$'"

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -179,7 +179,7 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
 
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
         expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ '{matches.regex_pattern}'"
+        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
 
     def _build_tuple_sql(self, tuple: TUPLE) -> str:
         if tuple.check_context(COUNT) and tuple.check_context(DISTINCT):

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -1,5 +1,5 @@
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
 from soda_redshift.common.data_sources.redshift_data_source import RedshiftSqlDialect
 
 
@@ -134,3 +134,16 @@ def test_primary_keys_constraint_definition_parsing_preserves_order():
         "orders": ["tenant_id", "id"],
         "customers": ["id"],
     }
+
+
+def test_regex_like_pattern_goes_through_literal_string():
+    """RedshiftSqlDialect overrides _build_regex_like_sql (it renders `~`, not
+    REGEXP_LIKE), so the base-class escaping does not reach it. Redshift's parser
+    consumes backslashes in string literals, so a pattern needs the doubled form its
+    own escape_string produces -- AWS documents `\\\\.` as the way to match a literal
+    metacharacter. Without it `^1\\.5$` arrives as `^1.5$` and matches anything.
+    See SCS-1413.
+    """
+    sql_dialect = RedshiftSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^1\.5$")) == "\"c\" ~ '^1\\\\.5$'"
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == "\"c\" ~ '^it''s$'"

--- a/soda-snowflake/tests/unit/test_snowflake_dialect.py
+++ b/soda-snowflake/tests/unit/test_snowflake_dialect.py
@@ -1,6 +1,14 @@
 import pytest
 from soda_core.common.data_source_results import QueryResult
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
+from soda_core.common.sql_dialect import (
+    COLUMN,
+    FROM,
+    RANDOM,
+    REGEX_LIKE,
+    SELECT,
+    STAR,
+    SamplerType,
+)
 from soda_snowflake.common.data_sources.snowflake_data_source import SnowflakeSqlDialect
 
 
@@ -236,3 +244,42 @@ def test_primary_keys_show_parsing_locates_columns_by_name():
         rows=[(2, "ID", "ORDERS"), (1, "TENANT_ID", "ORDERS")],
     )
     assert SnowflakeMetadataPrimaryKeysQuery._ordered_key_columns(show_result) == ["TENANT_ID", "ID"]
+
+
+# ---------------------------------------------------------------------------
+# Regex literals — Snowflake's SQL parser consumes backslashes in single-quoted
+# string literals ('\d' arrives at the regex engine as 'd'), so a regex pattern
+# has to go through the same escaping as any other string literal. Without it,
+# a `valid regex` like ^\d+$ silently matches nothing and every non-null row is
+# reported invalid. See SCS-1413.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "regex_pattern, expected_sql",
+    [
+        pytest.param(
+            r"^[+-]?((\d+(\.\d*)?)|(\.\d+))$",
+            r"""REGEXP_LIKE("c", '^[+-]?((\\d+(\\.\\d*)?)|(\\.\\d+))$')""",
+            id="decimal_pattern_backslashes_doubled",
+        ),
+        pytest.param(
+            r"^\d+$",
+            r"""REGEXP_LIKE("c", '^\\d+$')""",
+            id="digits_backslash_doubled",
+        ),
+        pytest.param(
+            "^[A-Z]+$",
+            """REGEXP_LIKE("c", '^[A-Z]+$')""",
+            id="no_backslash_unchanged",
+        ),
+        pytest.param(
+            "^it's$",
+            """REGEXP_LIKE("c", '^it''s$')""",
+            id="single_quote_escaped",
+        ),
+    ],
+)
+def test_regex_like_escapes_pattern(regex_pattern, expected_sql):
+    sql_dialect: SnowflakeSqlDialect = SnowflakeSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), regex_pattern)) == expected_sql

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -318,7 +318,8 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
         # see: https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver17
         # CS: Case sensitive; AS: Accent sensitive
         # The default is SQL_Latin1_General_Cp1_CI_AS (case-insensitive), we replcae with a case sensitive collation
-        return f"PATINDEX ('%{regex_pattern}%', {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+        pattern_literal: str = self.literal_string(f"%{regex_pattern}%")
+        return f"PATINDEX ({pattern_literal}, {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
 
     def supports_regex_advanced(self) -> bool:
         return False

--- a/soda-tests/tests/integration/test_invalid_check.py
+++ b/soda-tests/tests/integration/test_invalid_check.py
@@ -21,6 +21,22 @@ test_table_specification = (
     .build()
 )
 
+# Dedicated table for the escaped-metacharacter regex test: '1.5' must match
+# `^1\.5$` and '1x5' must not. Both rows are needed -- with only '1.5' the
+# pattern matches either way and the test proves nothing.
+escaped_metacharacter_test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("invalid_regex_escape")
+    .column_varchar("value")
+    .rows(
+        rows=[
+            ("1.5",),
+            ("1x5",),
+        ]
+    )
+    .build()
+)
+
 
 @pytest.mark.parametrize(
     "contract_yaml_str",
@@ -153,6 +169,47 @@ def test_invalid_count_valid_regex_sql(data_source_test_helper: DataSourceTestHe
                 valid_format:
                   regex: '{regex_pattern}'
                   name: one-two-threes
+                checks:
+                  - invalid:
+        """,
+    )
+    assert (
+        get_diagnostic_value(
+            check_result=contract_verification_result.check_results[0], diagnostic_name="invalid_count"
+        )
+        == 1
+    )
+
+
+def test_invalid_count_valid_regex_escaped_metacharacter(data_source_test_helper: DataSourceTestHelper):
+    """A backslash in a regex must survive into the data source's regex engine.
+
+    Data sources whose SQL parser consumes backslashes inside string literals
+    (Snowflake, Databricks, Redshift) drop the backslash before the engine ever
+    sees it, turning `1\\.5` into `1.5` -- where `.` matches any character, so
+    '1x5' is silently accepted as valid. The other regex tests here all use
+    backslash-free patterns (`^[123]$`), which is why that went unnoticed.
+    See SCS-1413 / SCS-1230.
+
+    Escaping a metacharacter is used rather than a shorthand like `\\d` because
+    it is valid in POSIX ERE as well as PCRE -- Redshift's REGEXP_LIKE is POSIX,
+    where `\\d` is not a digit class on any code path.
+    """
+    if not data_source_test_helper.data_source_impl.sql_dialect.supports_regex_advanced():
+        pytest.skip("data source does not evaluate the pattern as a regex")
+
+    test_table = data_source_test_helper.ensure_test_table(escaped_metacharacter_test_table_specification)
+
+    # Only '1x5' is invalid. If the backslash is eaten, `.` matches 'x' too and
+    # the check finds nothing invalid, so assert_contract_fail itself fails.
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str="""
+            columns:
+              - name: value
+                valid_format:
+                  regex: '^1\\.5$'
+                  name: one-point-five
                 checks:
                   - invalid:
         """,

--- a/soda-tests/tests/integration/test_invalid_check.py
+++ b/soda-tests/tests/integration/test_invalid_check.py
@@ -191,9 +191,11 @@ def test_invalid_count_valid_regex_escaped_metacharacter(data_source_test_helper
     backslash-free patterns (`^[123]$`), which is why that went unnoticed.
     See SCS-1413 / SCS-1230.
 
-    Escaping a metacharacter is used rather than a shorthand like `\\d` because
-    it is valid in POSIX ERE as well as PCRE -- Redshift's REGEXP_LIKE is POSIX,
-    where `\\d` is not a digit class on any code path.
+    Escaping a metacharacter is used rather than a shorthand like `\\d` so the test
+    means the same thing on every engine: `\\d` is a PCRE-ism that POSIX engines read
+    as a literal `d`, and a pattern that matches nothing cannot distinguish "the
+    shorthand is unsupported" from "the backslash was eaten". An escaped metacharacter
+    discriminates: drop the backslash and `.` starts matching '1x5'.
     """
     if not data_source_test_helper.data_source_impl.sql_dialect.supports_regex_advanced():
         pytest.skip("data source does not evaluate the pattern as a regex")

--- a/soda-tests/tests/integration/test_invalid_check.py
+++ b/soda-tests/tests/integration/test_invalid_check.py
@@ -24,6 +24,22 @@ test_table_specification = (
 # Dedicated table for the escaped-metacharacter regex test: '1.5' must match
 # `^1\.5$` and '1x5' must not. Both rows are needed -- with only '1.5' the
 # pattern matches either way and the test proves nothing.
+# Dedicated table for the apostrophe regex test: "it's" must match `^it's$` and "its"
+# must not. An apostrophe in a pattern is what breaks a hand-quoted literal outright,
+# rather than silently mismatching the way an eaten backslash does.
+apostrophe_test_table_specification = (
+    TestTableSpecification.builder()
+    .table_purpose("invalid_regex_quote")
+    .column_varchar("value")
+    .rows(
+        rows=[
+            ("it's",),
+            ("its",),
+        ]
+    )
+    .build()
+)
+
 escaped_metacharacter_test_table_specification = (
     TestTableSpecification.builder()
     .table_purpose("invalid_regex_escape")
@@ -212,6 +228,41 @@ def test_invalid_count_valid_regex_escaped_metacharacter(data_source_test_helper
                 valid_format:
                   regex: '^1\\.5$'
                   name: one-point-five
+                checks:
+                  - invalid:
+        """,
+    )
+    assert (
+        get_diagnostic_value(
+            check_result=contract_verification_result.check_results[0], diagnostic_name="invalid_count"
+        )
+        == 1
+    )
+
+
+def test_invalid_count_valid_regex_apostrophe(data_source_test_helper: DataSourceTestHelper):
+    """An apostrophe in a pattern must be escaped for the data source's literal syntax.
+
+    Unlike an eaten backslash, which silently mismatches, an unescaped quote terminates
+    the string literal and breaks the query outright. Every dialect spells the escape
+    differently -- '' for most, \\' inside BigQuery's triple-quoted form and for
+    Databricks -- so this runs the whole set against a live engine rather than trusting
+    the per-dialect unit tests alone. See SCS-1413.
+    """
+    if not data_source_test_helper.data_source_impl.sql_dialect.supports_regex_advanced():
+        pytest.skip("data source does not evaluate the pattern as a regex")
+
+    test_table = data_source_test_helper.ensure_test_table(apostrophe_test_table_specification)
+
+    # Only 'its' is invalid; "it's" matches the pattern exactly.
+    contract_verification_result: ContractVerificationResult = data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str="""
+            columns:
+              - name: value
+                valid_format:
+                  regex: "^it's$"
+                  name: it-apostrophe-s
                 checks:
                   - invalid:
         """,

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -465,3 +465,16 @@ def test_empty_invalid_values_renders_portable_always_false_predicate():
     sql_dialect: SqlDialect = SqlDialect()
     expr = _missing_and_validity(invalid_values=[]).is_invalid_expr(COLUMN("c"))
     assert sql_dialect.build_expression_sql(expr) == "1 = 0"
+
+
+def test_regex_like_pattern_goes_through_literal_string():
+    """The regex pattern is a string literal and must be escaped like one.
+
+    Hand-wrapping it in quotes leaves an apostrophe in a user pattern to break the
+    query outright, and on data sources whose parser consumes backslashes it silently
+    strips the escape so the pattern matches nothing. Every dialect that overrides
+    _build_regex_like_sql has its own copy of this test. See SCS-1413.
+    """
+    sql_dialect: SqlDialect = SqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == """REGEXP_LIKE("c", '^it''s$')"""
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^\d$")) == """REGEXP_LIKE("c", '^\\d$')"""


### PR DESCRIPTION
Chain: **this** → #2843 → #2842. Merge bottom-up.

`REGEXP_LIKE` hand-wrapped the pattern in quotes instead of going through
`literal_string()`. On data sources whose SQL parser consumes backslashes in string
literals, `^-?\d+$` reaches the regex engine as `^-?d+$` — matches nothing, so every
non-null row is reported invalid with no error. An apostrophe in a pattern breaks the
query outright.

Five dialects override the builder and needed the same fix:

| dialect | rendered | note |
|---|---|---|
| redshift | `{expr} ~ …` | parser eats backslashes; needs the doubled form [AWS documents](https://docs.aws.amazon.com/redshift/latest/dg/pattern-matching-conditions-posix.html) |
| postgres | `{expr} ~ …` | backslash-safe already, now quote-safe |
| duckdb | `REGEXP_MATCHES(…)` | backslash-safe already, now quote-safe |
| bigquery | `REGEXP_CONTAINS(…)` | its `literal_string()` is triple-quoted, so the pattern reaches the engine as the old `r''` prefix delivered it; apostrophe now escaped |
| sqlserver | `PATINDEX('%…%', …) > 0` | quote-safe; keeps the full override because it rewrites the pattern text |

In soda-extensions: `soda-db2z` already escapes quotes; `soda-db2` and `soda-dremio` carry
copies of the old base implementation and should be deleted so they inherit the fix.

Verified on live Snowflake — [without the fix](https://github.com/sodadata/soda-core/actions/runs/32833001202)
fails on 3.10–3.14 with `assert 3 == 1`, [with it](https://github.com/sodadata/soda-core/actions/runs/32833010800)
passes. `invalid_count: 3` on a 4-row table with one invalid row, which is the report on
SCS-1230: "showing all rows failed".

Tests: `…_escaped_metacharacter` (`^1\.5$` against `1.5` / `1x5` — an escaped metacharacter
rather than `\d`, which POSIX engines read as a literal `d` and so cannot distinguish
"unsupported" from "backslash eaten") and `…_apostrophe` (`^it's$`, exercising `''` and
`\'` live). Per-dialect unit tests for each override.

v3 escapes user regexes via `data_source.escape_regex()`; v4 did not, so a SodaCL
`valid regex: \d+` that worked breaks when migrated to a v4 contract on Snowflake. This
restores parity and drops the dead base `escape_regex()` hook.

**Behaviour change:** a regex field is a regex, not a SQL literal. Doubled-backslash
workarounds must revert to single backslashes. SQL-level escape sequences in a pattern are
no longer interpreted by the data source — matches v3; see SCS-728, SAS-7560.

**Release note:** Fixed: regex patterns in `valid_format` / `invalid_format` /
`missing_format` were not escaped for the data source, so on Snowflake, Databricks and
Redshift a backslash in a pattern never reached the regex engine and every non-null row
could be reported invalid. If you worked around this by doubling backslashes in your
contract, revert those patterns to single backslashes.

Refs SCS-1413, SCS-1230.

<!-- customer-facing-release-note
Fixed: regex patterns in `valid_format` / `invalid_format` / `missing_format` were not
escaped for the data source, so on Snowflake, Databricks and Redshift a backslash in a
pattern never reached the regex engine and every non-null row could be reported invalid.
If you worked around this by doubling backslashes in your contract, revert those patterns
to single backslashes.
-->
