### PR TITLE
chore(lint): stop isort wrapping imports at 88 when black allows 120

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
+# profile = "black" sets line_length = 88 and does NOT read [tool.black]
+# line-length below, so without this isort wraps imports at 88 while black is
+# happy up to 120 -- a 100-char import line passes black and fails isort.
+line_length = 120
 
 [tool.black]
 line-length = 120

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source.py
@@ -5,12 +5,8 @@ from datetime import datetime
 from typing import Any, Optional, Tuple
 
 import boto3
-from soda_athena.common.data_sources.athena_data_source_connection import (
-    AthenaDataSource as AthenaDataSourceModel,
-)
-from soda_athena.common.data_sources.athena_data_source_connection import (
-    AthenaDataSourceConnection,
-)
+from soda_athena.common.data_sources.athena_data_source_connection import AthenaDataSource as AthenaDataSourceModel
+from soda_athena.common.data_sources.athena_data_source_connection import AthenaDataSourceConnection
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl, FullyQualifiedTableName
 from soda_core.common.logging_constants import soda_logger

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
@@ -12,9 +12,7 @@ from soda_core.common.aws_credentials import AwsCredentials
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-athena/tests/unit/test_athena_catalog_with_slash.py
+++ b/soda-athena/tests/unit/test_athena_catalog_with_slash.py
@@ -11,10 +11,7 @@ affected paths: contract verify queries, column metadata queries, and DDL.
 
 from __future__ import annotations
 
-from soda_athena.common.data_sources.athena_data_source import (
-    AthenaSqlDialect,
-    _collapse_athena_prefixes,
-)
+from soda_athena.common.data_sources.athena_data_source import AthenaSqlDialect, _collapse_athena_prefixes
 from soda_core.common.dataset_identifier import DatasetIdentifier
 from soda_core.common.metadata_types import DbSchemaDataSourceNamespace
 from soda_core.common.sql_ast import CTE, SELECT, STAR, WITH

--- a/soda-athena/tests/unit/test_athena_dialect.py
+++ b/soda-athena/tests/unit/test_athena_dialect.py
@@ -1,7 +1,4 @@
-from soda_athena.common.data_sources.athena_data_source import (
-    AthenaSqlDialect,
-    _collapse_athena_prefixes,
-)
+from soda_athena.common.data_sources.athena_data_source import AthenaSqlDialect, _collapse_athena_prefixes
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR
 
 
@@ -222,9 +219,7 @@ def test_ddl_float_type_name_stays_hive_float():
 def test_lenient_timestamp_converter_accepts_both_precisions():
     from datetime import datetime
 
