### PR TITLE
refactor(sql-dialect): give REGEX_LIKE a syntax-only override seam

### DIFF
--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -23,7 +23,6 @@ from soda_core.common.sql_ast import (
     LITERAL,
     PERCENTILE_WITHIN_GROUP,
     RANDOM,
-    REGEX_LIKE,
     STRING_HASH,
     TIME_DELTA,
     TUPLE,
@@ -262,13 +261,10 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
     def _build_tuple_sql_in_distinct(self, tuple: TUPLE) -> str:
         return f"TO_JSON_STRING(STRUCT({super()._build_tuple_sql(tuple)}))"
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        # literal_string() below is BigQuery's own triple-quoted form, which escapes
-        # the backslash as \\ -- so the pattern reaches the regex engine exactly as the
-        # r'' prefix used to deliver it, and an apostrophe is escaped as \' instead of
-        # terminating the literal. See SCS-1413.
-        return f"REGEXP_CONTAINS({expression}, {self.literal_string(matches.regex_pattern)})"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        # `pattern` arrives quoted by this dialect's own literal_string(), the
+        # triple-quoted form that escapes the backslash as \\ and an apostrophe as \'.
+        return f"REGEXP_CONTAINS({expression}, {pattern})"
 
     def _build_percentile_within_group_sql(self, percentile_within_group: PERCENTILE_WITHIN_GROUP) -> str:
         """BigQuery has no ordered-set aggregates; render as

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from datetime import date, datetime, time, timezone
 from numbers import Number
 from textwrap import indent
-from typing import Any, ClassVar, Optional, Tuple
+from typing import Any, ClassVar, Optional, Tuple, final
 
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.dataset_identifier import DatasetIdentifier
@@ -1246,15 +1246,46 @@ class SqlDialect:
     def _build_not_like_sql(self, not_like: NOT_LIKE) -> str:
         return f"{self.build_expression_sql(not_like.left)} NOT LIKE {self.build_expression_sql(not_like.right)}"
 
+    @final
     def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
+        """Renders REGEX_LIKE. Final on purpose -- override the two seams below.
+
+        REGEX_LIKE.regex_pattern is a bare str rather than an expression node, so
+        unlike LIKE -- whose pattern is a LITERAL and is escaped by the expression
+        renderer in every dialect for free -- nothing escapes it unless this method
+        does. Six dialects each hand-quoted it and five got it wrong (SCS-1413).
+
+        Escaping therefore happens here, once, and cannot be skipped: a dialect that
+        needs different syntax overrides _regex_like_sql, and one that needs the
+        pattern text itself rewritten overrides _rewrite_regex_pattern, which runs
+        before the escaping rather than instead of it.
+        """
         expression: str = self.build_expression_sql(matches.expression)
-        # The pattern is a string literal like any other, so it goes through
-        # literal_string(). Data sources whose parser consumes backslashes in
-        # string literals (Snowflake, Databricks, Redshift) would otherwise
-        # hand the regex engine `d` where the user wrote `\d`, silently
-        # matching nothing, and an apostrophe in a pattern would break the
-        # query outright.
-        return f"REGEXP_LIKE({expression}, {self.literal_string(matches.regex_pattern)})"
+        pattern: str = self.literal_string(self._rewrite_regex_pattern(matches.regex_pattern))
+        return self._regex_like_sql(expression, pattern)
+
+    def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
+        """Adapt the pattern text to what this engine's matcher understands.
+
+        Runs on the raw pattern, before it is escaped as a literal. Return it
+        unchanged unless the engine needs a different dialect of regex -- sqlserver
+        expands `a-z` / `A-Z` and wraps the pattern for PATINDEX here.
+        """
+        return regex_pattern
+
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        """Per-dialect regex syntax. `pattern` arrives already escaped as a string
+        literal, quotes and all -- do not re-quote it.
+
+        Override for a different function name or operator. Three shapes are in use:
+        a function call (base, duckdb's REGEXP_MATCHES, bigquery's REGEXP_CONTAINS),
+        an infix operator (postgres and redshift's `~`), and a whole-predicate
+        rewrite (sqlserver's PATINDEX(...) > 0, and soda-extensions' db2z, which
+        binds the pattern into an XQuery fn:matches). A dialect needing a
+        non-standard literal form does not belong here -- that is what its own
+        literal_string() override is for, as bigquery's triple-quoted form shows.
+        """
+        return f"REGEXP_LIKE({expression}, {pattern})"
 
     def _build_lower_sql(self, lower: LOWER) -> str:
         return f"LOWER({self.build_expression_sql(lower.expression)})"

--- a/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
+++ b/soda-duckdb/src/soda_duckdb/common/data_sources/duckdb_data_source.py
@@ -119,9 +119,8 @@ class DuckDBSqlDialect(SqlDialect, sqlglot_dialect="duckdb"):
     def supports_data_type_datetime_precision(self) -> bool:
         return False
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"REGEXP_MATCHES({expression}, {self.literal_string(matches.regex_pattern)})"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"REGEXP_MATCHES({expression}, {pattern})"
 
     def create_schema_if_not_exists_sql(self, prefixes: list[str], add_semicolon: bool = True) -> str:
         schema_name: str = prefixes[0]

--- a/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
+++ b/soda-postgres/src/soda_postgres/common/data_sources/postgres_data_source.py
@@ -26,7 +26,6 @@ from soda_core.common.sql_ast import (
     LOWER,
     ORDER_BY_ASC,
     RAW_SQL,
-    REGEX_LIKE,
     SELECT,
     WHERE,
 )
@@ -105,9 +104,8 @@ class PostgresSqlDialect(SqlDialect, sqlglot_dialect="postgres"):
     def is_system_schema(self, schema_name: str) -> bool:
         return schema_name.lower().startswith("pg_") or super().is_system_schema(schema_name)
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"{expression} ~ {pattern}"
 
     def supports_sampler(self, sampler_type: SamplerType) -> bool:
         return sampler_type is SamplerType.PERCENTAGE

--- a/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
+++ b/soda-redshift/src/soda_redshift/common/data_sources/redshift_data_source.py
@@ -13,7 +13,6 @@ from soda_core.common.sql_ast import (
     DISTINCT,
     FROM,
     PERCENTILE_WITHIN_GROUP,
-    REGEX_LIKE,
     TUPLE,
     VALUES,
 )
@@ -177,9 +176,8 @@ class RedshiftSqlDialect(SqlDialect, sqlglot_dialect="redshift"):
             ["time", "time without time zone"],
         ]
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        return f"{expression} ~ {self.literal_string(matches.regex_pattern)}"
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
+        return f"{expression} ~ {pattern}"
 
     def _build_tuple_sql(self, tuple: TUPLE) -> str:
         if tuple.check_context(COUNT) and tuple.check_context(DISTINCT):

--- a/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
+++ b/soda-sqlserver/src/soda_sqlserver/common/data_sources/sqlserver_data_source.py
@@ -32,7 +32,6 @@ from soda_core.common.sql_ast import (
     OFFSET,
     PERCENTILE_WITHIN_GROUP,
     RANDOM,
-    REGEX_LIKE,
     SELECT,
     STAR,
     STRING_HASH,
@@ -307,19 +306,23 @@ class SqlServerSqlDialect(SqlDialect, sqlglot_dialect="tsql"):
             return ", ".join(self.build_expression_sql(e) for e in tuple.expressions)
         return super()._build_tuple_sql(tuple)
 
-    def _build_regex_like_sql(self, matches: REGEX_LIKE) -> str:
-        expression: str = self.build_expression_sql(matches.expression)
-        regex_pattern = matches.regex_pattern
+    def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
         # alpha expansion doesn't work properly for case sensitive ranges in SQLServer
-        # this is quite a hack to fit the common use-cases.  generally regex's are only partially supported anyway
+        # this is quite a hack to fit the common use-cases.  generally regex's are only
+        # partially supported anyway
         regex_pattern = regex_pattern.replace("a-z", "abcdefghijklmnopqrstuvwxyz")
         regex_pattern = regex_pattern.replace("A-Z", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        # PATINDEX matches a substring, so the pattern is wrapped rather than anchored.
+        # Wrapping here rather than around the rendered literal keeps the % inside the
+        # quotes that the base escaping puts on.
+        return f"%{regex_pattern}%"
+
+    def _regex_like_sql(self, expression: str, pattern: str) -> str:
         # collations define rules for sorting strings and distinguishing similar characters
         # see: https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver17
         # CS: Case sensitive; AS: Accent sensitive
         # The default is SQL_Latin1_General_Cp1_CI_AS (case-insensitive), we replcae with a case sensitive collation
-        pattern_literal: str = self.literal_string(f"%{regex_pattern}%")
-        return f"PATINDEX ({pattern_literal}, {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+        return f"PATINDEX ({pattern}, {expression} COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
 
     def supports_regex_advanced(self) -> bool:
         return False

--- a/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
+++ b/soda-sqlserver/tests/unit/test_sqlserver_dialect.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from soda_core.common.metadata_types import SqlDataType
 from soda_core.common.sql_ast import COUNT, CREATE_TABLE_COLUMN, STAR
-from soda_core.common.sql_dialect import FROM, RANDOM, SELECT
+from soda_core.common.sql_dialect import COLUMN, FROM, RANDOM, REGEX_LIKE, SELECT
 from soda_sqlserver.common.data_sources.sqlserver_data_source import SqlServerSqlDialect
 
 
@@ -250,3 +250,20 @@ def test_paginated_sql_normalizes_only_the_flagged_key_column():
     # LOWER fold + raw tiebreaker so OFFSET/FETCH paging is deterministic; "label" stays raw.
     assert "LOWER([code]) ASC, [code] ASC" in sql
     assert sql.upper().count("LOWER(") == 1
+
+
+def test_regex_like_rewrites_and_escapes_the_pattern():
+    """sqlserver is the one dialect whose matcher is not a regex engine.
+
+    PATINDEX takes a LIKE-style pattern, so the text is rewritten (`a-z` expanded,
+    wrapped in `%…%`) before being escaped as a literal. The rewrite happens in
+    _rewrite_regex_pattern so the escaping in the base builder still applies -- an
+    apostrophe in a user pattern used to break the query outright. See SCS-1413.
+    """
+    sql_dialect = SqlServerSqlDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == (
+        "PATINDEX ('%^it''s$%', [c] COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+    )
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^[a-z]+$")) == (
+        "PATINDEX ('%^[abcdefghijklmnopqrstuvwxyz]+$%', [c] COLLATE SQL_Latin1_General_Cp1_CS_AS) > 0"
+    )

--- a/soda-tests/tests/unit/test_sql_generation.py
+++ b/soda-tests/tests/unit/test_sql_generation.py
@@ -478,3 +478,36 @@ def test_regex_like_pattern_goes_through_literal_string():
     sql_dialect: SqlDialect = SqlDialect()
     assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == """REGEXP_LIKE("c", '^it''s$')"""
     assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), r"^\d$")) == """REGEXP_LIKE("c", '^\\d$')"""
+
+
+def test_regex_like_seam_escapes_for_dialects_that_only_change_syntax():
+    """A dialect that overrides only the syntax seam still gets escaping.
+
+    This is the property the seam exists for: _regex_like_sql receives the pattern
+    already quoted, so a dialect cannot render a regex without it. Before SCS-1413
+    each dialect overrode the whole builder and had to remember to escape; five
+    didn't.
+    """
+
+    class TildeDialect(SqlDialect, sqlglot_dialect="test"):
+        def _regex_like_sql(self, expression: str, pattern: str) -> str:
+            return f"{expression} ~ {pattern}"
+
+    sql_dialect = TildeDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == """"c" ~ '^it''s$'"""
+
+
+def test_regex_like_seam_escapes_for_dialects_that_rewrite_the_pattern():
+    """The other seam: rewriting the pattern text cannot skip the escaping either.
+
+    _rewrite_regex_pattern runs before literal_string, so a dialect that adapts the
+    pattern for its matcher (sqlserver) still gets the quote escaped. Together with
+    the syntax seam this is why _build_regex_like_sql is @final. See SCS-1413.
+    """
+
+    class WrappingDialect(SqlDialect, sqlglot_dialect="test"):
+        def _rewrite_regex_pattern(self, regex_pattern: str) -> str:
+            return f"%{regex_pattern}%"
+
+    sql_dialect = WrappingDialect()
+    assert sql_dialect.build_expression_sql(REGEX_LIKE(COLUMN("c"), "^it's$")) == ("""REGEXP_LIKE("c", '%^it''s$%')""")


### PR DESCRIPTION
Chain: #2841 → **this** → #2842. Diff is against #2841.

#2841 fixed the same one-line bug in six places, which is the tell: the escaping was an
invariant every dialect could re-implement, and five re-implemented it wrong.

Cause is one field — `REGEX_LIKE.regex_pattern` is a bare `str`, so it never passes through
`build_expression_sql`. `LIKE`/`NOT_LIKE` extend `Operator(left, right)` and render both
sides through it, so their pattern is a `LITERAL` and gets escaped in every dialect for
free; `LIKE` has never had this bug. Every other bare-`str` field in the AST is an
identifier or the `SqlExpressionStr` escape hatch — `regex_pattern` is the only one
carrying user data.

Split the two decisions the builder conflated:

```python
def _build_regex_like_sql(self, matches):
    expression = self.build_expression_sql(matches.expression)
    pattern = self.literal_string(matches.regex_pattern)   # once, here
    return self._regex_like_sql(expression, pattern)

def _regex_like_sql(self, expression, pattern):            # dialects override this
    return f"REGEXP_LIKE({expression}, {pattern})"
```

redshift, postgres, duckdb and bigquery become one-liners that cannot forget to escape.
`test_regex_like_seam_escapes_for_dialects_that_only_change_syntax` pins it for future
dialects. sqlserver keeps the full override — it rewrites the pattern text (`a-z`
expansion) and renders `PATINDEX(…) > 0`.

A keyword table wouldn't cover this: two dialects use an infix operator and one isn't a
regex call.

Rejected: typing `regex_pattern` as a `LITERAL` so escaping is inherited structurally.
Cleaner, but soda-extensions reads it as a `str` (`soda-db2` and `soda-dremio` interpolate
it, `soda-db2z` calls `.replace` on it), so it's a cross-repo break needing a coordinated
pin bump. Worth revisiting once those overrides are deleted.

No behaviour change: rendered SQL is identical per dialect, asserted by the per-dialect
tests from #2841.

<!-- customer-facing-release-note
internal
-->
