### PR TITLE
fix(discovery): map Dremio/Databricks physical table types, warn once per unmapped type

### DIFF
--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -133,6 +133,7 @@ class SqlDialect:
         self._data_type_name_synonym_mappings: dict[str, str] = self._build_data_type_name_synonym_mappings(
             self._get_data_type_name_synonyms()
         )
+        self._warned_table_types: set[str] = set()
 
     def __init_subclass__(cls, sqlglot_dialect: str, **kwargs: Any):
         super().__init_subclass__(**kwargs)
@@ -1497,7 +1498,9 @@ class SqlDialect:
         return self.default_casify("table_type")
 
     def convert_table_type_to_enum(self, table_type: str) -> TableType:
-        if table_type == "BASE TABLE":
+        # "TABLE" is what Dremio (and other FlightSQL sources) report for a physical dataset,
+        # where the SQL standard information_schema says "BASE TABLE".
+        if table_type in ("BASE TABLE", "TABLE"):
             return TableType.TABLE
         elif table_type == "VIEW":
             return TableType.VIEW
@@ -1505,8 +1508,20 @@ class SqlDialect:
             return TableType.MATERIALIZED_VIEW
         else:
             # Default to TABLE if the table type is not recognized (so we're backwards compatible with existing code)
-            logger.warning(f"Invalid table type: {table_type}, defaulting to TABLE")
+            self._warn_unmapped_table_type_once(table_type)
             return TableType.TABLE
+
+    def _warn_unmapped_table_type_once(self, table_type: str) -> None:
+        """
+        Warn at most once per distinct unmapped type.
+
+        convert_table_type_to_enum runs once per metadata row, so warning per call turns an
+        unmapped type on a large data source into one log line per table.
+        """
+        if table_type in self._warned_table_types:
+            return
+        self._warned_table_types.add(table_type)
+        logger.warning(f"Unmapped table type: {table_type}, defaulting to TABLE")
 
     def column_column_name(self) -> str:
         """

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -403,7 +403,8 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
         return False  # Note, this is technically supported. But we need to change the delta table mapping mode name for this (out of scope at the time of writing)
 
     def convert_table_type_to_enum(self, table_type: str) -> TableType:
-        if table_type == "MANAGED":
+        # Unity Catalog reports MANAGED and EXTERNAL for the two kinds of physical table.
+        if table_type in ("MANAGED", "EXTERNAL"):
             return TableType.TABLE
         elif table_type == "VIEW":
             return TableType.VIEW
@@ -411,7 +412,7 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
             return TableType.VIEW  # For now, a materialized view is treated as a view.
         else:
             # Default to TABLE if the table type is not recognized (so we're backwards compatible with existing code)
-            logger.warning(f"Invalid table type: {table_type}, defaulting to TABLE")
+            self._warn_unmapped_table_type_once(table_type)
             return TableType.TABLE
 
     def metadata_casify(self, identifier: str) -> str:

--- a/soda-tests/tests/unit/test_metadata_tables_query_get_results.py
+++ b/soda-tests/tests/unit/test_metadata_tables_query_get_results.py
@@ -6,6 +6,10 @@ an unrecognized table type (e.g. postgres' "FOREIGN TABLE") defaults to TABLE
 and is still returned (v3 parity).
 """
 
+import logging
+from unittest import mock
+
+import soda_core.common.sql_dialect as sql_dialect_module
 from soda_core.common.data_source_results import QueryResult
 from soda_core.common.sql_dialect import SqlDialect
 from soda_core.common.statements.metadata_tables_query import MetadataTablesQuery
@@ -58,3 +62,28 @@ def test_filters_out_types_not_requested():
         types_to_return=[TableType.TABLE],
     )
     assert results == [FullyQualifiedTableName(database_name="soda", schema_name="public", table_name="customers")]
+
+
+def test_dremio_style_table_type_maps_to_table_without_warning(caplog):
+    """Dremio reports TABLE_TYPE 'TABLE' for physical datasets, not 'BASE TABLE'."""
+    with caplog.at_level(logging.WARNING, logger="soda"):
+        results = _get_results([("soda", "public", "customers", "TABLE")])
+
+    assert results == [FullyQualifiedTableName(database_name="soda", schema_name="public", table_name="customers")]
+    assert caplog.records == []
+
+
+def test_unmapped_table_type_warns_once_per_type():
+    """get_results runs per metadata row, so an unmapped type must not log per table."""
+    dialect = SqlDialect()
+    query = MetadataTablesQuery(sql_dialect=dialect, data_source_connection=None)
+    rows = [("soda", "public", f"t{i}", "FOREIGN TABLE") for i in range(5)]
+    rows += [("soda", "public", f"s{i}", "SYSTEM TABLE") for i in range(5)]
+
+    with mock.patch.object(sql_dialect_module.logger, "warning") as warning:
+        query.get_results(QueryResult(rows=rows, columns=_COLUMNS), _ALL_TYPES)
+
+    warned_types = [call.args[0] for call in warning.call_args_list]
+    assert len(warned_types) == 2
+    assert any("FOREIGN TABLE" in message for message in warned_types)
+    assert any("SYSTEM TABLE" in message for message in warned_types)


### PR DESCRIPTION
## Problem

`SqlDialect.convert_table_type_to_enum` only mapped the SQL-standard `BASE TABLE`,
so Dremio's `TABLE` fell through to the default branch. That branch logs a warning —
and it runs **once per metadata row** in `MetadataTablesQuery.get_results`. The result
is one warning per discovered dataset, with a message that contradicts itself:

```
WARNING  Invalid table type: TABLE, defaulting to TABLE
```

Measured on our dev environment: **~320,000 lines per Dremio discovery run**, across 13
Dremio scan definitions = **4.17M lines/day**, over **99%** of all dev discovery log
volume. The same runs OOM-kill their discover pods — over two days, 42 Dremio discovery
runs started and only 14 returned an exit code.

Databricks has the same shape: its override maps `MANAGED` but not `EXTERNAL`, so every
external Unity Catalog table warns too.

## Change

- Map `TABLE` (Dremio and other FlightSQL sources) and `EXTERNAL` (Unity Catalog) to
  `TableType.TABLE`.
- Warn at most **once per distinct unmapped type** instead of once per row, so a future
  unmapped type cannot reproduce the same storm.

Behaviour is unchanged — both types already defaulted to `TableType.TABLE`. This is a
logging fix, not a discovery-result change.

## Tests

Two unit tests in `test_metadata_tables_query_get_results.py`, both failing before the fix:

- `TABLE` maps to a table object and logs nothing.
- 5 `FOREIGN TABLE` + 5 `SYSTEM TABLE` rows produce exactly 2 warnings, not 10.

Full unit suite: 1274 passed, 2 skipped.

### 📣 Customer-facing release note

```customer-facing-release-note
Dremio and Databricks discovery no longer log a warning for every table.
```