-    from soda_athena.common.data_sources.athena_data_source_connection import (
-        LenientTypeConverter,
-    )
+    from soda_athena.common.data_sources.athena_data_source_connection import LenientTypeConverter
 
     converter = LenientTypeConverter()
     convert = converter.mappings["timestamp"]

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -23,7 +23,6 @@ from soda_core.common.sql_ast import (
     LITERAL,
     PERCENTILE_WITHIN_GROUP,
     RANDOM,
-    REGEX_LIKE,
     STRING_HASH,
     TIME_DELTA,
     TUPLE,
@@ -262,13 +261,10 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     def _build_tuple_sql_in_distinct(self, tuple: TUPLE) -> str:
         return f"TO_JSON_STRING(STRUCT({super()._build_tuple_sql(tuple)}))"
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        # literal_string() below is BigQuery's own triple-quoted form, which escapes
-        # the backslash as \\ -- so the pattern reaches the regex engine exactly as the
-        # r'' prefix used to deliver it, and an apostrophe is escaped as \' instead of
-        # terminating the literal. See SCS-1413.
-        return f"REGEXP_CONTAINS({expression}, {self.literal_string(matches.regex_pattern)})"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        # `pattern` arrives quoted by this dialect's own literal_string(), the
+        # triple-quoted form that escapes the backslash as \\ and an apostrophe as \'.
+        return f"REGEXP_CONTAINS({expression}, {pattern})"
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """BigQuery has no ordered-set aggregates; render as

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -5,9 +5,7 @@ from typing import Optional
 from soda_bigquery.common.data_sources.bigquery_data_source_connection import (
     BigQueryDataSource as BigQueryDataSourceModel,
 )
-from soda_bigquery.common.data_sources.bigquery_data_source_connection import (
-    BigQueryDataSourceConnection,
-)
+from soda_bigquery.common.data_sources.bigquery_data_source_connection import BigQueryDataSourceConnection
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
@@ -32,9 +30,7 @@ from soda_core.common.sql_ast import (
     WITH,
 )
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 
 logger: logging.Logger = soda_logger

--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source_connection.py
@@ -16,9 +16,7 @@ from pydantic import Field, SecretStr
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -1,8 +1,5 @@
 import pytest
-from soda_bigquery.common.data_sources.bigquery_data_source import (
-    BigQueryMetadataPrimaryKeysQuery,
-    BigQuerySqlDialect,
-)
+from soda_bigquery.common.data_sources.bigquery_data_source import BigQueryMetadataPrimaryKeysQuery, BigQuerySqlDialect
 from soda_core.common.metadata_types import SqlDataType
 from soda_core.common.sql_ast import CREATE_TABLE, CREATE_TABLE_COLUMN
 from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT

--- a/soda-core/src/soda_core/check_collections/base.py
+++ b/soda-core/src/soda_core/check_collections/base.py
@@ -31,15 +31,7 @@ from soda_core.common.metadata_types import SamplerType
 from soda_core.common.soda_cloud_converter import map_sampler_type_from_dto
 from soda_core.common.soda_cloud_dto import DatasetConfigurationDTO
 from soda_core.common.sql_ast import SODA_FILTERED_CTE_NAME
-from soda_core.common.sql_dialect import (
-    CTE,
-    FROM,
-    SELECT,
-    STAR,
-    WHERE,
-    DatasetIdentifier,
-    SqlExpressionStr,
-)
+from soda_core.common.sql_dialect import CTE, FROM, SELECT, STAR, WHERE, DatasetIdentifier, SqlExpressionStr
 from soda_core.common.yaml import CheckCollectionYamlSource, YamlObject
 from soda_core.contracts.contract_verification import (
     CheckCollectionStatus,
@@ -52,9 +44,7 @@ from soda_core.contracts.contract_verification import (
     ScanTokenUsage,
     YamlFileContentInfo,
 )
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 logger: logging.Logger = soda_logger
 
@@ -496,9 +486,7 @@ class CheckCollectionImpl:
     ):
         # Defer import: CheckImpl/ColumnImpl/MetricsResolver/RowCountMetricImpl live in
         # contract_verification_impl.py which imports this module.
-        from soda_core.contracts.impl.check_types.row_count_check import (
-            RowCountMetricImpl,
-        )
+        from soda_core.contracts.impl.check_types.row_count_check import RowCountMetricImpl
         from soda_core.contracts.impl.contract_verification_impl import MetricsResolver
 
         self.logs: Logs = logs if logs is not None else Logs()
@@ -705,10 +693,7 @@ class CheckCollectionImpl:
 
     def _build_queries(self) -> list:
         from soda_core.contracts.impl.check_types.schema_check import SchemaQuery
-        from soda_core.contracts.impl.contract_verification_impl import (
-            AggregationMetricImpl,
-            AggregationQuery,
-        )
+        from soda_core.contracts.impl.contract_verification_impl import AggregationMetricImpl, AggregationQuery
 
         queries: list = []
 
@@ -1080,9 +1065,7 @@ class CheckCollectionImpl:
         ``response_json=None`` to match this path's "run handlers regardless
         of upload success" semantics.
         """
-        from soda_core.contracts.impl.contract_verification_impl import (
-            ContractVerificationHandlerRegistry,
-        )
+        from soda_core.contracts.impl.contract_verification_impl import ContractVerificationHandlerRegistry
 
         scan_id = verification_result.scan_id
         for handler in ContractVerificationHandlerRegistry.contract_verification_handlers:

--- a/soda-core/src/soda_core/check_collections/session.py
+++ b/soda-core/src/soda_core/check_collections/session.py
@@ -15,25 +15,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional, Union
 
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionSessionResult,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionSessionResult
 from soda_core.common.data_source_impl import DataSourceImpl
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.exceptions import InvalidArgumentException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs, preserve_active_logs
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import CheckCollectionYamlSource
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 logger = soda_logger
 

--- a/soda-core/src/soda_core/cli/cli.py
+++ b/soda-core/src/soda_core/cli/cli.py
@@ -29,24 +29,14 @@ from soda_core.cli.handlers.dependencies import (
     run_with_failure_reporting,
 )
 from soda_core.cli.handlers.failure_reporting import ScanExecutionFailedException
-from soda_core.cli.handlers.request import (
-    handle_fetch_proposal,
-    handle_push_proposal,
-    handle_transition_request,
-)
-from soda_core.cli.handlers.soda_cloud import (
-    handle_create_soda_cloud,
-    handle_test_soda_cloud,
-)
+from soda_core.cli.handlers.request import handle_fetch_proposal, handle_push_proposal, handle_transition_request
+from soda_core.cli.handlers.soda_cloud import handle_create_soda_cloud, handle_test_soda_cloud
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.logging_configuration import configure_logging
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.contracts.contract_request import RequestStatus
-from soda_core.contracts.impl.check_selector import (
-    CheckSelector,
-    CheckSelectorParseException,
-)
+from soda_core.contracts.impl.check_selector import CheckSelector, CheckSelectorParseException
 from soda_core.telemetry.soda_telemetry import SodaTelemetry
 from soda_core.telemetry.soda_tracer import soda_trace
 

--- a/soda-core/src/soda_core/cli/handlers/contract.py
+++ b/soda-core/src/soda_core/cli/handlers/contract.py
@@ -4,10 +4,7 @@ from typing import Dict, Optional
 
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.common._deprecation import deprecated_kwarg
-from soda_core.common.exceptions import (
-    ContractParserException,
-    InvalidArgumentException,
-)
+from soda_core.common.exceptions import ContractParserException, InvalidArgumentException
 from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.logs import Logs
 from soda_core.common.yaml import ContractYamlSource
@@ -15,9 +12,7 @@ from soda_core.contracts.api import test_contract, verify_contract
 from soda_core.contracts.api.publish_api import publish_contract
 from soda_core.contracts.contract_verification import ContractVerificationSessionResult
 from soda_core.contracts.impl.check_selector import CheckSelector
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 
 def handle_verify_contract(

--- a/soda-core/src/soda_core/cli/handlers/dependencies.py
+++ b/soda-core/src/soda_core/cli/handlers/dependencies.py
@@ -17,10 +17,7 @@ import os
 from typing import TYPE_CHECKING, Callable, Optional
 
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.failure_reporting import (
-    ScanExecutionFailedException,
-    report_scan_execution_failure,
-)
+from soda_core.cli.handlers.failure_reporting import ScanExecutionFailedException, report_scan_execution_failure
 from soda_core.common.exceptions import (
     InvalidDataSourceConfigurationException,
     InvalidSodaCloudConfigurationException,

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -15,13 +15,8 @@ from soda_core.common.metadata_types import (
     SchemaDataSourceNamespace,
 )
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
-from soda_core.common.statements.metadata_tables_query import (
-    FullyQualifiedTableName,
-    MetadataTablesQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
+from soda_core.common.statements.metadata_tables_query import FullyQualifiedTableName, MetadataTablesQuery
 from soda_core.common.statements.table_types import FullyQualifiedObjectName, TableType
 from soda_core.common.yaml import DataSourceYamlSource, YamlObject
 from soda_core.contracts.contract_verification import DataSource

--- a/soda-core/src/soda_core/common/logging_configuration.py
+++ b/soda-core/src/soda_core/common/logging_configuration.py
@@ -3,16 +3,7 @@ import logging
 import os
 import sys
 from datetime import datetime
-from logging import (
-    CRITICAL,
-    DEBUG,
-    ERROR,
-    INFO,
-    WARNING,
-    Formatter,
-    LogRecord,
-    StreamHandler,
-)
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING, Formatter, LogRecord, StreamHandler
 from typing import Optional
 
 from soda_core.common.logging_constants import Emoticons, ExtraKeys

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -17,10 +17,7 @@ import requests
 from pydantic import ValidationError
 from requests import Response
 from soda_core.common.dataset_identifier import DatasetIdentifier
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.exceptions import (
     ContractNotFoundException,
     DatasetNotFoundException,
@@ -2006,9 +2003,7 @@ def _build_v4_diagnostics_check_type_json_dict(check_result: CheckResult) -> Opt
         return None
 
     from soda_core.contracts.contract_interfaces import SodaCloudJsonable
-    from soda_core.contracts.impl.check_types.freshness_check import (
-        FreshnessCheckResult,
-    )
+    from soda_core.contracts.impl.check_types.freshness_check import FreshnessCheckResult
     from soda_core.contracts.impl.check_types.schema_check import SchemaCheckResult
 
     if check_result.autogenerate_diagnostics_payload:

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from datetime import date, datetime, time, timezone
 from numbers import Number
 from textwrap import indent
-from typing import Any, ClassVar, Optional, Tuple
+from typing import Any, ClassVar, Optional, Tuple, final
 
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.dataset_identifier import DatasetIdentifier
@@ -1246,15 +1246,46 @@ class SqlDialect:
     def _build_not_like_sql(self, not_like: NOT_LIKE) -> str:
         return f"{self.build_expression_sql(not_like.left)} NOT LIKE {self.build_expression_sql(not_like.right)}"
 
+    @final
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
+        """Renders REGEX_LIKE. Final on purpose -- override the two seams below.
+
+        REGEX_LIKE.regex_pattern is a bare str rather than an expression node, so
+        unlike LIKE -- whose pattern is a LITERAL and is escaped by the expression
+        renderer in every dialect for free -- nothing escapes it unless this method
+        does. Six dialects each hand-quoted it and five got it wrong (SCS-1413).
+
+        Escaping therefore happens here, once, and cannot be skipped: a dialect that
+        needs different syntax overrides _regex_like_sql, and one that needs the
+        pattern text itself rewritten overrides _rewrite_regex_pattern, which runs
+        before the escaping rather than instead of it.
+        """
         expression: str = self.build_expression_sql(matches.expression)
-        # The pattern is a string literal like any other, so it goes through
-        # literal_string(). Data sources whose parser consumes backslashes in
-        # string literals (Snowflake, Databricks, Redshift) would otherwise
-        # hand the regex engine `d` where the user wrote `\d`, silently
-        # matching nothing, and an apostrophe in a pattern would break the
-        # query outright.
-        return f"REGEXP_LIKE({expression}, {self.literal_string(matches.regex_pattern)})"
+        pattern: str = self.literal_string(self._rewrite_regex_pattern(matches.regex_pattern))
+        return self._regex_like_sql(expression, pattern)
+
+    def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
+        """Adapt the pattern text to what this engine's matcher understands.
+
+        Runs on the raw pattern, before it is escaped as a literal. Return it
+        unchanged unless the engine needs a different dialect of regex -- sqlserver
+        expands `a-z` / `A-Z` and wraps the pattern for PATINDEX here.
+        """
+        return regex_pattern
+
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        """Per-dialect regex syntax. `pattern` arrives already escaped as a string
+        literal, quotes and all -- do not re-quote it.
+
+        Override for a different function name or operator. Three shapes are in use:
+        a function call (base, duckdb's REGEXP_MATCHES, bigquery's REGEXP_CONTAINS),
+        an infix operator (postgres and redshift's `~`), and a whole-predicate
+        rewrite (sqlserver's PATINDEX(...) > 0, and soda-extensions' db2z, which
+        binds the pattern into an XQuery fn:matches). A dialect needing a
+        non-standard literal form does not belong here -- that is what its own
+        literal_string() override is for, as bigquery's triple-quoted form shows.
+        """
+        return f"REGEXP_LIKE({expression}, {pattern})"
 
     def _build_lower_sql(self, lower: LOWER) -> str:
         return f"LOWER({self.build_expression_sql(lower.expression)})"

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -11,10 +11,7 @@ from typing import Any, ClassVar, Optional, Tuple, final
 
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.dataset_identifier import DatasetIdentifier
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import (
     ColumnMetadata,

--- a/soda-core/src/soda_core/common/statements/metadata_primary_keys_query.py
+++ b/soda-core/src/soda_core/common/statements/metadata_primary_keys_query.py
@@ -2,22 +2,8 @@ from __future__ import annotations
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_results import QueryResult
-from soda_core.common.metadata_types import (
-    DataSourceNamespace,
-    DbSchemaDataSourceNamespace,
-    SchemaDataSourceNamespace,
-)
-from soda_core.common.sql_ast import (
-    AND,
-    COLUMN,
-    EQ,
-    FROM,
-    IN,
-    JOIN,
-    LITERAL,
-    SELECT,
-    WHERE,
-)
+from soda_core.common.metadata_types import DataSourceNamespace, DbSchemaDataSourceNamespace, SchemaDataSourceNamespace
+from soda_core.common.sql_ast import AND, COLUMN, EQ, FROM, IN, JOIN, LITERAL, SELECT, WHERE
 from soda_core.common.sql_dialect import SqlDialect
 
 

--- a/soda-core/src/soda_core/common/yaml.py
+++ b/soda-core/src/soda_core/common/yaml.py
@@ -11,10 +11,7 @@ from typing import Iterable, Optional
 
 from ruamel.yaml import YAML, CommentedMap, CommentedSeq
 from ruamel.yaml.error import MarkedYAMLError
-from soda_core.common.exceptions import (
-    InvalidDataSourceConfigurationException,
-    YamlParserException,
-)
+from soda_core.common.exceptions import InvalidDataSourceConfigurationException, YamlParserException
 from soda_core.common.logging_constants import ExtraKeys, soda_logger
 from soda_core.common.logs import Location
 

--- a/soda-core/src/soda_core/contracts/api/publish_api.py
+++ b/soda-core/src/soda_core/contracts/api/publish_api.py
@@ -1,7 +1,4 @@
-from soda_core.contracts.contract_publication import (
-    ContractPublication,
-    ContractPublicationResultList,
-)
+from soda_core.contracts.contract_publication import ContractPublication, ContractPublicationResultList
 
 
 def publish_contract(contract_file_path: str, soda_cloud_file_path: str) -> ContractPublicationResultList:

--- a/soda-core/src/soda_core/contracts/api/test_api.py
+++ b/soda-core/src/soda_core/contracts/api/test_api.py
@@ -2,10 +2,7 @@ from typing import Dict, Optional, Union
 
 from soda_core.common.exceptions import InvalidArgumentException
 from soda_core.common.yaml import ContractYamlSource
-from soda_core.contracts.contract_verification import (
-    ContractVerificationSession,
-    ContractVerificationSessionResult,
-)
+from soda_core.contracts.contract_verification import ContractVerificationSession, ContractVerificationSessionResult
 from soda_core.telemetry.soda_telemetry import SodaTelemetry
 from typing_extensions import deprecated
 

--- a/soda-core/src/soda_core/contracts/api/verify_api.py
+++ b/soda-core/src/soda_core/contracts/api/verify_api.py
@@ -7,19 +7,10 @@ from soda_core.common.exceptions import InvalidArgumentException, SodaCloudExcep
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import SodaCloud
-from soda_core.common.yaml import (
-    ContractYamlSource,
-    DataSourceYamlSource,
-    build_data_source_yaml_sources,
-)
-from soda_core.contracts.contract_verification import (
-    ContractVerificationSession,
-    ContractVerificationSessionResult,
-)
+from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource, build_data_source_yaml_sources
+from soda_core.contracts.contract_verification import ContractVerificationSession, ContractVerificationSessionResult
 from soda_core.contracts.impl.check_selector import CheckSelector
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 from soda_core.telemetry.soda_telemetry import SodaTelemetry
 from typing_extensions import deprecated
 

--- a/soda-core/src/soda_core/contracts/contract_publication.py
+++ b/soda-core/src/soda_core/contracts/contract_publication.py
@@ -25,9 +25,7 @@ class ContractPublication:
         if not contract_publication_builder.soda_cloud and not contract_publication_builder.soda_cloud_yaml_source:
             logger.error(f"Cannot publish without a Soda Cloud configuration")
 
-        from soda_core.contracts.impl.contract_publication_impl import (
-            ContractPublicationImpl,
-        )
+        from soda_core.contracts.impl.contract_publication_impl import ContractPublicationImpl
 
         self.contract_publication_impl: ContractPublicationImpl = ContractPublicationImpl(
             contract_yaml_sources=contract_publication_builder.contract_yaml_sources,

--- a/soda-core/src/soda_core/contracts/contract_verification.py
+++ b/soda-core/src/soda_core/contracts/contract_verification.py
@@ -11,9 +11,7 @@ from soda_core.common.logging_constants import Emoticons, soda_logger
 from soda_core.common.logs import Location, Logs
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
 from soda_core.contracts.contract_interfaces import Loggable
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 logger: logging.Logger = soda_logger
 
@@ -57,9 +55,7 @@ class ContractVerificationSession:
     ) -> ContractVerificationSessionResult:
         from soda_core.common._deprecation import deprecated_kwarg
         from soda_core.contracts.impl.check_selector import CheckSelector
-        from soda_core.contracts.impl.contract_verification_impl import (
-            ContractVerificationSessionImpl,
-        )
+        from soda_core.contracts.impl.contract_verification_impl import ContractVerificationSessionImpl
 
         soda_cloud_use_runner = deprecated_kwarg(
             kwargs, "soda_cloud_use_agent", "soda_cloud_use_runner", soda_cloud_use_runner

--- a/soda-core/src/soda_core/contracts/impl/check_types/aggregate_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/aggregate_check_yaml.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    MissingAncValidityCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, MissingAncValidityCheckYaml
 
 
 class AggregateCheckYamlParser(CheckYamlParser):

--- a/soda-core/src/soda_core/contracts/impl/check_types/check_types.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/check_types.py
@@ -12,72 +12,47 @@ class CoreCheckTypesPlugin(Plugin):
 
     @classmethod
     def register_check_types(cls) -> None:
-        from soda_core.contracts.impl.check_types.schema_check_yaml import (
-            SchemaCheckYamlParser,
-        )
-        from soda_core.contracts.impl.contract_verification_impl import (
-            CheckImpl,
-            CheckYaml,
-        )
+        from soda_core.contracts.impl.check_types.schema_check_yaml import SchemaCheckYamlParser
+        from soda_core.contracts.impl.contract_verification_impl import CheckImpl, CheckYaml
 
         CheckYaml.register(SchemaCheckYamlParser())
         from soda_core.contracts.impl.check_types.schema_check import SchemaCheckParser
 
         CheckImpl.register(SchemaCheckParser())
 
-        from soda_core.contracts.impl.check_types.missing_check_yaml import (
-            MissingCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.missing_check_yaml import MissingCheckYamlParser
 
         CheckYaml.register(MissingCheckYamlParser())
-        from soda_core.contracts.impl.check_types.missing_check import (
-            MissingCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.missing_check import MissingCheckParser
 
         CheckImpl.register(MissingCheckParser())
 
-        from soda_core.contracts.impl.check_types.invalidity_check_yaml import (
-            InvalidCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.invalidity_check_yaml import InvalidCheckYamlParser
 
         CheckYaml.register(InvalidCheckYamlParser())
-        from soda_core.contracts.impl.check_types.invalidity_check import (
-            InvalidCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.invalidity_check import InvalidCheckParser
 
         CheckImpl.register(InvalidCheckParser())
 
-        from soda_core.contracts.impl.check_types.duplicate_check_yaml import (
-            DuplicateCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.duplicate_check_yaml import DuplicateCheckYamlParser
 
         CheckYaml.register(DuplicateCheckYamlParser())
-        from soda_core.contracts.impl.check_types.duplicate_check import (
-            DuplicateCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.duplicate_check import DuplicateCheckParser
 
         CheckImpl.register(DuplicateCheckParser())
 
-        from soda_core.contracts.impl.check_types.row_count_check_yaml import (
-            RowCountCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.row_count_check_yaml import RowCountCheckYamlParser
 
         CheckYaml.register(RowCountCheckYamlParser())
-        from soda_core.contracts.impl.check_types.row_count_check import (
-            RowCountCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.row_count_check import RowCountCheckParser
 
         CheckImpl.register(RowCountCheckParser())
 
-        from soda_core.contracts.impl.check_types.aggregate_check import (
-            AggregateCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.aggregate_check import AggregateCheckParser
 
         CheckImpl.register(AggregateCheckParser())
 
-        from soda_core.contracts.impl.check_types.aggregate_check_yaml import (
-            AggregateCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.aggregate_check_yaml import AggregateCheckYamlParser
 
         CheckYaml.register(AggregateCheckYamlParser())
 
@@ -85,30 +60,20 @@ class CoreCheckTypesPlugin(Plugin):
 
         CheckImpl.register(MetricCheckParser())
 
-        from soda_core.contracts.impl.check_types.metric_check_yaml import (
-            MetricCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.metric_check_yaml import MetricCheckYamlParser
 
         CheckYaml.register(MetricCheckYamlParser())
 
-        from soda_core.contracts.impl.check_types.freshness_check_yaml import (
-            FreshnessCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.freshness_check_yaml import FreshnessCheckYamlParser
 
         CheckYaml.register(FreshnessCheckYamlParser())
-        from soda_core.contracts.impl.check_types.freshness_check import (
-            FreshnessCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.freshness_check import FreshnessCheckParser
 
         CheckImpl.register(FreshnessCheckParser())
 
-        from soda_core.contracts.impl.check_types.failed_rows_check_yaml import (
-            FailedRowsCheckYamlParser,
-        )
+        from soda_core.contracts.impl.check_types.failed_rows_check_yaml import FailedRowsCheckYamlParser
 
         CheckYaml.register(FailedRowsCheckYamlParser())
-        from soda_core.contracts.impl.check_types.failed_rows_check import (
-            FailedRowsCheckParser,
-        )
+        from soda_core.contracts.impl.check_types.failed_rows_check import FailedRowsCheckParser
 
         CheckImpl.register(FailedRowsCheckParser())

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -7,9 +7,7 @@ from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.sql_dialect import *
 from soda_core.contracts.contract_verification import CheckResult, Measurement
-from soda_core.contracts.impl.check_types.failed_rows_check_yaml import (
-    FailedRowsCheckYaml,
-)
+from soda_core.contracts.impl.check_types.failed_rows_check_yaml import FailedRowsCheckYaml
 from soda_core.contracts.impl.check_types.row_count_check import RowCountMetricImpl
 from soda_core.contracts.impl.contract_verification_impl import (
     AggregationMetricImpl,

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check_yaml.py
@@ -6,12 +6,7 @@ from typing import Optional
 
 from soda_core.common.logging_constants import ExtraKeys, soda_logger
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    ThresholdCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, ThresholdCheckYaml
 
 logger: logging.Logger = soda_logger
 

--- a/soda-core/src/soda_core/contracts/impl/check_types/freshness_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/freshness_check_yaml.py
@@ -5,12 +5,7 @@ from typing import Optional
 
 from soda_core.common.logging_constants import ExtraKeys, soda_logger
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    MissingAncValidityCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, MissingAncValidityCheckYaml
 
 logger: logging.Logger = soda_logger
 

--- a/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check_yaml.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    MissingAncValidityCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, MissingAncValidityCheckYaml
 
 
 class InvalidCheckYamlParser(CheckYamlParser):

--- a/soda-core/src/soda_core/contracts/impl/check_types/metric_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/metric_check.py
@@ -6,11 +6,7 @@ from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.sql_dialect import *
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    CheckResult,
-    Measurement,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, CheckResult, Measurement
 from soda_core.contracts.impl.check_types.metric_check_yaml import MetricCheckYaml
 from soda_core.contracts.impl.check_types.row_count_check import RowCountMetricImpl
 from soda_core.contracts.impl.contract_verification_impl import (

--- a/soda-core/src/soda_core/contracts/impl/check_types/metric_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/metric_check_yaml.py
@@ -6,12 +6,7 @@ from typing import Optional
 
 from soda_core.common.logging_constants import ExtraKeys, soda_logger
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    MissingAncValidityCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, MissingAncValidityCheckYaml
 
 logger: logging.Logger = soda_logger
 

--- a/soda-core/src/soda_core/contracts/impl/check_types/missing_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/missing_check_yaml.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    MissingAncValidityCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, MissingAncValidityCheckYaml
 
 
 class MissingCheckYamlParser(CheckYamlParser):

--- a/soda-core/src/soda_core/contracts/impl/check_types/row_count_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/row_count_check_yaml.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-    ThresholdCheckYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml, ThresholdCheckYaml
 
 
 class RowCountCheckYamlParser(CheckYamlParser):

--- a/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/schema_check.py
@@ -8,13 +8,7 @@ from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import ColumnMetadata, SqlDataType
 from soda_core.common.utils import format_items
-from soda_core.contracts.contract_verification import (
-    Check,
-    CheckOutcome,
-    CheckResult,
-    Measurement,
-    Threshold,
-)
+from soda_core.contracts.contract_verification import Check, CheckOutcome, CheckResult, Measurement, Threshold
 from soda_core.contracts.impl.check_types.schema_check_yaml import SchemaCheckYaml
 from soda_core.contracts.impl.contract_verification_impl import (
     CheckImpl,

--- a/soda-core/src/soda_core/contracts/impl/check_types/schema_check_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/schema_check_yaml.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.yaml import YamlObject
-from soda_core.contracts.impl.contract_yaml import (
-    CheckYaml,
-    CheckYamlParser,
-    ColumnYaml,
-)
+from soda_core.contracts.impl.contract_yaml import CheckYaml, CheckYamlParser, ColumnYaml
 
 
 class SchemaCheckYamlParser(CheckYamlParser):

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -15,11 +15,7 @@ from soda_core.common.exceptions import InvalidRegexException, SodaCoreException
 from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.sql_dialect import *
-from soda_core.common.yaml import (
-    ContractYamlSource,
-    DataSourceYamlSource,
-    SodaCloudYamlSource,
-)
+from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_verification import (
     Check,
     CheckCollectionStatus,
@@ -46,9 +42,7 @@ from soda_core.contracts.impl.contract_yaml import (
     is_known_threshold_level,
     normalize_threshold_level,
 )
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 logger: logging.Logger = soda_logger
 

--- a/soda-core/src/soda_core/contracts/impl/contract_yaml.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_yaml.py
@@ -8,22 +8,13 @@ from typing import Optional
 
 from soda_core.check_collections.base import CheckCollectionYaml
 from soda_core.common.data_source_impl import DataSourceImpl
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.exceptions import ContractParserException
 from soda_core.common.logging_constants import Emoticons, ExtraKeys, soda_logger
 from soda_core.common.logs import Location
 from soda_core.common.metadata_types import SodaDataTypeName
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.yaml import (
-    ContractYamlSource,
-    VariableResolver,
-    YamlList,
-    YamlObject,
-    YamlValue,
-)
+from soda_core.common.yaml import ContractYamlSource, VariableResolver, YamlList, YamlObject, YamlValue
 
 logger: logging.Logger = soda_logger
 

--- a/soda-core/src/soda_core/discovery/discovery_payload.py
+++ b/soda-core/src/soda_core/discovery/discovery_payload.py
@@ -5,10 +5,7 @@ from datetime import datetime, timezone
 from logging import LogRecord
 from typing import Optional
 
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.common.soda_cloud import build_log_cloud_json_dict
 from soda_core.common.soda_cloud_dto import SodaCoreInsertScanResultsDTO

--- a/soda-core/src/soda_core/model/data_source/data_source.py
+++ b/soda-core/src/soda_core/model/data_source/data_source.py
@@ -2,9 +2,7 @@ import abc
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 
 class DataSourceBase(BaseModel, abc.ABC):

--- a/soda-core/src/soda_core/telemetry/soda_telemetry.py
+++ b/soda-core/src/soda_core/telemetry/soda_telemetry.py
@@ -12,10 +12,7 @@ from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.env_config_helper import EnvConfigHelper
 from soda_core.contracts.contract_verification import ContractVerificationSessionResult
 from soda_core.telemetry.memory_span_exporter import MemorySpanExporter
-from soda_core.telemetry.soda_exporter import (
-    SodaConsoleSpanExporter,
-    SodaOTLPSpanExporter,
-)
+from soda_core.telemetry.soda_exporter import SodaConsoleSpanExporter, SodaOTLPSpanExporter
 
 
 class SodaTelemetry:

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -6,12 +6,7 @@ from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    DataSourceNamespace,
-    SamplerType,
-    SodaDataTypeName,
-)
+from soda_core.common.metadata_types import ColumnMetadata, DataSourceNamespace, SamplerType, SodaDataTypeName
 from soda_core.common.sql_ast import (
     ADD_INTERVAL,
     ALTER_TABLE_ADD_COLUMN,
@@ -24,15 +19,9 @@ from soda_core.common.sql_ast import (
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_core.common.statements.table_types import TableType
-from soda_databricks.common.data_sources.databricks_data_source_connection import (
-    DatabricksDataSourceConnection,
-)
-from soda_databricks.common.statements.hive_metadata_tables_query import (
-    HiveMetadataTablesQuery,
-)
-from soda_databricks.model.data_source.databricks_data_source import (
-    DatabricksDataSource as DatabricksDataSourceModel,
-)
+from soda_databricks.common.data_sources.databricks_data_source_connection import DatabricksDataSourceConnection
+from soda_databricks.common.statements.hive_metadata_tables_query import HiveMetadataTablesQuery
+from soda_databricks.model.data_source.databricks_data_source import DatabricksDataSource as DatabricksDataSourceModel
 
 logger: Logger = soda_logger
 

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source_connection.py
@@ -4,14 +4,9 @@ import logging
 from datetime import timezone, tzinfo
 
 from databricks import sql
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 from soda_databricks.model.data_source.databricks_connection_properties import (
     DatabricksAzureServicePrincipal,
     DatabricksConnectionProperties,
@@ -69,10 +64,7 @@ class DatabricksDataSourceConnection(DataSourceConnection):
             return None
 
         from databricks.sdk.core import Config
-        from databricks.sdk.credentials_provider import (
-            azure_service_principal,
-            oauth_service_principal,
-        )
+        from databricks.sdk.credentials_provider import azure_service_principal, oauth_service_principal
 
         host = f"https://{connection_kwargs['server_hostname']}"
 

--- a/soda-databricks/src/soda_databricks/common/statements/hive_metadata_tables_query.py
+++ b/soda-databricks/src/soda_databricks/common/statements/hive_metadata_tables_query.py
@@ -6,10 +6,7 @@ from typing import Optional
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_tables_query import (
-    FullyQualifiedTableName,
-    MetadataTablesQuery,
-)
+from soda_core.common.statements.metadata_tables_query import FullyQualifiedTableName, MetadataTablesQuery
 from soda_core.common.statements.table_types import FullyQualifiedViewName, TableType
 
 

--- a/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
+++ b/soda-databricks/src/soda_databricks/model/data_source/databricks_connection_properties.py
@@ -2,9 +2,7 @@ from abc import ABC
 from typing import Annotated, Any, ClassVar, Dict, Literal, Optional, Union
 
 from pydantic import Discriminator, Field, SecretStr, Tag
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 # Explicit auth_type discriminator values (Trino/Snowflake/BigQuery style). These literals
 # are the cross-repo contract: they match soda-library#759 and the Cloud connection form.

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -3,9 +3,7 @@ from datetime import date
 import pytest
 from soda_core.common.metadata_types import SodaDataTypeName
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
-from soda_databricks.common.data_sources.databricks_data_source import (
-    DatabricksSqlDialect,
-)
+from soda_databricks.common.data_sources.databricks_data_source import DatabricksSqlDialect
 
 
 @pytest.mark.parametrize(
@@ -101,9 +99,7 @@ def test_max_sql_statement_length_respects_databricks_16mib_cap():
     # Databricks rejects statements over its documented 16 MiB query-text
     # cap ("Query text size exceeds limit", observed live at ~30 MB on
     # 2026-06-12); 1 MiB is reserved for chars-vs-bytes skew.
-    from soda_databricks.common.data_sources.databricks_data_source import (
-        DatabricksSqlDialect,
-    )
+    from soda_databricks.common.data_sources.databricks_data_source import DatabricksSqlDialect
 
     sql_dialect = DatabricksSqlDialect()
     assert sql_dialect.get_max_sql_statement_length() == 15 * 1024 * 1024

--- a/soda-databricks/tests/unit/test_databricks_empty_token.py
+++ b/soda-databricks/tests/unit/test_databricks_empty_token.py
@@ -15,18 +15,10 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import SecretStr
-from soda_databricks.common.data_sources import (
-    databricks_data_source_connection as conn_mod,
-)
-from soda_databricks.common.data_sources.databricks_data_source_connection import (
-    DatabricksDataSourceConnection,
-)
-from soda_databricks.model.data_source.databricks_connection_properties import (
-    DatabricksTokenAuth,
-)
-from soda_databricks.model.data_source.databricks_data_source import (
-    DatabricksDataSource,
-)
+from soda_databricks.common.data_sources import databricks_data_source_connection as conn_mod
+from soda_databricks.common.data_sources.databricks_data_source_connection import DatabricksDataSourceConnection
+from soda_databricks.model.data_source.databricks_connection_properties import DatabricksTokenAuth
+from soda_databricks.model.data_source.databricks_data_source import DatabricksDataSource
 
 
 def infer(connection: dict):

--- a/soda-databricks/tests/unit/test_databricks_oauth.py
+++ b/soda-databricks/tests/unit/test_databricks_oauth.py
@@ -7,20 +7,14 @@ real provider performs OIDC endpoint discovery over the network.
 from unittest.mock import patch
 
 import pytest
-from soda_databricks.common.data_sources import (
-    databricks_data_source_connection as conn_mod,
-)
-from soda_databricks.common.data_sources.databricks_data_source_connection import (
-    DatabricksDataSourceConnection,
-)
+from soda_databricks.common.data_sources import databricks_data_source_connection as conn_mod
+from soda_databricks.common.data_sources.databricks_data_source_connection import DatabricksDataSourceConnection
 from soda_databricks.model.data_source.databricks_connection_properties import (
     DatabricksAzureServicePrincipal,
     DatabricksOAuthM2M,
     DatabricksTokenAuth,
 )
-from soda_databricks.model.data_source.databricks_data_source import (
-    DatabricksDataSource,
-)
+from soda_databricks.model.data_source.databricks_data_source import DatabricksDataSource
 
 
 def infer(connection: dict):

--- a/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
+++ b/soda-databricks/tests/unit/test_hive_metadata_tables_query.py
@@ -8,12 +8,8 @@ must keep the unqualified form.
 
 import pytest
 from soda_core.common.statements.table_types import TableType
-from soda_databricks.common.data_sources.databricks_data_source import (
-    DatabricksHiveSqlDialect,
-)
-from soda_databricks.common.statements.hive_metadata_tables_query import (
-    HiveMetadataTablesQuery,
-)
+from soda_databricks.common.data_sources.databricks_data_source import DatabricksHiveSqlDialect
+from soda_databricks.common.statements.hive_metadata_tables_query import HiveMetadataTablesQuery
 
 
 def _query() -> HiveMetadataTablesQuery:

--- a/soda-duckdb/src/soda_duckdb/__init__.py
+++ b/soda-duckdb/src/soda_duckdb/__init__.py
@@ -1,6 +1,4 @@
-from soda_duckdb.common.data_sources.duckdb_data_source import (
-    DuckDBDataSourceImpl as DuckDBDataSource,
-)
+from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBDataSourceImpl as DuckDBDataSource
 
 __all__ = [
     "DuckDBDataSource",

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -3,21 +3,14 @@ from datetime import timezone, tzinfo
 from pathlib import Path
 
 from duckdb import DuckDBPyConnection
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.metadata_types import DataSourceNamespace, SodaDataTypeName
 from soda_core.common.sql_ast import *
 from soda_core.common.sql_dialect import SqlDialect
-from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
-    DuckDBConnectionProperties,
-)
-from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
-    DuckDBDataSource as DuckDBDataSourceModel,
-)
+from soda_duckdb.common.data_sources.duckdb_data_source_connection import DuckDBConnectionProperties
+from soda_duckdb.common.data_sources.duckdb_data_source_connection import DuckDBDataSource as DuckDBDataSourceModel
 from soda_duckdb.common.data_sources.duckdb_data_source_connection import (
     DuckDBExistingConnectionProperties,
     DuckDBStandardConnectionProperties,

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -119,9 +119,8 @@ class DuckDBSqlDialect(SqlDialect, sqlglot_dialect="duckdb"):
     def supports_data_type_datetime_precision(self) -> bool:
         return False
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"REGEXP_MATCHES({expression}, {self.literal_string(matches.regex_pattern)})"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"REGEXP_MATCHES({expression}, {pattern})"
 
     def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: bool = True) -> str:
         schema_name: str = prefixes[0]

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source_connection.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source_connection.py
@@ -4,9 +4,7 @@ from typing import Dict, Literal, Optional
 from duckdb import DuckDBPyConnection
 from pydantic import Field, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 
 class DuckDBConnectionProperties(DataSourceConnectionProperties, ABC):

--- a/soda-duckdb/tests/unit/test_duckdb_dialect.py
+++ b/soda-duckdb/tests/unit/test_duckdb_dialect.py
@@ -1,7 +1,5 @@
 from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBSqlDialect
 
 

--- a/soda-duckdb/tests/unit/test_duckdb_session_timezone.py
+++ b/soda-duckdb/tests/unit/test_duckdb_session_timezone.py
@@ -17,10 +17,7 @@ from __future__ import annotations
 from datetime import tzinfo
 
 import duckdb
-from soda_duckdb.common.data_sources.duckdb_data_source import (
-    DuckDBCursor,
-    DuckDBDataSourceConnectionWrapper,
-)
+from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBCursor, DuckDBDataSourceConnectionWrapper
 
 
 class TestDuckDBCursorContextManager:
@@ -74,9 +71,7 @@ class TestDuckDBFetchSessionTimezone:
         # DuckDB connection so the with-cursor path runs end-to-end. The
         # adapter doesn't need any other state to satisfy
         # ``_fetch_session_timezone``.
-        from soda_duckdb.common.data_sources.duckdb_data_source import (
-            DuckDBDataSourceConnection,
-        )
+        from soda_duckdb.common.data_sources.duckdb_data_source import DuckDBDataSourceConnection
 
         instance = DuckDBDataSourceConnection.__new__(DuckDBDataSourceConnection)
         raw = duckdb.connect(":memory:")

--- a/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
+++ b/soda-fabric/src/soda_fabric/common/data_sources/fabric_data_source.py
@@ -7,16 +7,9 @@ from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import CREATE_TABLE_COLUMN, INSERT_INTO, VALUES_ROW
 from soda_core.common.sql_dialect import SqlDialect
-from soda_fabric.common.data_sources.fabric_data_source_connection import (
-    FabricDataSource as FabricDataSourceModel,
-)
-from soda_fabric.common.data_sources.fabric_data_source_connection import (
-    FabricDataSourceConnection,
-)
-from soda_sqlserver.common.data_sources.sqlserver_data_source import (
-    SqlServerDataSourceImpl,
-    SqlServerSqlDialect,
-)
+from soda_fabric.common.data_sources.fabric_data_source_connection import FabricDataSource as FabricDataSourceModel
+from soda_fabric.common.data_sources.fabric_data_source_connection import FabricDataSourceConnection
+from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerDataSourceImpl, SqlServerSqlDialect
 
 logger: logging.Logger = soda_logger
 

--- a/soda-fabric/src/soda_fabric/test_helpers/fabric_data_source_test_helper.py
+++ b/soda-fabric/src/soda_fabric/test_helpers/fabric_data_source_test_helper.py
@@ -5,14 +5,9 @@ import os
 from typing import Optional
 
 from soda_core.common.sql_ast import DROP_TABLE, DROP_VIEW
-from soda_core.common.statements.metadata_tables_query import (
-    FullyQualifiedTableName,
-    MetadataTablesQuery,
-)
+from soda_core.common.statements.metadata_tables_query import FullyQualifiedTableName, MetadataTablesQuery
 from soda_core.common.statements.table_types import FullyQualifiedViewName, TableType
-from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import (
-    SqlServerDataSourceTestHelper,
-)
+from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import SqlServerDataSourceTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -26,7 +26,6 @@ from soda_core.common.sql_ast import (
     LOWER,
     ORDER_BY_ASC,
     RAW_SQL,
-    REGEX_LIKE,
     SELECT,
     WHERE,
 )
@@ -105,9 +104,8 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
     def is_system_schema(self, schema_name: str) -> bool:
         return schema_name.lower().startswith("pg_") or super().is_system_schema(schema_name)
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"{expression} ~ {pattern}"
 
     def supports_sampler(self, sampler_type: SamplerType) -> bool:
         return sampler_type is SamplerType.PERCENTAGE

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -5,12 +5,7 @@ from typing import Optional
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import (
-    DataSourceNamespace,
-    SamplerType,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import DataSourceNamespace, SamplerType, SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
     AND,
     CAST,
@@ -30,22 +25,14 @@ from soda_core.common.sql_ast import (
     WHERE,
 )
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_postgres.common.data_sources.postgres_data_source_connection import (
     PostgresDataSource as PostgresDataSourceModel,
 )
-from soda_postgres.common.data_sources.postgres_data_source_connection import (
-    PostgresDataSourceConnection,
-)
-from soda_postgres.statements.postgres_metadata_primary_keys_query import (
-    PostgresMetadataPrimaryKeysQuery,
-)
-from soda_postgres.statements.postgres_metadata_tables_query import (
-    PostgresMetadataTablesQuery,
-)
+from soda_postgres.common.data_sources.postgres_data_source_connection import PostgresDataSourceConnection
+from soda_postgres.statements.postgres_metadata_primary_keys_query import PostgresMetadataPrimaryKeysQuery
+from soda_postgres.statements.postgres_metadata_tables_query import PostgresMetadataTablesQuery
 
 logger: Logger = soda_logger
 

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source_connection.py
@@ -18,9 +18,7 @@ from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.value_size import estimate_value_size
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-postgres/src/soda_postgres/statements/postgres_metadata_primary_keys_query.py
+++ b/soda-postgres/src/soda_postgres/statements/postgres_metadata_primary_keys_query.py
@@ -1,22 +1,8 @@
 from __future__ import annotations
 
 from soda_core.common.metadata_types import DataSourceNamespace
-from soda_core.common.sql_ast import (
-    AND,
-    COLUMN,
-    EQ,
-    FROM,
-    IN,
-    JOIN,
-    LITERAL,
-    LOWER,
-    RAW_SQL,
-    SELECT,
-    WHERE,
-)
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.sql_ast import AND, COLUMN, EQ, FROM, IN, JOIN, LITERAL, LOWER, RAW_SQL, SELECT, WHERE
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 
 
 class PostgresMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):

--- a/soda-postgres/tests/unit/test_postgres_dialect.py
+++ b/soda-postgres/tests/unit/test_postgres_dialect.py
@@ -1,13 +1,5 @@
 import pytest
-from soda_core.common.sql_dialect import (
-    COLUMN,
-    FROM,
-    RANDOM,
-    REGEX_LIKE,
-    SELECT,
-    STAR,
-    SamplerType,
-)
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT, STAR, SamplerType
 from soda_postgres.common.data_sources.postgres_data_source import PostgresSqlDialect
 
 
@@ -83,9 +75,7 @@ def test_primary_keys_query_reads_pg_catalog_not_information_schema():
     key_column_usage are filtered to tables the current user owns or holds a
     non-SELECT privilege on, so a read-only monitoring user silently gets zero
     primary keys through them."""
-    from soda_postgres.statements.postgres_metadata_primary_keys_query import (
-        PostgresMetadataPrimaryKeysQuery,
-    )
+    from soda_postgres.statements.postgres_metadata_primary_keys_query import PostgresMetadataPrimaryKeysQuery
 
     dialect = PostgresSqlDialect()
     query = PostgresMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)

--- a/soda-redshift/pyproject.toml
+++ b/soda-redshift/pyproject.toml
@@ -25,9 +25,3 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-
-[tool.isort]
-profile = "black"
-
-[tool.black]
-line-length = 120

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -17,22 +17,14 @@ from soda_core.common.sql_ast import (
     VALUES,
 )
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_redshift.common.data_sources.redshift_data_source_connection import (
     RedshiftDataSource as RedshiftDataSourceModel,
 )
-from soda_redshift.common.data_sources.redshift_data_source_connection import (
-    RedshiftDataSourceConnection,
-)
-from soda_redshift.statements.redshift_metadata_primary_keys_query import (
-    RedshiftMetadataPrimaryKeysQuery,
-)
-from soda_redshift.statements.redshift_metadata_tables_query import (
-    RedshiftMetadataTablesQuery,
-)
+from soda_redshift.common.data_sources.redshift_data_source_connection import RedshiftDataSourceConnection
+from soda_redshift.statements.redshift_metadata_primary_keys_query import RedshiftMetadataPrimaryKeysQuery
+from soda_redshift.statements.redshift_metadata_tables_query import RedshiftMetadataTablesQuery
 
 logger: logging.Logger = soda_logger
 

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -13,7 +13,6 @@ from soda_core.common.sql_ast import (
     DISTINCT,
     FROM,
     PERCENTILE_WITHIN_GROUP,
-    REGEX_LIKE,
     TUPLE,
     VALUES,
 )
@@ -177,9 +176,8 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
             ["time", "time without time zone"],
         ]
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"{expression} ~ {pattern}"
 
     def _build_tuple_sql(self, tuple: TUPLE) -> str:
         if tuple.check_context(COUNT) and tuple.check_context(DISTINCT):

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source_connection.py
@@ -9,14 +9,9 @@ import boto3
 import psycopg
 from pydantic import Field, IPvAnyAddress, SecretStr
 from soda_core.common.aws_credentials import AwsCredentials
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 
 class RedshiftConnectionProperties(DataSourceConnectionProperties):

--- a/soda-redshift/src/soda_redshift/statements/redshift_metadata_primary_keys_query.py
+++ b/soda-redshift/src/soda_redshift/statements/redshift_metadata_primary_keys_query.py
@@ -2,22 +2,8 @@ from __future__ import annotations
 
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.metadata_types import DataSourceNamespace
-from soda_core.common.sql_ast import (
-    AND,
-    COLUMN,
-    EQ,
-    FROM,
-    IN,
-    JOIN,
-    LITERAL,
-    LOWER,
-    RAW_SQL,
-    SELECT,
-    WHERE,
-)
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.sql_ast import AND, COLUMN, EQ, FROM, IN, JOIN, LITERAL, LOWER, RAW_SQL, SELECT, WHERE
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 
 
 class RedshiftMetadataPrimaryKeysQuery(MetadataPrimaryKeysQuery):

--- a/soda-redshift/tests/unit/test_redshift_dialect.py
+++ b/soda-redshift/tests/unit/test_redshift_dialect.py
@@ -90,9 +90,7 @@ def test_primary_keys_query_reads_pg_catalog_not_information_schema():
     information_schema constraint views only list tables the current user owns, so a
     read-only monitoring user silently gets zero primary keys through them (same reason
     the schemas/tables/columns queries read SVV/pg_catalog views)."""
-    from soda_redshift.statements.redshift_metadata_primary_keys_query import (
-        RedshiftMetadataPrimaryKeysQuery,
-    )
+    from soda_redshift.statements.redshift_metadata_primary_keys_query import RedshiftMetadataPrimaryKeysQuery
 
     dialect = RedshiftSqlDialect()
     query = RedshiftMetadataPrimaryKeysQuery(sql_dialect=dialect, data_source_connection=None)
@@ -111,9 +109,7 @@ def test_primary_keys_query_reads_pg_catalog_not_information_schema():
 
 def test_primary_keys_constraint_definition_parsing_preserves_order():
     from soda_core.common.data_source_results import QueryResult
-    from soda_redshift.statements.redshift_metadata_primary_keys_query import (
-        RedshiftMetadataPrimaryKeysQuery,
-    )
+    from soda_redshift.statements.redshift_metadata_primary_keys_query import RedshiftMetadataPrimaryKeysQuery
 
     parse = RedshiftMetadataPrimaryKeysQuery._parse_primary_key_columns
     assert parse("PRIMARY KEY (id)") == ["id"]

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source.py
@@ -6,12 +6,7 @@ from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    DataSourceNamespace,
-    SamplerType,
-    SodaDataTypeName,
-)
+from soda_core.common.metadata_types import ColumnMetadata, DataSourceNamespace, SamplerType, SodaDataTypeName
 from soda_core.common.sql_ast import (
     ADD_INTERVAL,
     AND,
@@ -31,16 +26,12 @@ from soda_core.common.sql_ast import (
     seconds_per_time_bucket,
 )
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 from soda_core.contracts.impl.contract_verification_impl import ContractImpl
 from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
     SnowflakeDataSource as SnowflakeDataSourceModel,
 )
-from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
-    SnowflakeDataSourceConnection,
-)
+from soda_snowflake.common.data_sources.snowflake_data_source_connection import SnowflakeDataSourceConnection
 
 logger: Logger = soda_logger
 

--- a/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
+++ b/soda-snowflake/src/soda_snowflake/common/data_sources/snowflake_data_source_connection.py
@@ -10,15 +10,10 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from pydantic import Field, SecretStr, field_validator
 from snowflake import connector
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-snowflake/tests/data_sources/test_warehouse_switching.py
+++ b/soda-snowflake/tests/data_sources/test_warehouse_switching.py
@@ -3,10 +3,7 @@ from unittest import mock
 
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.common.soda_cloud_dto import (
-    ComputeWarehouseOverrideDTO,
-    DatasetConfigurationDTO,
-)
+from soda_core.common.soda_cloud_dto import ComputeWarehouseOverrideDTO, DatasetConfigurationDTO
 from soda_core.contracts.contract_verification import ContractVerificationResult
 from sqlglot import logger
 

--- a/soda-snowflake/tests/unit/test_snowflake_dialect.py
+++ b/soda-snowflake/tests/unit/test_snowflake_dialect.py
@@ -1,14 +1,6 @@
 import pytest
 from soda_core.common.data_source_results import QueryResult
-from soda_core.common.sql_dialect import (
-    COLUMN,
-    FROM,
-    RANDOM,
-    REGEX_LIKE,
-    SELECT,
-    STAR,
-    SamplerType,
-)
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT, STAR, SamplerType
 from soda_snowflake.common.data_sources.snowflake_data_source import SnowflakeSqlDialect
 
 
@@ -199,9 +191,7 @@ def test_primary_keys_queries_table_constraints_then_shows_per_table():
     SHOW PRIMARY KEYS IN TABLE per such table. Requested tables without a PK get no SHOW and are
     absent; composite keys come back ordered by key_sequence even when SHOW rows arrive
     out of order."""
-    from soda_snowflake.common.data_sources.snowflake_data_source import (
-        SnowflakeMetadataPrimaryKeysQuery,
-    )
+    from soda_snowflake.common.data_sources.snowflake_data_source import SnowflakeMetadataPrimaryKeysQuery
 
     connection = _StubConnection(
         [
@@ -234,9 +224,7 @@ def test_primary_keys_queries_table_constraints_then_shows_per_table():
 def test_primary_keys_show_parsing_locates_columns_by_name():
     """SHOW output is parsed by column NAME from the cursor description, not by position — a
     reordered SHOW output must still parse correctly (and a missing column fails loud)."""
-    from soda_snowflake.common.data_sources.snowflake_data_source import (
-        SnowflakeMetadataPrimaryKeysQuery,
-    )
+    from soda_snowflake.common.data_sources.snowflake_data_source import SnowflakeMetadataPrimaryKeysQuery
 
     reordered_columns = (("key_sequence",), ("column_name",), ("table_name",))
     show_result = QueryResult(

--- a/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
+++ b/soda-snowflake/tests/unit/test_snowflake_session_timezone.py
@@ -14,9 +14,7 @@ from datetime import timezone
 from unittest.mock import MagicMock
 
 from soda_core.common.logs import Logs
-from soda_snowflake.common.data_sources.snowflake_data_source_connection import (
-    SnowflakeDataSourceConnection,
-)
+from soda_snowflake.common.data_sources.snowflake_data_source_connection import SnowflakeDataSourceConnection
 
 
 def _make_connection(rows, description):

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source.py
@@ -4,22 +4,15 @@ from typing import Any, Optional
 from freezegun import freeze_time
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import Row
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.data_source_impl import DataSourceImpl, MetadataTablesQuery
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import FullyQualifiedTableName
 from soda_core.common.statements.table_types import FullyQualifiedViewName, TableType
-from soda_databricks.common.data_sources.databricks_data_source import (
-    DatabricksSqlDialect,
-)
-from soda_databricks.common.statements.hive_metadata_tables_query import (
-    HiveMetadataTablesQuery,
-)
+from soda_databricks.common.data_sources.databricks_data_source import DatabricksSqlDialect
+from soda_databricks.common.statements.hive_metadata_tables_query import HiveMetadataTablesQuery
 from soda_sparkdf.common.data_sources.sparkdf_data_source_connection import (
     SparkDataFrameActiveSessionProperties,
     SparkDataFrameConnectionProperties,

--- a/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
+++ b/soda-sparkdf/src/soda_sparkdf/common/data_sources/sparkdf_data_source_connection.py
@@ -4,9 +4,7 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import Field, SecretStr, field_validator
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 
 class SparkDataFrameConnectionProperties(DataSourceConnectionProperties, ABC):

--- a/soda-sparkdf/tests/data_sources/test_sparkdf.py
+++ b/soda-sparkdf/tests/data_sources/test_sparkdf.py
@@ -9,9 +9,7 @@ from soda_core.common.logging_constants import soda_logger
 from soda_core.common.yaml import ContractYamlSource
 from soda_core.contracts.api.verify_api import verify_contract_locally
 from soda_core.contracts.contract_verification import ContractVerificationSession
-from soda_sparkdf.common.data_sources.sparkdf_data_source import (
-    SparkDataFrameDataSource,
-)
+from soda_sparkdf.common.data_sources.sparkdf_data_source import SparkDataFrameDataSource
 
 logger: Logger = soda_logger
 

--- a/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
+++ b/soda-sparkdf/tests/unit/test_sparkdf_dialect.py
@@ -1,7 +1,5 @@
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
-from soda_sparkdf.common.data_sources.sparkdf_data_source import (
-    SparkDataFrameSqlDialect,
-)
+from soda_sparkdf.common.data_sources.sparkdf_data_source import SparkDataFrameSqlDialect
 
 
 def test_random():

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -32,7 +32,6 @@ from soda_core.common.sql_ast import (
     OFFSET,
     PERCENTILE_WITHIN_GROUP,
     RANDOM,
-    REGEX_LIKE,
     SELECT,
     STAR,
     STRING_HASH,
@@ -307,19 +306,23 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
             return ", ".join(self.build_expression_sql(e) for e in tuple.expressions)
         return super()._build_tuple_sql(tuple)
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        regex_pattern = matches.regex_pattern
+    def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
         # alpha expansion doesn't work properly for case sensitive ranges in SQLServer
-        # this is quite a hack to fit the common use-cases.  generally regex's are only partially supported anyway
+        # this is quite a hack to fit the common use-cases.  generally regex's are only
+        # partially supported anyway
         regex_pattern = regex_pattern.replace("a-z", "abcdefghijklmnopqrstuvwxyz")
         regex_pattern = regex_pattern.replace("A-Z", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        # PATINDEX matches a substring, so the pattern is wrapped rather than anchored.
+        # Wrapping here rather than around the rendered literal keeps the % inside the
+        # quotes that the base escaping puts on.
+        return f"%{regex_pattern}%"
+
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
         # collations define rules for sorting strings and distinguishing similar characters
         # see: https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver17
         # CS: Case sensitive; AS: Accent sensitive
         # The default is SQL_Latin1_General_Cp1_CI_AS (case-insensitive), we replcae with a case sensitive collation
-        pattern_literal: str = self.literal_string(f"%{regex_pattern}%")
-        return f"PATINDEX ({pattern_literal}, {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+        return f"PATINDEX ({pattern}, {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
 
     def supports_regex_advanced(self) -> bool:
         return False

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -47,9 +47,7 @@ from soda_core.common.sql_dialect import SqlDialect
 from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
     SqlServerDataSource as SqlServerDataSourceModel,
 )
-from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
-    SqlServerDataSourceConnection,
-)
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import SqlServerDataSourceConnection
 
 logger: logging.Logger = soda_logger
 

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source_connection.py
@@ -16,9 +16,7 @@ from soda_core.common.data_source_results import QueryResult
 from soda_core.common.exceptions import DataSourceConnectionException
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-sqlserver/src/soda_sqlserver/test_helpers/sqlserver_data_source_test_helper.py
+++ b/soda-sqlserver/src/soda_sqlserver/test_helpers/sqlserver_data_source_test_helper.py
@@ -5,10 +5,7 @@ from typing import Optional
 
 from helpers.data_source_test_helper import DataSourceTestHelper
 from soda_core.common.sql_ast import DROP_TABLE, DROP_VIEW
-from soda_sqlserver.common.data_sources.sqlserver_data_source import (
-    SqlServerDataSourceImpl,
-    SqlServerSqlDialect,
-)
+from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerDataSourceImpl, SqlServerSqlDialect
 
 
 class SqlServerDataSourceTestHelper(DataSourceTestHelper):

--- a/soda-sqlserver/tests/unit/test_sqlserver_deadlock_retry.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_deadlock_retry.py
@@ -6,9 +6,7 @@ import time
 
 import pyodbc
 import pytest
-from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
-    SqlServerDataSourceConnection,
-)
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import SqlServerDataSourceConnection
 
 
 def deadlock_error() -> pyodbc.OperationalError:

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from soda_core.common.metadata_types import SqlDataType
 from soda_core.common.sql_ast import COUNT, CREATE_TABLE_COLUMN, STAR
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
 from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerSqlDialect
 
 
@@ -250,3 +250,20 @@ def test_paginated_sql_normalizes_only_the_flagged_key_column():
     # LOWER fold + raw tiebreaker so OFFSET/FETCH paging is deterministic; "label" stays raw.
     assert "LOWER([code]) ASC, [code] ASC" in sql
     assert sql.upper().count("LOWER(") == 1
+
+
+def test_regex_like_rewrites_and_escapes_the_pattern():
+    """sqlserver is the one dialect whose matcher is not a regex engine.
+
+    PATINDEX takes a LIKE-style pattern, so the text is rewritten (`a-z` expanded,
+    wrapped in `%…%`) before being escaped as a literal. The rewrite happens in
+    _rewrite_regex_pattern so the escaping in the base builder still applies -- an
+    apostrophe in a user pattern used to break the query outright. See SCS-1413.
+    """
+    sql_dialect = SqlServerSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == (
+        "PATINDEX ('%^it''s$%', [c] COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+    )
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^[a-z]+$")) == (
+        "PATINDEX ('%^[abcdefghijklmnopqrstuvwxyz]+$%', [c] COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+    )

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -160,9 +160,7 @@ def test_supports_percentile_within_group_derived_from_server_facts():
 
 
 def test_parse_server_major_version():
-    from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
-        SqlServerDataSourceConnection,
-    )
+    from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import SqlServerDataSourceConnection
 
     parse = SqlServerDataSourceConnection._parse_server_major_version
     assert parse("15.00.4123") == 15

--- a/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_session_timezone.py
@@ -16,9 +16,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import (
-    SqlServerDataSourceConnection,
-)
+from soda_sqlserver.common.data_sources.sqlserver_data_source_connection import SqlServerDataSourceConnection
 
 
 def _make_connection(returned_offset_value):

--- a/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
+++ b/soda-synapse/src/soda_synapse/common/data_sources/synapse_data_source.py
@@ -4,25 +4,11 @@ from typing import Callable, Optional
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.dataset_identifier import DatasetIdentifier
 from soda_core.common.logging_constants import soda_logger
-from soda_core.common.sql_ast import (
-    COLUMN,
-    CREATE_TABLE,
-    CREATE_TABLE_IF_NOT_EXISTS,
-    INSERT_INTO,
-    VALUES,
-    VALUES_ROW,
-)
+from soda_core.common.sql_ast import COLUMN, CREATE_TABLE, CREATE_TABLE_IF_NOT_EXISTS, INSERT_INTO, VALUES, VALUES_ROW
 from soda_core.common.sql_dialect import SqlDialect
-from soda_sqlserver.common.data_sources.sqlserver_data_source import (
-    SqlServerDataSourceImpl,
-    SqlServerSqlDialect,
-)
-from soda_synapse.common.data_sources.synapse_data_source_connection import (
-    SynapseDataSource as SynapseDataSourceModel,
-)
-from soda_synapse.common.data_sources.synapse_data_source_connection import (
-    SynapseDataSourceConnection,
-)
+from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerDataSourceImpl, SqlServerSqlDialect
+from soda_synapse.common.data_sources.synapse_data_source_connection import SynapseDataSource as SynapseDataSourceModel
+from soda_synapse.common.data_sources.synapse_data_source_connection import SynapseDataSourceConnection
 
 logger: logging.Logger = soda_logger
 

--- a/soda-synapse/src/soda_synapse/test_helpers/synapse_data_source_test_helper.py
+++ b/soda-synapse/src/soda_synapse/test_helpers/synapse_data_source_test_helper.py
@@ -5,14 +5,9 @@ import os
 from typing import Optional
 
 from soda_core.common.sql_ast import DROP_TABLE, DROP_VIEW
-from soda_core.common.statements.metadata_tables_query import (
-    FullyQualifiedTableName,
-    MetadataTablesQuery,
-)
+from soda_core.common.statements.metadata_tables_query import FullyQualifiedTableName, MetadataTablesQuery
 from soda_core.common.statements.table_types import FullyQualifiedViewName, TableType
-from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import (
-    SqlServerDataSourceTestHelper,
-)
+from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import SqlServerDataSourceTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -13,19 +13,12 @@ from typing import Callable, Optional
 
 import pytest
 from helpers.mock_soda_cloud import MockResponse, MockSodaCloud
-from helpers.snapshot_connection import (
-    SnapshotDataSourceConnection,
-    is_any_rerun_in_progress,
-)
+from helpers.snapshot_connection import SnapshotDataSourceConnection, is_any_rerun_in_progress
 from helpers.test_table import TestColumn, TestTable, TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.logs import Logs
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName, SqlDataType
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.sql_ast import (
     COLUMN,
@@ -49,11 +42,7 @@ from soda_core.common.statements.metadata_tables_query import (
     TableType,
 )
 from soda_core.common.statements.table_types import FullyQualifiedMaterializedViewName
-from soda_core.common.yaml import (
-    ContractYamlSource,
-    DataSourceYamlSource,
-    SodaCloudYamlSource,
-)
+from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource, SodaCloudYamlSource
 from soda_core.contracts.contract_verification import (
     ContractVerificationResult,
     ContractVerificationSession,
@@ -237,108 +226,74 @@ class DataSourceTestHelper:
     @classmethod
     def create(cls, test_datasource: str, name: str) -> DataSourceTestHelper:
         if test_datasource == "postgres":
-            from soda_postgres.test_helpers.postgres_data_source_test_helper import (
-                PostgresDataSourceTestHelper,
-            )
+            from soda_postgres.test_helpers.postgres_data_source_test_helper import PostgresDataSourceTestHelper
 
             return PostgresDataSourceTestHelper(name)
         elif test_datasource == "snowflake":
-            from soda_snowflake.test_helpers.snowflake_data_source_test_helper import (
-                SnowflakeDataSourceTestHelper,
-            )
+            from soda_snowflake.test_helpers.snowflake_data_source_test_helper import SnowflakeDataSourceTestHelper
 
             return SnowflakeDataSourceTestHelper(name)
         elif test_datasource == "databricks":
-            from soda_databricks.test_helpers.databricks_data_source_test_helper import (
-                DatabricksDataSourceTestHelper,
-            )
+            from soda_databricks.test_helpers.databricks_data_source_test_helper import DatabricksDataSourceTestHelper
 
             return DatabricksDataSourceTestHelper(name)
         elif test_datasource == "duckdb":
-            from soda_duckdb.test_helpers.duckdb_data_source_test_helper import (
-                DuckdbDataSourceTestHelper,
-            )
+            from soda_duckdb.test_helpers.duckdb_data_source_test_helper import DuckdbDataSourceTestHelper
 
             return DuckdbDataSourceTestHelper(name)
         elif test_datasource == "bigquery":
-            from soda_bigquery.test_helpers.bigquery_data_source_test_helper import (
-                BigQueryDataSourceTestHelper,
-            )
+            from soda_bigquery.test_helpers.bigquery_data_source_test_helper import BigQueryDataSourceTestHelper
 
             return BigQueryDataSourceTestHelper(name)
 
         elif test_datasource == "oracle":
-            from soda_oracle.test_helpers.oracle_data_source_test_helper import (
-                OracleDataSourceTestHelper,
-            )
+            from soda_oracle.test_helpers.oracle_data_source_test_helper import OracleDataSourceTestHelper
 
             return OracleDataSourceTestHelper(name)
 
         elif test_datasource == "sqlserver":
-            from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import (
-                SqlServerDataSourceTestHelper,
-            )
+            from soda_sqlserver.test_helpers.sqlserver_data_source_test_helper import SqlServerDataSourceTestHelper
 
             return SqlServerDataSourceTestHelper(name)
         elif test_datasource == "synapse":
-            from soda_synapse.test_helpers.synapse_data_source_test_helper import (
-                SynapseDataSourceTestHelper,
-            )
+            from soda_synapse.test_helpers.synapse_data_source_test_helper import SynapseDataSourceTestHelper
 
             return SynapseDataSourceTestHelper(name)
         elif test_datasource == "redshift":
-            from soda_redshift.test_helpers.redshift_data_source_test_helper import (
-                RedshiftDataSourceTestHelper,
-            )
+            from soda_redshift.test_helpers.redshift_data_source_test_helper import RedshiftDataSourceTestHelper
 
             return RedshiftDataSourceTestHelper(name)
         elif test_datasource == "fabric":
-            from soda_fabric.test_helpers.fabric_data_source_test_helper import (
-                FabricDataSourceTestHelper,
-            )
+            from soda_fabric.test_helpers.fabric_data_source_test_helper import FabricDataSourceTestHelper
 
             return FabricDataSourceTestHelper(name)
         elif test_datasource == "athena":
-            from soda_athena.test_helpers.athena_data_source_test_helper import (
-                AthenaDataSourceTestHelper,
-            )
+            from soda_athena.test_helpers.athena_data_source_test_helper import AthenaDataSourceTestHelper
 
             return AthenaDataSourceTestHelper(name)
         elif test_datasource == "sparkdf":
-            from soda_sparkdf.test_helpers.sparkdf_data_source_test_helper import (
-                SparkDataFrameDataSourceTestHelper,
-            )
+            from soda_sparkdf.test_helpers.sparkdf_data_source_test_helper import SparkDataFrameDataSourceTestHelper
 
             return SparkDataFrameDataSourceTestHelper(name)
 
         elif test_datasource == "dremio":
-            from soda_dremio.test_helpers.dremio_data_source_test_helper import (
-                DremioDataSourceTestHelper,
-            )
+            from soda_dremio.test_helpers.dremio_data_source_test_helper import DremioDataSourceTestHelper
 
             return DremioDataSourceTestHelper(name)
         elif test_datasource == "trino":
-            from soda_trino.test_helpers.trino_data_source_test_helper import (
-                TrinoDataSourceTestHelper,
-            )
+            from soda_trino.test_helpers.trino_data_source_test_helper import TrinoDataSourceTestHelper
 
             return TrinoDataSourceTestHelper(name)
         elif test_datasource == "db2":
-            from soda_db2.test_helpers.db2_data_source_test_helper import (
-                Db2DataSourceTestHelper,
-            )
+            from soda_db2.test_helpers.db2_data_source_test_helper import Db2DataSourceTestHelper
 
             return Db2DataSourceTestHelper(name)
         elif test_datasource == "hana":
-            from soda_hana.test_helpers.hana_data_source_test_helper import (
-                HanaDataSourceTestHelper,
-            )
+            from soda_hana.test_helpers.hana_data_source_test_helper import HanaDataSourceTestHelper
 
             return HanaDataSourceTestHelper(name)
         elif test_datasource == "salesforce":
-            from soda_salesforce.test_helpers.salesforce_data_source_test_helper import (
-                SalesforceDataSourceTestHelper,
-            )
+            from soda_salesforce.test_helpers.salesforce_data_source_test_helper import SalesforceDataSourceTestHelper
 
             return SalesforceDataSourceTestHelper(name)
         else:
@@ -871,10 +826,7 @@ class DataSourceTestHelper:
                 # rows that pass the next run's row-count check. Fail loudly
                 # instead; the host-side __prepare_outside__ is the only
                 # legitimate (re)creator of these tables.
-                from helpers.memory_container_stub import (
-                    in_memory_container,
-                    lookup_forced_table_name,
-                )
+                from helpers.memory_container_stub import in_memory_container, lookup_forced_table_name
 
                 if in_memory_container() and lookup_forced_table_name(test_table_specification.unique_name):
                     raise AssertionError(

--- a/soda-tests/src/helpers/impl_test_helpers.py
+++ b/soda-tests/src/helpers/impl_test_helpers.py
@@ -15,15 +15,10 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from helpers.test_functions import dedent_and_strip
-from soda_core.common.logging_constants import (  # noqa: F401 – side-effect import
-    Emoticons,
-)
+from soda_core.common.logging_constants import Emoticons  # noqa: F401 – side-effect import
 from soda_core.common.logs import Logs
 from soda_core.common.yaml import ContractYamlSource
-from soda_core.contracts.contract_verification import (
-    ContractVerificationSession,
-    Measurement,
-)
+from soda_core.contracts.contract_verification import ContractVerificationSession, Measurement
 from soda_core.contracts.impl.contract_verification_impl import (
     CheckImpl,
     ContractImpl,

--- a/soda-tests/src/helpers/memory_container_plugin.py
+++ b/soda-tests/src/helpers/memory_container_plugin.py
@@ -550,10 +550,7 @@ def _run_prepare_outside(item: pytest.Item) -> dict:
     # instead of inline SQL — the inline path trips cloud adapter request
     # limits at these sizes. The flag is reset right after prepare_fn so no
     # other fixture flow ever sees it on.
-    from helpers.data_source_test_helper import (
-        activate_fixture_bulk_inserter,
-        deactivate_fixture_bulk_inserter,
-    )
+    from helpers.data_source_test_helper import activate_fixture_bulk_inserter, deactivate_fixture_bulk_inserter
 
     bulk_prev = activate_fixture_bulk_inserter()
     try:

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -9,12 +9,7 @@ from collections import namedtuple
 from collections.abc import Iterator
 from typing import Any, Callable, Optional
 
-from helpers.snapshot_manager import (
-    SnapshotEntry,
-    SnapshotManager,
-    SnapshotMismatchError,
-    SnapshotNotFoundError,
-)
+from helpers.snapshot_manager import SnapshotEntry, SnapshotManager, SnapshotMismatchError, SnapshotNotFoundError
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator
 from soda_core.common.logging_constants import soda_logger

--- a/soda-tests/src/helpers/test_table.py
+++ b/soda-tests/src/helpers/test_table.py
@@ -5,11 +5,7 @@ from typing import Iterable, Optional
 
 from soda_core.common.consistent_hash_builder import ConsistentHashBuilder
 from soda_core.common.dataset_identifier import DatasetIdentifier
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName, SqlDataType
 from soda_core.common.statements.table_types import TableType
 
 MAX_TABLE_NAME_LENGTH = 63  # Postgres max table name length.  Needed or else table names may be incorrectly truncated.

--- a/soda-tests/tests/conftest.py
+++ b/soda-tests/tests/conftest.py
@@ -5,9 +5,7 @@ import pytest
 from helpers.test_fixtures import *  # noqa: F401
 from soda_core.common.logging_configuration import configure_logging
 from soda_core.common.streaming import StreamingOrchestrator
-from soda_core.contracts.impl.contract_verification_impl import (
-    ContractVerificationHandlerRegistry,
-)
+from soda_core.contracts.impl.contract_verification_impl import ContractVerificationHandlerRegistry
 
 # Surface snapshot fallback events in pytest output (custom progress char,
 # end-of-session summary). Loaded as a plugin so its hooks register cleanly.

--- a/soda-tests/tests/integration/test_aggregate_check.py
+++ b/soda-tests/tests/integration/test_aggregate_check.py
@@ -3,10 +3,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_aggregation_query_aliasing.py
+++ b/soda-tests/tests/integration/test_aggregation_query_aliasing.py
@@ -16,11 +16,7 @@ Regression tests for two linked bugs surfaced on Databricks (DBR 18.2 / Spark 4.
 import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, CheckResult, ContractVerificationResult
 
 _test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_all_columns_metadata_for_schema.py
+++ b/soda-tests/tests/integration/test_all_columns_metadata_for_schema.py
@@ -2,11 +2,7 @@ import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName, SqlDataType
 from soda_core.common.sql_dialect import SqlDialect
 
 table_a_specification = (

--- a/soda-tests/tests/integration/test_dataset_and_check_filters.py
+++ b/soda-tests/tests/integration/test_dataset_and_check_filters.py
@@ -1,10 +1,7 @@
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_dataset_filter.py
+++ b/soda-tests/tests/integration/test_dataset_filter.py
@@ -5,10 +5,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 t1 = datetime(year=2025, month=4, day=16, hour=12, minute=0, second=0)
 t2 = datetime(year=2025, month=4, day=17, hour=12, minute=0, second=0)

--- a/soda-tests/tests/integration/test_discovery.py
+++ b/soda-tests/tests/integration/test_discovery.py
@@ -7,11 +7,7 @@ from helpers.test_fixtures import test_datasource
 from helpers.test_table import TestTableSpecification
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.data_source import handle_discover_data_source
-from soda_core.cli.handlers.dependencies import (
-    resolve_data_source,
-    resolve_soda_cloud,
-    run_with_failure_reporting,
-)
+from soda_core.cli.handlers.dependencies import resolve_data_source, resolve_soda_cloud, run_with_failure_reporting
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.discovery.discovery import discover_dataset_dqns
 from soda_core.discovery.discovery_payload import build_discovery_payload

--- a/soda-tests/tests/integration/test_duplicate_column_check.py
+++ b/soda-tests/tests/integration/test_duplicate_column_check.py
@@ -2,10 +2,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_duplicate_dataset_check.py
+++ b/soda-tests/tests/integration/test_duplicate_dataset_check.py
@@ -2,10 +2,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_hyphenated_identifiers.py
+++ b/soda-tests/tests/integration/test_hyphenated_identifiers.py
@@ -1,10 +1,6 @@
 from helpers.data_source_test_helper import DataSourceTestHelper
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
-from soda_core.common.sql_ast import (
-    CREATE_TABLE_COLUMN,
-    CREATE_TABLE_IF_NOT_EXISTS,
-    DROP_TABLE_IF_EXISTS,
-)
+from soda_core.common.sql_ast import CREATE_TABLE_COLUMN, CREATE_TABLE_IF_NOT_EXISTS, DROP_TABLE_IF_EXISTS
 from soda_core.common.sql_dialect import FROM, SELECT, STAR
 
 

--- a/soda-tests/tests/integration/test_invalid_reference_check.py
+++ b/soda-tests/tests/integration/test_invalid_reference_check.py
@@ -1,11 +1,7 @@
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, CheckResult, ContractVerificationResult
 
 referencing_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_missing_check_no_rows.py
+++ b/soda-tests/tests/integration/test_missing_check_no_rows.py
@@ -1,9 +1,6 @@
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, ContractVerificationResult
 
 missing_no_rows_specification = (
     TestTableSpecification.builder().table_purpose("missing_no_rows").column_varchar("id").build()

--- a/soda-tests/tests/integration/test_row_count_check.py
+++ b/soda-tests/tests/integration/test_row_count_check.py
@@ -3,10 +3,7 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
 from helpers.test_functions import get_diagnostic_value
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_sampling_unsupported.py
+++ b/soda-tests/tests/integration/test_sampling_unsupported.py
@@ -18,10 +18,7 @@ from unittest import mock
 
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.common.soda_cloud_dto import (
-    DatasetConfigurationDTO,
-    TestRowSamplerConfigurationDTO,
-)
+from soda_core.common.soda_cloud_dto import DatasetConfigurationDTO, TestRowSamplerConfigurationDTO
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_schema_check_survives_missing_column.py
+++ b/soda-tests/tests/integration/test_schema_check_survives_missing_column.py
@@ -1,10 +1,7 @@
 import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckOutcome,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckOutcome, ContractVerificationResult
 from soda_core.contracts.impl.check_types.schema_check import SchemaCheckResult
 
 # These tests deliberately reference a missing column to exercise the SQL-error

--- a/soda-tests/tests/integration/test_soda_data_types.py
+++ b/soda-tests/tests/integration/test_soda_data_types.py
@@ -2,11 +2,7 @@ import datetime
 
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName, SqlDataType
 
 
 def test_soda_data_types(data_source_test_helper: DataSourceTestHelper):

--- a/soda-tests/tests/integration/test_table_metadata.py
+++ b/soda-tests/tests/integration/test_table_metadata.py
@@ -1,21 +1,11 @@
 import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.common.metadata_types import (
-    ColumnMetadata,
-    SodaDataTypeName,
-    SqlDataType,
-)
+from soda_core.common.metadata_types import ColumnMetadata, SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import CREATE_TABLE, CREATE_TABLE_COLUMN
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_tables_query import (
-    FullyQualifiedViewName,
-    TableType,
-)
-from soda_core.common.statements.table_types import (
-    FullyQualifiedMaterializedViewName,
-    FullyQualifiedTableName,
-)
+from soda_core.common.statements.metadata_tables_query import FullyQualifiedViewName, TableType
+from soda_core.common.statements.table_types import FullyQualifiedMaterializedViewName, FullyQualifiedTableName
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/integration/test_udf_metric_check.py
+++ b/soda-tests/tests/integration/test_udf_metric_check.py
@@ -1,9 +1,6 @@
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.test_table import TestTableSpecification
-from soda_core.contracts.contract_verification import (
-    CheckResult,
-    ContractVerificationResult,
-)
+from soda_core.contracts.contract_verification import CheckResult, ContractVerificationResult
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/memory_container/test_inner_summary_parsing.py
+++ b/soda-tests/tests/memory_container/test_inner_summary_parsing.py
@@ -5,10 +5,7 @@ pytest's JUnit XML — immune to ``-s`` stdout pollution) and ``_inner_run_skipp
 stdout-summary fallback used only when the XML is missing/unparseable).
 """
 
-from helpers.memory_container_plugin import (
-    _inner_outcome_from_junit,
-    _inner_run_skipped,
-)
+from helpers.memory_container_plugin import _inner_outcome_from_junit, _inner_run_skipped
 
 
 class TestInnerRunSkipped:

--- a/soda-tests/tests/memory_container/test_peak_gate.py
+++ b/soda-tests/tests/memory_container/test_peak_gate.py
@@ -10,11 +10,7 @@ from __future__ import annotations
 
 import json
 
-from helpers.memory_container_plugin import (
-    BASELINES_FILENAME,
-    _lookup_peak_baseline,
-    _peak_gate_failure,
-)
+from helpers.memory_container_plugin import BASELINES_FILENAME, _lookup_peak_baseline, _peak_gate_failure
 
 
 class _FakeMarker:

--- a/soda-tests/tests/unit/check_types/impl/test_freshness_check_impl.py
+++ b/soda-tests/tests/unit/check_types/impl/test_freshness_check_impl.py
@@ -16,10 +16,7 @@ from datetime import datetime, timedelta, timezone
 
 from helpers.impl_test_helpers import build_contract_impl, build_measurement_values
 from soda_core.contracts.contract_verification import CheckOutcome
-from soda_core.contracts.impl.check_types.freshness_check import (
-    FreshnessCheckImpl,
-    FreshnessCheckResult,
-)
+from soda_core.contracts.impl.check_types.freshness_check import FreshnessCheckImpl, FreshnessCheckResult
 
 
 def _freshness_yaml(unit: str = "hour", threshold: int = 24) -> str:

--- a/soda-tests/tests/unit/check_types/impl/test_invalid_check_impl.py
+++ b/soda-tests/tests/unit/check_types/impl/test_invalid_check_impl.py
@@ -10,15 +10,8 @@ Generic threshold pass/fail/warn/NOT_EVALUATED patterns are covered in
 test_threshold_checks.py.  Percent threshold is covered there too.
 """
 
-from helpers.impl_test_helpers import (
-    build_contract_impl,
-    build_measurement_values,
-    get_check_impl,
-)
-from soda_core.contracts.impl.check_types.invalidity_check import (
-    InvalidCheckImpl,
-    InvalidCountMetricImpl,
-)
+from helpers.impl_test_helpers import build_contract_impl, build_measurement_values, get_check_impl
+from soda_core.contracts.impl.check_types.invalidity_check import InvalidCheckImpl, InvalidCountMetricImpl
 from soda_core.contracts.impl.check_types.missing_check import MissingCountMetricImpl
 from soda_core.contracts.impl.check_types.row_count_check import RowCountMetricImpl
 

--- a/soda-tests/tests/unit/check_types/impl/test_schema_check_impl.py
+++ b/soda-tests/tests/unit/check_types/impl/test_schema_check_impl.py
@@ -15,11 +15,7 @@ mismatch testing to integration tests.
 from helpers.impl_test_helpers import build_contract_impl, get_check_impl
 from soda_core.common.metadata_types import ColumnMetadata, SqlDataType
 from soda_core.contracts.contract_verification import CheckOutcome, Measurement
-from soda_core.contracts.impl.check_types.schema_check import (
-    SchemaCheckImpl,
-    SchemaCheckResult,
-    SchemaMetricImpl,
-)
+from soda_core.contracts.impl.check_types.schema_check import SchemaCheckImpl, SchemaCheckResult, SchemaMetricImpl
 from soda_core.contracts.impl.contract_verification_impl import MeasurementValues
 
 

--- a/soda-tests/tests/unit/check_types/impl/test_threshold_checks.py
+++ b/soda-tests/tests/unit/check_types/impl/test_threshold_checks.py
@@ -15,38 +15,15 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 
 import pytest
-from helpers.impl_test_helpers import (
-    build_contract_impl,
-    build_measurement_values,
-    get_check_impl,
-)
+from helpers.impl_test_helpers import build_contract_impl, build_measurement_values, get_check_impl
 from soda_core.contracts.contract_verification import CheckOutcome
-from soda_core.contracts.impl.check_types.aggregate_check import (
-    AggregateCheckImpl,
-    AggregateFunctionMetricImpl,
-)
-from soda_core.contracts.impl.check_types.failed_rows_check import (
-    FailedRowsCheckImpl,
-    FailedRowsExpressionMetricImpl,
-)
+from soda_core.contracts.impl.check_types.aggregate_check import AggregateCheckImpl, AggregateFunctionMetricImpl
+from soda_core.contracts.impl.check_types.failed_rows_check import FailedRowsCheckImpl, FailedRowsExpressionMetricImpl
 from soda_core.contracts.impl.check_types.invalidity_check import InvalidCheckImpl
-from soda_core.contracts.impl.check_types.metric_check import (
-    MetricCheckImpl,
-    MetricExpressionMetricImpl,
-)
-from soda_core.contracts.impl.check_types.missing_check import (
-    MissingCheckImpl,
-    MissingCountMetricImpl,
-)
-from soda_core.contracts.impl.check_types.row_count_check import (
-    RowCountCheckImpl,
-    RowCountMetricImpl,
-)
-from soda_core.contracts.impl.contract_verification_impl import (
-    CheckImpl,
-    ContractImpl,
-    DerivedPercentageMetricImpl,
-)
+from soda_core.contracts.impl.check_types.metric_check import MetricCheckImpl, MetricExpressionMetricImpl
+from soda_core.contracts.impl.check_types.missing_check import MissingCheckImpl, MissingCountMetricImpl
+from soda_core.contracts.impl.check_types.row_count_check import RowCountCheckImpl, RowCountMetricImpl
+from soda_core.contracts.impl.contract_verification_impl import CheckImpl, ContractImpl, DerivedPercentageMetricImpl
 
 # ---------------------------------------------------------------------------
 # Configuration dataclass: one entry per check type

--- a/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
+++ b/soda-tests/tests/unit/contract_yaml/test_contract_yaml_parsing.py
@@ -5,10 +5,7 @@ Unit tests for ContractYaml parsing of basic dataset and column structures.
 import pytest
 from helpers.test_functions import dedent_and_strip
 from helpers.yaml_parsing_helpers import parse_column_check, parse_contract
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.exceptions import ContractParserException
 from soda_core.common.logs import Logs
 from soda_core.common.metadata_types import SodaDataTypeName

--- a/soda-tests/tests/unit/metrics/test_measurement_values.py
+++ b/soda-tests/tests/unit/metrics/test_measurement_values.py
@@ -6,11 +6,7 @@ and handles derived metric computation.
 """
 
 from soda_core.contracts.contract_verification import Measurement
-from soda_core.contracts.impl.contract_verification_impl import (
-    DerivedMetricImpl,
-    MeasurementValues,
-    MetricImpl,
-)
+from soda_core.contracts.impl.contract_verification_impl import DerivedMetricImpl, MeasurementValues, MetricImpl
 
 
 class SimpleMockMetric(MetricImpl):

--- a/soda-tests/tests/unit/metrics/test_metrics_resolver.py
+++ b/soda-tests/tests/unit/metrics/test_metrics_resolver.py
@@ -5,10 +5,7 @@ Tests that MetricsResolver correctly deduplicates metrics based on identity
 and returns the same metric instance for equivalent metric configurations.
 """
 
-from soda_core.contracts.impl.contract_verification_impl import (
-    MetricImpl,
-    MetricsResolver,
-)
+from soda_core.contracts.impl.contract_verification_impl import MetricImpl, MetricsResolver
 
 
 class MockMetricImpl(MetricImpl):

--- a/soda-tests/tests/unit/test_alignment_guard.py
+++ b/soda-tests/tests/unit/test_alignment_guard.py
@@ -13,11 +13,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.common.logs import Location, Logs
 from soda_core.contracts.contract_verification import (
     Check,

--- a/soda-tests/tests/unit/test_check_collections_base.py
+++ b/soda-tests/tests/unit/test_check_collections_base.py
@@ -14,19 +14,11 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.logs import Logs
 from soda_core.common.yaml import CheckCollectionYamlSource
-from soda_core.contracts.contract_verification import (
-    CheckCollectionStatus,
-    Contract,
-    YamlFileContentInfo,
-)
+from soda_core.contracts.contract_verification import CheckCollectionStatus, Contract, YamlFileContentInfo
 
 
 class _FakeYaml(CheckCollectionYaml):

--- a/soda-tests/tests/unit/test_check_path_emission.py
+++ b/soda-tests/tests/unit/test_check_path_emission.py
@@ -22,13 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 from soda_core.common.logs import Location
 from soda_core.common.soda_cloud import _build_check_result_cloud_dict
-from soda_core.contracts.contract_verification import (
-    Check,
-    CheckOutcome,
-    CheckResult,
-    Contract,
-    YamlFileContentInfo,
-)
+from soda_core.contracts.contract_verification import Check, CheckOutcome, CheckResult, Contract, YamlFileContentInfo
 
 
 def _make_contract() -> Contract:
@@ -113,9 +107,7 @@ class _StubCheckImpl:
 
     # Borrow the production property verbatim so any future refactor that
     # adds branches is exercised by these tests.
-    from soda_core.contracts.impl.contract_verification_impl import (  # noqa: E402
-        CheckImpl as _RealCheckImpl,
-    )
+    from soda_core.contracts.impl.contract_verification_impl import CheckImpl as _RealCheckImpl  # noqa: E402
 
     check_path = _RealCheckImpl.check_path
 
@@ -186,11 +178,7 @@ def test_verify_raises_when_non_contract_impl_missing_collection_id():
     ``collection_id``. Without it the wire ``checkPath`` would be bare and
     the backend filter would drop every check. ``verify()`` raises early.
     """
-    from soda_core.check_collections.base import (
-        CheckCollectionImpl,
-        CheckCollectionResult,
-        CheckCollectionYaml,
-    )
+    from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 
     class _NoCollectionIdImpl(CheckCollectionImpl):
         wire_source = "data-standard"

--- a/soda-tests/tests/unit/test_check_result_cloud_dict_override_hook.py
+++ b/soda-tests/tests/unit/test_check_result_cloud_dict_override_hook.py
@@ -15,10 +15,7 @@ from __future__ import annotations
 from typing import Optional
 
 from soda_core.common.logs import Location
-from soda_core.common.soda_cloud import (
-    _build_check_result_cloud_dict,
-    _build_check_results_cloud_json_dicts,
-)
+from soda_core.common.soda_cloud import _build_check_result_cloud_dict, _build_check_results_cloud_json_dicts
 from soda_core.contracts.contract_verification import (
     Check,
     CheckCollectionStatus,

--- a/soda-tests/tests/unit/test_check_selectors.py
+++ b/soda-tests/tests/unit/test_check_selectors.py
@@ -1,10 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from soda_core.contracts.impl.check_selector import (
-    CheckSelector,
-    CheckSelectorParseException,
-)
+from soda_core.contracts.impl.check_selector import CheckSelector, CheckSelectorParseException
 
 
 def _make_check_impl(

--- a/soda-tests/tests/unit/test_cli_contract_handlers.py
+++ b/soda-tests/tests/unit/test_cli_contract_handlers.py
@@ -2,15 +2,8 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.contract import (
-    handle_publish_contract,
-    handle_test_contract,
-    handle_verify_contract,
-)
-from soda_core.cli.handlers.dependencies import (
-    resolve_soda_cloud_for_failure_report,
-    run_with_failure_reporting,
-)
+from soda_core.cli.handlers.contract import handle_publish_contract, handle_test_contract, handle_verify_contract
+from soda_core.cli.handlers.dependencies import resolve_soda_cloud_for_failure_report, run_with_failure_reporting
 from soda_core.common.logs import Logs
 from soda_core.contracts.contract_publication import (
     ContractPublication,

--- a/soda-tests/tests/unit/test_cli_data_source_handlers.py
+++ b/soda-tests/tests/unit/test_cli_data_source_handlers.py
@@ -9,11 +9,7 @@ from soda_core.cli.handlers.data_source import (
     handle_discover_data_source_locally,
     handle_test_data_source,
 )
-from soda_core.cli.handlers.dependencies import (
-    resolve_data_source,
-    resolve_soda_cloud,
-    run_with_failure_reporting,
-)
+from soda_core.cli.handlers.dependencies import resolve_data_source, resolve_soda_cloud, run_with_failure_reporting
 
 
 @patch("soda_core.cli.handlers.data_source.exists", return_value=True)

--- a/soda-tests/tests/unit/test_cli_request_handlers.py
+++ b/soda-tests/tests/unit/test_cli_request_handlers.py
@@ -1,11 +1,7 @@
 from unittest.mock import ANY, MagicMock, mock_open, patch
 
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.request import (
-    handle_fetch_proposal,
-    handle_push_proposal,
-    handle_transition_request,
-)
+from soda_core.cli.handlers.request import handle_fetch_proposal, handle_push_proposal, handle_transition_request
 from soda_core.contracts.contract_request import RequestStatus
 
 

--- a/soda-tests/tests/unit/test_cli_soda_cloud_handlers.py
+++ b/soda-tests/tests/unit/test_cli_soda_cloud_handlers.py
@@ -1,10 +1,7 @@
 from unittest.mock import MagicMock, mock_open, patch
 
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.soda_cloud import (
-    handle_create_soda_cloud,
-    handle_test_soda_cloud,
-)
+from soda_core.cli.handlers.soda_cloud import handle_create_soda_cloud, handle_test_soda_cloud
 
 
 @patch("soda_core.cli.handlers.soda_cloud.exists", return_value=True)

--- a/soda-tests/tests/unit/test_cloud_threshold_diagnostics.py
+++ b/soda-tests/tests/unit/test_cloud_threshold_diagnostics.py
@@ -1,10 +1,5 @@
 from soda_core.common.soda_cloud import _build_diagnostics_json_dict
-from soda_core.contracts.contract_verification import (
-    Check,
-    CheckOutcome,
-    CheckResult,
-    Threshold,
-)
+from soda_core.contracts.contract_verification import Check, CheckOutcome, CheckResult, Threshold
 
 
 def build_check_result(threshold: Threshold, warn_threshold: Threshold = None) -> CheckResult:

--- a/soda-tests/tests/unit/test_combined_results_wire.py
+++ b/soda-tests/tests/unit/test_combined_results_wire.py
@@ -14,10 +14,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 from soda_core.common.logs import Location
-from soda_core.common.soda_cloud import (
-    SodaCloud,
-    _build_check_collection_results_json_dict,
-)
+from soda_core.common.soda_cloud import SodaCloud, _build_check_collection_results_json_dict
 from soda_core.contracts.contract_verification import (
     Check,
     CheckCollectionStatus,

--- a/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
+++ b/soda-tests/tests/unit/test_contract_marks_scan_failed_on_connection_error.py
@@ -26,10 +26,7 @@ import pytest
 from helpers.mock_soda_cloud import MockResponse, MockSodaCloud
 from soda_core.cli.exit_codes import ExitCode
 from soda_core.cli.handlers.contract import handle_verify_contract
-from soda_core.cli.handlers.dependencies import (
-    resolve_soda_cloud_for_failure_report,
-    run_with_failure_reporting,
-)
+from soda_core.cli.handlers.dependencies import resolve_soda_cloud_for_failure_report, run_with_failure_reporting
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource

--- a/soda-tests/tests/unit/test_contract_verification_api.py
+++ b/soda-tests/tests/unit/test_contract_verification_api.py
@@ -9,15 +9,8 @@ from soda_core.common.exceptions import (
 )
 from soda_core.common.soda_cloud import SodaCloud
 from soda_core.common.yaml import ContractYamlSource, build_data_source_yaml_sources
-from soda_core.contracts.api.verify_api import (
-    ContractVerificationSession,
-    all_none_or_empty,
-    verify_contract,
-)
-from soda_core.contracts.contract_verification import (
-    ContractVerificationSessionResult,
-    SodaException,
-)
+from soda_core.contracts.api.verify_api import ContractVerificationSession, all_none_or_empty, verify_contract
+from soda_core.contracts.contract_verification import ContractVerificationSessionResult, SodaException
 
 
 def test_contract_verification_file_api():

--- a/soda-tests/tests/unit/test_contract_verification_handler.py
+++ b/soda-tests/tests/unit/test_contract_verification_handler.py
@@ -5,18 +5,13 @@ from helpers.mock_soda_cloud import MockResponse
 from helpers.test_table import TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.soda_cloud import SodaCloud
-from soda_core.contracts.contract_verification import (
-    ContractVerificationResult,
-    PostProcessingStage,
-)
+from soda_core.contracts.contract_verification import ContractVerificationResult, PostProcessingStage
 from soda_core.contracts.impl.contract_verification_impl import (
     ContractImpl,
     ContractVerificationHandler,
     ContractVerificationHandlerRegistry,
 )
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 test_table_specification = (
     TestTableSpecification.builder()

--- a/soda-tests/tests/unit/test_diagnostics_warehouse_files.py
+++ b/soda-tests/tests/unit/test_diagnostics_warehouse_files.py
@@ -1,6 +1,4 @@
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 
 def test_normalize_none_returns_none():

--- a/soda-tests/tests/unit/test_dup_collection_id_validation.py
+++ b/soda-tests/tests/unit/test_dup_collection_id_validation.py
@@ -17,19 +17,11 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.exceptions import InvalidArgumentException
 from soda_core.common.logs import Logs
-from soda_core.contracts.contract_verification import (
-    CheckCollectionStatus,
-    Contract,
-    YamlFileContentInfo,
-)
+from soda_core.contracts.contract_verification import CheckCollectionStatus, Contract, YamlFileContentInfo
 
 # Unique kinds per stub so registrations don't collide with other test
 # modules' sentinel impls or with the real subtypes.

--- a/soda-tests/tests/unit/test_expected_kinds.py
+++ b/soda-tests/tests/unit/test_expected_kinds.py
@@ -16,11 +16,7 @@ from __future__ import annotations
 from typing import Optional
 
 import pytest
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.exceptions import InvalidArgumentException
 from soda_core.common.logs import Logs

--- a/soda-tests/tests/unit/test_failure_reporting.py
+++ b/soda-tests/tests/unit/test_failure_reporting.py
@@ -2,10 +2,7 @@ import logging
 from unittest.mock import MagicMock
 
 from soda_core.cli.exit_codes import ExitCode
-from soda_core.cli.handlers.failure_reporting import (
-    ScanExecutionFailedException,
-    report_scan_execution_failure,
-)
+from soda_core.cli.handlers.failure_reporting import ScanExecutionFailedException, report_scan_execution_failure
 from soda_core.common.exceptions import SodaCoreException
 
 

--- a/soda-tests/tests/unit/test_memory_optimized_query.py
+++ b/soda-tests/tests/unit/test_memory_optimized_query.py
@@ -15,13 +15,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    memory_optimized_driver_settings,
-)
-from soda_postgres.common.data_sources.postgres_data_source_connection import (
-    PostgresDataSourceConnection,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, memory_optimized_driver_settings
+from soda_postgres.common.data_sources.postgres_data_source_connection import PostgresDataSourceConnection
 
 
 @pytest.fixture(autouse=True)
@@ -209,9 +204,7 @@ def _stream_rows(rows, row_limit=None):
 
 class TestByteBudgetedFetchBatching:
     def test_thin_rows_ramp_up_to_row_cap(self):
-        from soda_postgres.common.data_sources.postgres_data_source_connection import (
-            STREAM_FETCH_MAX_BATCH_ROWS,
-        )
+        from soda_postgres.common.data_sources.postgres_data_source_connection import STREAM_FETCH_MAX_BATCH_ROWS
 
         rows = [("x",)] * 2500
         fetch_sizes, seen = _stream_rows(rows)
@@ -241,9 +234,7 @@ class TestByteBudgetedFetchBatching:
         assert len(seen) == 4
 
     def test_late_fat_row_shrinks_batch_permanently(self):
-        from soda_postgres.common.data_sources.postgres_data_source_connection import (
-            STREAM_FETCH_MAX_BATCH_ROWS,
-        )
+        from soda_postgres.common.data_sources.postgres_data_source_connection import STREAM_FETCH_MAX_BATCH_ROWS
 
         # 1500 thin rows, then a fat one, then more thin rows. The widest
         # row seen is monotonic, so once the fat row lands the batch size

--- a/soda-tests/tests/unit/test_phase3_handler_skip_on_error.py
+++ b/soda-tests/tests/unit/test_phase3_handler_skip_on_error.py
@@ -22,11 +22,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Optional
 
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.logging_constants import soda_logger
@@ -45,9 +41,7 @@ from soda_core.contracts.impl.contract_verification_impl import (
     ContractVerificationHandlerRegistry,
     PostProcessingSessionItem,
 )
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 _HANDLER_SKIP_KIND = "phase3-handler-skip-stub"
 

--- a/soda-tests/tests/unit/test_primary_keys_metadata.py
+++ b/soda-tests/tests/unit/test_primary_keys_metadata.py
@@ -5,9 +5,7 @@ from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.metadata_types import ColumnMetadata
 from soda_core.common.sql_dialect import SqlDialect
-from soda_core.common.statements.metadata_primary_keys_query import (
-    MetadataPrimaryKeysQuery,
-)
+from soda_core.common.statements.metadata_primary_keys_query import MetadataPrimaryKeysQuery
 
 
 class _SchemaOnlyDialect(SqlDialect, sqlglot_dialect="schema-only"):

--- a/soda-tests/tests/unit/test_session_log_isolation.py
+++ b/soda-tests/tests/unit/test_session_log_isolation.py
@@ -28,24 +28,14 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
-from soda_core.check_collections.base import (
-    CheckCollectionImpl,
-    CheckCollectionResult,
-    CheckCollectionYaml,
-)
+from soda_core.check_collections.base import CheckCollectionImpl, CheckCollectionResult, CheckCollectionYaml
 from soda_core.check_collections.session import execute_check_collections
 from soda_core.common import logs as logs_module
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.logs import Logs
 from soda_core.common.soda_cloud import _build_check_collection_results_json_dict
-from soda_core.contracts.contract_verification import (
-    CheckCollectionStatus,
-    Contract,
-    YamlFileContentInfo,
-)
-from soda_core.contracts.impl.contract_verification_impl import (
-    ContractVerificationHandlerRegistry,
-)
+from soda_core.contracts.contract_verification import CheckCollectionStatus, Contract, YamlFileContentInfo
+from soda_core.contracts.impl.contract_verification_impl import ContractVerificationHandlerRegistry
 
 _LOGGING_KIND = "logging-isolation-test"
 _RAISING_KIND = "logging-isolation-raise-test"

--- a/soda-tests/tests/unit/test_snapshot.py
+++ b/soda-tests/tests/unit/test_snapshot.py
@@ -8,17 +8,8 @@ import pickle
 from unittest.mock import MagicMock, patch
 
 import pytest
-from helpers.snapshot_connection import (
-    FakeCursor,
-    PicklableColumn,
-    SnapshotDataSourceConnection,
-)
-from helpers.snapshot_manager import (
-    SnapshotEntry,
-    SnapshotManager,
-    SnapshotMismatchError,
-    SnapshotNotFoundError,
-)
+from helpers.snapshot_connection import FakeCursor, PicklableColumn, SnapshotDataSourceConnection
+from helpers.snapshot_manager import SnapshotEntry, SnapshotManager, SnapshotMismatchError, SnapshotNotFoundError
 from soda_core.common.data_source_results import QueryResult, QueryResultIterator
 
 # ---------------------------------------------------------------------------

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -7,12 +7,7 @@ from unittest import mock
 import pytest
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.dict_helpers import assert_dict, matcher_string_contains
-from helpers.mock_soda_cloud import (
-    MockHttpMethod,
-    MockRequest,
-    MockResponse,
-    MockSodaCloud,
-)
+from helpers.mock_soda_cloud import MockHttpMethod, MockRequest, MockResponse, MockSodaCloud
 from helpers.test_table import TestTableSpecification
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.dataset_identifier import DatasetIdentifier
@@ -47,9 +42,7 @@ from soda_core.contracts.impl.contract_verification_impl import (
     ContractVerificationHandlerRegistry,
 )
 from soda_core.contracts.impl.contract_yaml import ContractYaml
-from soda_core.contracts.impl.diagnostics_warehouse_files import (
-    DiagnosticsWarehouseFiles,
-)
+from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
 
 test_table_specification = (
     TestTableSpecification.builder()
@@ -836,9 +829,7 @@ def test_build_diagnostics_json_dict_casts_bool_to_int(threshold_value, expected
 
 
 def _build_freshness_check_result(unit: str, threshold_value: float) -> "FreshnessCheckResult":
-    from soda_core.contracts.impl.check_types.freshness_check import (
-        FreshnessCheckResult,
-    )
+    from soda_core.contracts.impl.check_types.freshness_check import FreshnessCheckResult
 
     return FreshnessCheckResult(
         check=mock.MagicMock(),

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -478,3 +478,36 @@ def test_regex_like_pattern_goes_through_literal_string():
     sql_dialect: SqlDialect = SqlDialect()
     assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == """REGEXP_LIKE("c", '^it''s$')"""
     assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^\d$")) == """REGEXP_LIKE("c", '^\\d$')"""
+
+
+def test_regex_like_seam_escapes_for_dialects_that_only_change_syntax():
+    """A dialect that overrides only the syntax seam still gets escaping.
+
+    This is the property the seam exists for: _regex_like_sql receives the pattern
+    already quoted, so a dialect cannot render a regex without it. Before SCS-1413
+    each dialect overrode the whole builder and had to remember to escape; five
+    didn't.
+    """
+
+    class TildeDialect(SqlDialect, sqlglot_dialect="test"):
+        def _regex_like_sql(self, expression: str, pattern: str) -> str:
+            return f"{expression} ~ {pattern}"
+
+    sql_dialect = TildeDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == """"c" ~ '^it''s$'"""
+
+
+def test_regex_like_seam_escapes_for_dialects_that_rewrite_the_pattern():
+    """The other seam: rewriting the pattern text cannot skip the escaping either.
+
+    _rewrite_regex_pattern runs before literal_string, so a dialect that adapts the
+    pattern for its matcher (sqlserver) still gets the quote escaped. Together with
+    the syntax seam this is why _build_regex_like_sql is @final. See SCS-1413.
+    """
+
+    class WrappingDialect(SqlDialect, sqlglot_dialect="test"):
+        def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
+            return f"%{regex_pattern}%"
+
+    sql_dialect = WrappingDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == ("""REGEXP_LIKE("c", '%^it''s$%')""")

--- a/soda-tests/tests/unit/test_threshold_additional.py
+++ b/soda-tests/tests/unit/test_threshold_additional.py
@@ -5,16 +5,8 @@ from helpers.impl_test_helpers import build_contract_impl
 from helpers.test_functions import dedent_and_strip
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource, YamlObject
-from soda_core.contracts.contract_verification import (
-    CheckCollectionStatus,
-    CheckOutcome,
-    ContractVerificationSession,
-)
-from soda_core.contracts.impl.contract_verification_impl import (
-    ThresholdImpl,
-    ThresholdLevel,
-    warn_can_fire_alone,
-)
+from soda_core.contracts.contract_verification import CheckCollectionStatus, CheckOutcome, ContractVerificationSession
+from soda_core.contracts.impl.contract_verification_impl import ThresholdImpl, ThresholdLevel, warn_can_fire_alone
 from soda_core.contracts.impl.contract_yaml import ThresholdYaml
 
 

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source.py
@@ -5,10 +5,7 @@ from typing import Any, Optional, Tuple
 
 from soda_core.common.data_source_connection import DataSourceConnection
 from soda_core.common.data_source_impl import DataSourceImpl
-from soda_core.common.datetime_conversions import (
-    convert_datetime_to_str,
-    convert_str_to_datetime,
-)
+from soda_core.common.datetime_conversions import convert_datetime_to_str, convert_str_to_datetime
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
 from soda_core.common.sql_ast import (
@@ -21,12 +18,8 @@ from soda_core.common.sql_ast import (
 )
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
-from soda_trino.common.data_sources.trino_data_source_connection import (
-    TrinoDataSource as TrinoDataSourceModel,
-)
-from soda_trino.common.data_sources.trino_data_source_connection import (
-    TrinoDataSourceConnection,
-)
+from soda_trino.common.data_sources.trino_data_source_connection import TrinoDataSource as TrinoDataSourceModel
+from soda_trino.common.data_sources.trino_data_source_connection import TrinoDataSourceConnection
 from soda_trino.statements.trino_metadata_tables_query import TrinoMetadataTablesQuery
 
 logger: logging.Logger = soda_logger

--- a/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
+++ b/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py
@@ -8,15 +8,10 @@ from typing import Literal, Optional, Union
 import requests
 import trino
 from pydantic import BaseModel, Field, IPvAnyAddress, SecretStr
-from soda_core.common.data_source_connection import (
-    DataSourceConnection,
-    parse_session_timezone,
-)
+from soda_core.common.data_source_connection import DataSourceConnection, parse_session_timezone
 from soda_core.common.logging_constants import soda_logger
 from soda_core.model.data_source.data_source import DataSourceBase
-from soda_core.model.data_source.data_source_connection_properties import (
-    DataSourceConnectionProperties,
-)
+from soda_core.model.data_source.data_source_connection_properties import DataSourceConnectionProperties
 
 logger: logging.Logger = soda_logger
 

--- a/soda-trino/src/soda_trino/statements/trino_metadata_tables_query.py
+++ b/soda-trino/src/soda_trino/statements/trino_metadata_tables_query.py
@@ -2,18 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from soda_core.common.sql_ast import (
-    COLUMN,
-    EQ,
-    FROM,
-    LIKE,
-    LITERAL,
-    LOWER,
-    NOT_LIKE,
-    OR,
-    SELECT,
-    WHERE,
-)
+from soda_core.common.sql_ast import COLUMN, EQ, FROM, LIKE, LITERAL, LOWER, NOT_LIKE, OR, SELECT, WHERE
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
 from soda_core.common.statements.table_types import (
     FullyQualifiedMaterializedViewName,


### PR DESCRIPTION
Chain: #2841 → #2843 → **this**. Diff is against #2843.

`[tool.isort] profile = "black"` pins isort's `line_length` to isort's own default of 88;
it does not read `[tool.black] line-length = 120`. So a 100-char import line passes black
locally and fails the pre-commit CI job with a diff that reads as noise.

Sets `line_length = 120` and reformats to match. 140 files, **imports only** — every
changed line is an import statement, a bare imported name, a parenthesis or a blank.

No code lines change: `line_length` under `[tool.isort]` configures isort alone, and isort
only rewrites import blocks. Black's limit doesn't move, and formatters never expand lines
to fill a limit — raising one only un-wraps what the old limit split. `sql_dialect.py` on
main already carries 229 code lines between 89 and 120 chars, which couldn't exist if black
were running at 88.

`origin/main` is 0-files-dirty under `pre-commit run --all-files`, so none of the churn is
pre-existing drift. After the reformat pre-commit converges clean.

Last in the chain deliberately: keeps the two code PRs free of import churn, and picks up
their imports automatically. Regenerated on top of #2843 rather than rebased.

Reviewer notes: any open PR touching an import block will conflict, so worth merging when
the queue is quiet. `git blame --ignore-rev` on the merge commit hides the noise. The
comment above `line_length` is there so the redundant-looking setting isn't tidied away
later, silently restoring the 88/120 split.

<!-- customer-facing-release-note
internal
-->
