### PR TITLE
feat(mysql): dialect seams and shared-suite support for MySQL

### DIFF
--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -210,20 +210,23 @@ class DataSourceImpl(ABC):
         return self._can_create_materialized_view
 
     # The capability hooks below are all default-off / behavior-preserving. They are consumed by
-    # soda-reconciliation's cross-source reconciliation (rows_diff / reference_diff) and overridden
-    # only by soda-salesforce, letting a SOQL-first / case-insensitive source opt into the behavior
-    # cross-source recon needs without affecting any conventional SQL source. (get_value_comparator
-    # returns a ValueComparatorProtocol; the others are booleans.)
+    # soda-reconciliation's cross-source reconciliation (rows_diff / reference_diff), and let a
+    # source whose ordering or comparison differs from plain codepoint SQL opt into the behavior
+    # cross-source recon needs without affecting any conventional SQL source. Overridden by
+    # soda-salesforce (SOQL-first, case-insensitive) and soda-mysql (accent-insensitive ordering).
+    # (get_value_comparator returns a ValueComparatorProtocol; the others are booleans.)
     @property
     def normalizes_own_text_ordering(self) -> bool:
-        """Whether this data source must fold its OWN text keys to become codepoint-comparable.
+        """Whether reconciliation should fold THIS source's text keys rather than the peer's.
 
-        Default False. ``orders_text_case_insensitively`` says "my ordering differs, fold the other
-        side to match me" — which only works when the peer's fold can reproduce this source's
-        order. It cannot when the ordering is accent-insensitive: the fold is ``LOWER()``, which
-        drops case but keeps accents, so `café` still sorts on the wrong side of `cafz`. A source in
-        that position returns True here instead, and the merge-join folds *this* side — through its
-        own ``order_by_key_expression`` — leaving the peer's native codepoint order untouched.
+        Cross-source reconciliation merge-joins two streams, so both sides must arrive in the same
+        order. Default False: the peer is folded to match this source, using ``LOWER()``.
+
+        Return True when ``LOWER()`` cannot reproduce this source's order. It only removes case, so
+        a source that also ignores accents orders ``café`` before ``cafz`` while a lowered peer
+        orders it after — and the join reports differences that do not exist. Folding this source
+        instead, through its own ``order_by_key_expression``, gives both sides the peer's plain
+        codepoint order.
         """
         return False
 

--- a/soda-core/src/soda_core/common/data_source_impl.py
+++ b/soda-core/src/soda_core/common/data_source_impl.py
@@ -215,6 +215,19 @@ class DataSourceImpl(ABC):
     # cross-source recon needs without affecting any conventional SQL source. (get_value_comparator
     # returns a ValueComparatorProtocol; the others are booleans.)
     @property
+    def normalizes_own_text_ordering(self) -> bool:
+        """Whether this data source must fold its OWN text keys to become codepoint-comparable.
+
+        Default False. ``orders_text_case_insensitively`` says "my ordering differs, fold the other
+        side to match me" — which only works when the peer's fold can reproduce this source's
+        order. It cannot when the ordering is accent-insensitive: the fold is ``LOWER()``, which
+        drops case but keeps accents, so `café` still sorts on the wrong side of `cafz`. A source in
+        that position returns True here instead, and the merge-join folds *this* side — through its
+        own ``order_by_key_expression`` — leaving the peer's native codepoint order untouched.
+        """
+        return False
+
+    @property
     def orders_text_case_insensitively(self) -> bool:
         """Whether this data source's SQL orders text columns case-insensitively.
 

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -308,6 +308,27 @@ class TUPLE(SqlExpression):
 @dataclass
 class COMBINED_HASH(SqlExpression):
     expressions: list[SqlExpression | str]
+    # Whether the hash should treat two values the data source considers EQUAL as one, rather
+    # than hashing their bytes. Default-off, so every existing caller renders byte-for-byte
+    # unchanged on every dialect.
+    #
+    # The two uses of this node need opposite answers, which is why it is a flag rather than a
+    # dialect-wide choice:
+    #   - duplicate equivalence (the duplicate check's verdict, and the failed-rows query that
+    #     has to return the very rows that verdict counted) must agree with what the data source
+    #     considers a duplicate. On a case/accent-insensitive collation, 'ABC' and 'abc' ARE one
+    #     value, so hashing their bytes made the check report duplicates it could not then show.
+    #   - row identity (`__soda_row_id`) and diagnostics-warehouse keys must stay byte-exact:
+    #     folding there would give two genuinely different rows the same id.
+    #
+    # Byte-exactness is what row identity REQUIRES; it is not on its own enough to make the hash
+    # collision-free, and this flag does not change that either way. Two pre-existing sources of
+    # collision in the base rendering, both measured on MySQL 8.4:
+    #   - the CONCAT_WS separator is not escaped, so ('P','Q||R') and ('P||Q','R') are two rows
+    #     the server calls distinct and one hash group;
+    #   - CAST(x AS VARCHAR) yields NULL for bytes that are not valid text, so four distinct
+    #     VARBINARY values collapsed to two groups — one of them shared with a genuine NULL key.
+    fold_equal_values: bool = False
 
     def __post_init__(self):
         super().__post_init__()

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -4,7 +4,7 @@ import logging
 import weakref
 from dataclasses import dataclass, field
 from numbers import Number
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from soda_core.common.logging_constants import soda_logger
 from soda_core.common.metadata_types import SamplerType, SodaDataTypeName, SqlDataType
@@ -305,18 +305,25 @@ class TUPLE(SqlExpression):
         self.handle_parent_node_update(self.expressions)
 
 
+# Whose equality a hash agrees with. "exact" hashes the bytes; "database-equality" hashes so that
+# two values the data source itself calls equal hash alike — on a case- or accent-insensitive
+# collation those are different answers. Named for the equality, not for a transformation: nothing
+# is normalised, the dialect hashes the collation's own sort key.
+ComparisonMode = Literal["exact", "database-equality"]
+
+
 @dataclass
 class COMBINED_HASH(SqlExpression):
     expressions: list[SqlExpression | str]
-    # When True, two values the data source's own equality considers equal hash alike; when False
-    # their bytes are hashed. Default False, so every existing caller is unchanged.
+    # Whose definition of "equal" the hash agrees with. Defaults to "exact", so every existing
+    # caller is unchanged.
     #
-    # A flag rather than a per-dialect choice because the two callers need opposite answers:
+    # Per-node rather than per-dialect because the two callers need opposite answers:
     #   - a duplicate check must group the way the data source does, or the failed-rows query
     #     cannot return the rows the check's own verdict counted;
     #   - row identity (`__soda_row_id`) and the diagnostics-warehouse keys must stay byte-exact,
     #     or two different rows are given the same id.
-    fold_equal_values: bool = False
+    comparison_mode: ComparisonMode = "exact"
 
     def __post_init__(self):
         super().__post_init__()

--- a/soda-core/src/soda_core/common/sql_ast.py
+++ b/soda-core/src/soda_core/common/sql_ast.py
@@ -308,26 +308,14 @@ class TUPLE(SqlExpression):
 @dataclass
 class COMBINED_HASH(SqlExpression):
     expressions: list[SqlExpression | str]
-    # Whether the hash should treat two values the data source considers EQUAL as one, rather
-    # than hashing their bytes. Default-off, so every existing caller renders byte-for-byte
-    # unchanged on every dialect.
+    # When True, two values the data source's own equality considers equal hash alike; when False
+    # their bytes are hashed. Default False, so every existing caller is unchanged.
     #
-    # The two uses of this node need opposite answers, which is why it is a flag rather than a
-    # dialect-wide choice:
-    #   - duplicate equivalence (the duplicate check's verdict, and the failed-rows query that
-    #     has to return the very rows that verdict counted) must agree with what the data source
-    #     considers a duplicate. On a case/accent-insensitive collation, 'ABC' and 'abc' ARE one
-    #     value, so hashing their bytes made the check report duplicates it could not then show.
-    #   - row identity (`__soda_row_id`) and diagnostics-warehouse keys must stay byte-exact:
-    #     folding there would give two genuinely different rows the same id.
-    #
-    # Byte-exactness is what row identity REQUIRES; it is not on its own enough to make the hash
-    # collision-free, and this flag does not change that either way. Two pre-existing sources of
-    # collision in the base rendering, both measured on MySQL 8.4:
-    #   - the CONCAT_WS separator is not escaped, so ('P','Q||R') and ('P||Q','R') are two rows
-    #     the server calls distinct and one hash group;
-    #   - CAST(x AS VARCHAR) yields NULL for bytes that are not valid text, so four distinct
-    #     VARBINARY values collapsed to two groups — one of them shared with a genuine NULL key.
+    # A flag rather than a per-dialect choice because the two callers need opposite answers:
+    #   - a duplicate check must group the way the data source does, or the failed-rows query
+    #     cannot return the rows the check's own verdict counted;
+    #   - row identity (`__soda_row_id`) and the diagnostics-warehouse keys must stay byte-exact,
+    #     or two different rows are given the same id.
     fold_equal_values: bool = False
 
     def __post_init__(self):

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -1909,6 +1909,12 @@ class SqlDialect:
         sampler_limit: Number,
         sampler_type: SamplerType,
     ) -> str:
+        """Bound `sql` to a sample of the rows.
+
+        A dialect that cannot express a sample as a TABLESAMPLE clause, but can another way,
+        overrides this entirely — soda-mysql wraps each source in a row-limited derived table.
+        One that cannot sample at all runs unsampled, with a warning from apply_sampling_to_sql.
+        """
         return apply_sampling_to_sql(
             sql=sql,
             sampler_limit=sampler_limit,

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -102,6 +102,7 @@ from soda_core.common.sql_ast import (
     WHERE,
     WINDOW_FUNCTION,
     WITH,
+    ComparisonMode,
     Operator,
     SqlColumnTerm,
     SqlExpression,
@@ -1576,16 +1577,16 @@ class SqlDialect:
     def _build_combined_hash_sql(self, combined_hash: COMBINED_HASH) -> str:
         """Convert a set of columns into a unique hashed string which can be used as a key."""
         operands: list[SqlExpression] = [
-            self._build_hash_operand(expression, combined_hash.fold_equal_values)
+            self._build_hash_operand(expression, combined_hash.comparison_mode)
             for expression in combined_hash.expressions
         ]
         joined: SqlExpression = operands[0] if len(operands) == 1 else CONCAT_WS(separator="'||'", expressions=operands)
         return self.build_expression_sql(STRING_HASH(joined))
 
-    def _build_hash_operand(self, expression: SqlExpression | str, fold_equal_values: bool) -> SqlExpression:
+    def _build_hash_operand(self, expression: SqlExpression | str, comparison_mode: ComparisonMode) -> SqlExpression:
         """One operand of a combined hash: its value as text, or the NULL sentinel.
 
-        ``fold_equal_values`` asks for values the data source's own equality considers equal to
+        ``"database-equality"`` asks for values the data source's own equality considers equal to
         hash alike, so that a duplicate check's failed-row groups match the verdict it reported.
         Ignored here: the base rendering is byte-exact, which is what ``__soda_row_id`` needs and
         what a case-sensitive source answers anyway. A dialect whose source folds case or accents

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -1618,25 +1618,6 @@ class SqlDialect:
         """
         return True
 
-    def returns_native_boolean_values(self) -> bool:
-        """Whether this source's driver hands back a real ``bool`` for a canonically BOOLEAN column.
-
-        True for every dialect whose driver does. MySQL is the exception: its BOOLEAN is an alias
-        for TINYINT(1) and PyMySQL returns ``1``/``0``, so a consumer testing ``value is True``
-        silently classifies every true value as false.
-
-        A driver property expressed on the dialect because that is what result-consuming code is
-        given — profiling's column profilers hold a ``SqlDialect`` and nothing else, and
-        metric-monitoring already dispatches capabilities the same way (``is_supported_on``).
-        Consumers should branch on this rather than on a data source name, so a future adapter whose
-        driver behaves the same way is covered by overriding one flag.
-
-        Prefer this over widening a comparison to plain truthiness unconditionally when the values
-        cross a boundary that other sources' data also crosses: answering False here changes
-        handling for THIS source only.
-        """
-        return True
-
     def _build_random_sql(self, random: RANDOM) -> str:
         return "RANDOM()"
 

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -1618,6 +1618,25 @@ class SqlDialect:
         """
         return True
 
+    def returns_native_boolean_values(self) -> bool:
+        """Whether this source's driver hands back a real ``bool`` for a canonically BOOLEAN column.
+
+        True for every dialect whose driver does. MySQL is the exception: its BOOLEAN is an alias
+        for TINYINT(1) and PyMySQL returns ``1``/``0``, so a consumer testing ``value is True``
+        silently classifies every true value as false.
+
+        A driver property expressed on the dialect because that is what result-consuming code is
+        given — profiling's column profilers hold a ``SqlDialect`` and nothing else, and
+        metric-monitoring already dispatches capabilities the same way (``is_supported_on``).
+        Consumers should branch on this rather than on a data source name, so a future adapter whose
+        driver behaves the same way is covered by overriding one flag.
+
+        Prefer this over widening a comparison to plain truthiness unconditionally when the values
+        cross a boundary that other sources' data also crosses: answering False here changes
+        handling for THIS source only.
+        """
+        return True
+
     def _build_random_sql(self, random: RANDOM) -> str:
         return "RANDOM()"
 

--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -1575,17 +1575,27 @@ class SqlDialect:
 
     def _build_combined_hash_sql(self, combined_hash: COMBINED_HASH) -> str:
         """Convert a set of columns into a unique hashed string which can be used as a key."""
+        operands: list[SqlExpression] = [
+            self._build_hash_operand(expression, combined_hash.fold_equal_values)
+            for expression in combined_hash.expressions
+        ]
+        joined: SqlExpression = operands[0] if len(operands) == 1 else CONCAT_WS(separator="'||'", expressions=operands)
+        return self.build_expression_sql(STRING_HASH(joined))
 
-        def format_expr(e: SqlExpression) -> SqlExpression:
-            """Convert expression to a string, and replace nulls with a predefined string."""
-            return COALESCE([CAST(e, to_type=SodaDataTypeName.VARCHAR), LITERAL(self.get_soda_null_string_value())])
+    def _build_hash_operand(self, expression: SqlExpression | str, fold_equal_values: bool) -> SqlExpression:
+        """One operand of a combined hash: its value as text, or the NULL sentinel.
 
-        formatted_expressions: list[SqlExpression] = [format_expr(e) for e in combined_hash.expressions]
-        if len(formatted_expressions) == 1:
-            string_to_hash = formatted_expressions[0]
-        else:
-            string_to_hash = CONCAT_WS(separator="'||'", expressions=formatted_expressions)
-        return self.build_expression_sql(STRING_HASH(string_to_hash))
+        ``fold_equal_values`` asks for values the data source's own equality considers equal to
+        hash alike, so that a duplicate check's failed-row groups match the verdict it reported.
+        Ignored here: the base rendering is byte-exact, which is what ``__soda_row_id`` needs and
+        what a case-sensitive source answers anyway. A dialect whose source folds case or accents
+        overrides this to honour it. Note the SQL Server family folds by default and does not
+        override, so its multi-column duplicate checks group byte-exactly while their single-column
+        counterparts follow the collation.
+        """
+        return COALESCE(
+            [CAST(expression, to_type=SodaDataTypeName.VARCHAR), LITERAL(self.get_soda_null_string_value())]
+        )
 
     def _build_sample_sql(self, sampler_type: SamplerType, sample_size: Number) -> str:
         raise NotImplementedError("Sampling not implemented for this dialect")

--- a/soda-core/src/soda_core/common/sql_utils.py
+++ b/soda-core/src/soda_core/common/sql_utils.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from numbers import Number
 
 import sqlglot
+from soda_core.common.logging_constants import soda_logger
 from soda_core.common.sql_ast import SamplerType
 from sqlglot import exp
+
+logger = soda_logger
 
 
 def build_sample_clause(sampler_limit: Number, sampler_type: SamplerType) -> exp.TableSample:
@@ -55,6 +58,10 @@ def apply_sampling_to_sql(
     # FROM sources (top-level, CTE bodies, nested subqueries)
     # Keep track of CTEs and skip them as they are already sampled at their definition
     # Skip subqueries as they are sampled at their definition. We skip the FROM SUBQUERY part, the FROM within the subquery is handled when we process that subquery separately.
+    # Rendered before anything is attached, so the comparison at the end is against this dialect's
+    # own formatting of the same tree rather than against the caller's input string.
+    unsampled_sql: str = tree.sql(dialect=write_dialect, pretty=True) if write_dialect else tree.sql(pretty=True)
+
     ctes = {cte.alias_or_name for cte in tree.find_all(exp.CTE)}
     for from_ in tree.find_all(exp.From):
         if isinstance(from_.this, exp.Table) and from_.this.alias_or_name in ctes:
@@ -68,4 +75,20 @@ def apply_sampling_to_sql(
     for join in tree.find_all(exp.Join):
         attach_sample_to_relation(join.this, sampler_limit, sampler_type)
 
-    return tree.sql(dialect=write_dialect, pretty=True) if write_dialect else tree.sql(pretty=True)
+    sampled_sql: str = tree.sql(dialect=write_dialect, pretty=True) if write_dialect else tree.sql(pretty=True)
+
+    # A dialect with no TABLESAMPLE is not an error to sqlglot: the clause sits in the tree and the
+    # generator drops it, so the statement comes back semantically unchanged and the caller believes
+    # it sampled. Comparing against the unsampled render of the SAME tree is what detects that —
+    # comparing against the input string would not, because the generator reformats regardless.
+    #
+    # Not gated on SqlDialect.supports_sampler: that flag does not mean what its name suggests.
+    # postgres, duckdb, bigquery, sqlserver and trino all render a working TABLESAMPLE while
+    # returning False from it, so refusing on the flag would disable sampling that works today.
+    if sampled_sql == unsampled_sql:
+        logger.warning(
+            f"Sampling was requested ({sampler_type.name}, limit {sampler_limit}) but dialect "
+            f"'{write_dialect or read_dialect}' renders no sample clause, so the query runs over "
+            f"the full dataset. Results will not be sampled."
+        )
+    return sampled_sql

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -344,10 +344,17 @@ class MultiColumnDistinctCountMetricImpl(AggregationMetricImpl):
 
     def sql_expression(self) -> SqlExpression:
         filter_expr: SqlExpression = SqlExpressionStr.optional(self.check_filter)
+        # fold_equal_values so a multi-column duplicate check agrees with the single-column one
+        # above, which uses COUNT(DISTINCT(column)) and therefore folds under the data source's
+        # own text comparison. Without it the two answered differently about the same data on a
+        # case-insensitive collation, and the failed-rows query — which hashes the same way —
+        # could not return the rows this count reported. Identity on byte-exact dialects, so
+        # their SQL is unchanged.
+        combined_hash = COMBINED_HASH(self.column_expressions, fold_equal_values=True)
         if filter_expr:
-            return COUNT(DISTINCT(CASE_WHEN(filter_expr, COMBINED_HASH(self.column_expressions))))
+            return COUNT(DISTINCT(CASE_WHEN(filter_expr, combined_hash)))
         else:
-            return COUNT(DISTINCT(COMBINED_HASH(self.column_expressions)))
+            return COUNT(DISTINCT(combined_hash))
 
     def convert_db_value(self, value) -> int:
         # Note: expression SUM(CASE WHEN "id" IS NULL THEN 1 ELSE 0 END) gives NULL / None as a result if

--- a/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/duplicate_check.py
@@ -344,13 +344,13 @@ class MultiColumnDistinctCountMetricImpl(AggregationMetricImpl):
 
     def sql_expression(self) -> SqlExpression:
         filter_expr: SqlExpression = SqlExpressionStr.optional(self.check_filter)
-        # fold_equal_values so a multi-column duplicate check agrees with the single-column one
+        # "database-equality" so a multi-column duplicate check agrees with the single-column one
         # above, which uses COUNT(DISTINCT(column)) and therefore folds under the data source's
         # own text comparison. Without it the two answered differently about the same data on a
         # case-insensitive collation, and the failed-rows query — which hashes the same way —
         # could not return the rows this count reported. Identity on byte-exact dialects, so
         # their SQL is unchanged.
-        combined_hash = COMBINED_HASH(self.column_expressions, fold_equal_values=True)
+        combined_hash = COMBINED_HASH(self.column_expressions, comparison_mode="database-equality")
         if filter_expr:
             return COUNT(DISTINCT(CASE_WHEN(filter_expr, combined_hash)))
         else:

--- a/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/invalidity_check.py
@@ -296,7 +296,11 @@ class InvalidReferenceCountQuery(Query):
             # e.g. if column_name is "country" and the expression is country::json->>'country_code',
             # we only replace the standalone "country" to get "C".country::json->>'country_code',
             # without corrupting "country_code" inside the string literal.
-            aliased_column_name = f'"{self.referencing_alias}".{column_name}'
+            # Quote the alias through the dialect rather than hardcoding a double quote: a
+            # dialect that quotes identifiers differently — MySQL and BigQuery use backticks —
+            # reads a double-quoted alias as a string literal and answers with a syntax error.
+            quoted_alias: str = self.data_source_impl.sql_dialect.quote_default(self.referencing_alias)
+            aliased_column_name = f"{quoted_alias}.{column_name}"
             pattern = r"\b" + re.escape(column_name) + r"\b"
             referencing_column_expression = SqlExpressionStr(
                 re.sub(pattern, aliased_column_name, referencing_column_expression.expression_str)

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -296,6 +296,10 @@ class DataSourceTestHelper:
             from soda_salesforce.test_helpers.salesforce_data_source_test_helper import SalesforceDataSourceTestHelper
 
             return SalesforceDataSourceTestHelper(name)
+        elif test_datasource == "mysql":
+            from soda_mysql.test_helpers.mysql_data_source_test_helper import MysqlDataSourceTestHelper
+
+            return MysqlDataSourceTestHelper(name)
         else:
             raise AssertionError(f"Unknown test data source {test_datasource}")
 

--- a/soda-tests/src/helpers/data_source_test_helper.py
+++ b/soda-tests/src/helpers/data_source_test_helper.py
@@ -223,6 +223,20 @@ class _LazyRealConnectionFactory:
 
 
 class DataSourceTestHelper:
+    # column_expression carries customer-supplied SQL, so a test exercising it needs the spelling
+    # of the data source under test. These are the Postgres/DuckDB spellings the feature suite was
+    # written with; a dialect that spells casts or JSON access differently overrides the dict rather
+    # than the shared test carrying an `if test_datasource == ...` block. Not generated from the
+    # dialect: `CAST` has an AST node, but JSON path access has none, so three of the five have
+    # nothing to generate from.
+    column_expressions: dict[str, str] = {
+        "id_varchar": '"id"::varchar',
+        "age_str_integer": '"age_str"::integer',
+        "json_unique_id": "json_col::json->>'unique_id'",
+        "country_code": "country::json->>'country_code'",
+        "metadata_created": "metadata::json->>'created'",
+    }
+
     @classmethod
     def create(cls, test_datasource: str, name: str) -> DataSourceTestHelper:
         if test_datasource == "postgres":

--- a/soda-tests/src/helpers/snapshot_connection.py
+++ b/soda-tests/src/helpers/snapshot_connection.py
@@ -21,8 +21,13 @@ sql_logger = soda_logger
 # A picklable replacement for DBAPI cursor.description column entries.
 # DB drivers like psycopg3 use C-extension Column objects that can't be pickled.
 # This namedtuple preserves both attribute access (.name) and index access ([0]).
+# PEP-249 fixes the first seven entries; a driver may append its own. `driver_extra` carries an
+# eighth so a snapshot does not silently drop it — MySQL puts the charset id there, which is what
+# tells a binary column from a text one.
 PicklableColumn = namedtuple(
-    "PicklableColumn", ["name", "type_code", "display_size", "internal_size", "precision", "scale", "null_ok"]
+    "PicklableColumn",
+    ["name", "type_code", "display_size", "internal_size", "precision", "scale", "null_ok", "driver_extra"],
+    defaults=(None,),
 )
 
 # Sentinel object used as a fake DBAPI connection in replay mode.
@@ -1033,6 +1038,7 @@ class SnapshotDataSourceConnection(DataSourceConnection):
                 precision=col[4] if len(col) > 4 else None,
                 scale=col[5] if len(col) > 5 else None,
                 null_ok=col[6] if len(col) > 6 else None,
+                driver_extra=col[7] if len(col) > 7 else None,
             )
             for col in description
         )

--- a/soda-tests/src/helpers/test_table.py
+++ b/soda-tests/src/helpers/test_table.py
@@ -103,6 +103,9 @@ class TestTableSpecificationBuilder:
         Maps to the adapter's largest variable-length string type:
           * postgres / snowflake / bigquery / databricks / duckdb: ``TEXT``
             (or the adapter's equivalent unbounded string)
+          * mysql: ``LONGTEXT`` — reached through the plain ``TEXT`` mapping
+            below, since MySQL's own ``TEXT`` caps at 65,535 bytes and its
+            dialect already maps ``SodaDataTypeName.TEXT`` onto ``LONGTEXT``
           * sqlserver / fabric / synapse: ``varchar(max)`` (SqlServer's
             unbounded varchar — distinct from ``varchar(default_length)``
             which truncates at 8000 chars)

--- a/soda-tests/tests/feature/test_column_expression.py
+++ b/soda-tests/tests/feature/test_column_expression.py
@@ -1,30 +1,8 @@
 from freezegun import freeze_time
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
-from helpers.test_fixtures import test_datasource
 from helpers.test_table import TestTableSpecification
 from soda_core.contracts.contract_verification import CheckOutcome
-
-# column_expression carries customer-supplied SQL, so these fixtures are inherently
-# dialect-flavoured. The values below are the Postgres/DuckDB spellings the file was written
-# with; a dialect that spells casts or JSON access differently overrides them rather than
-# skipping the file. Plain constants, not a dict, so the contract f-strings need no subscript.
-if test_datasource == "mysql":
-    # MySQL has no `::` cast operator, and its JSON extraction takes a path expression rather
-    # than a bare key. JSON_VALUE rather than `->>`: `->>` renders a JSON null as the literal
-    # text 'null', while JSON_VALUE yields SQL NULL like Postgres' `->>` does.
-    EXPR_ID_VARCHAR = "CAST(`id` AS CHAR)"
-    EXPR_AGE_STR_INTEGER = "CAST(`age_str` AS SIGNED)"
-    EXPR_JSON_UNIQUE_ID = "JSON_VALUE(json_col, '$.unique_id')"
-    EXPR_COUNTRY_CODE = "JSON_VALUE(country, '$.country_code')"
-    EXPR_METADATA_CREATED = "JSON_VALUE(metadata, '$.created')"
-else:
-    EXPR_ID_VARCHAR = '"id"::varchar'
-    EXPR_AGE_STR_INTEGER = '"age_str"::integer'
-    EXPR_JSON_UNIQUE_ID = "json_col::json->>'unique_id'"
-    EXPR_COUNTRY_CODE = "country::json->>'country_code'"
-    EXPR_METADATA_CREATED = "metadata::json->>'created'"
-
 
 test_table_specification = (
     TestTableSpecification.builder()
@@ -62,6 +40,12 @@ reference_table_specification = (
 
 
 def test_column_level_column_expression_metric_checks_fail(data_source_test_helper: DataSourceTestHelper):
+    expressions = data_source_test_helper.column_expressions
+    EXPR_ID_VARCHAR = expressions["id_varchar"]
+    EXPR_AGE_STR_INTEGER = expressions["age_str_integer"]
+    EXPR_JSON_UNIQUE_ID = expressions["json_unique_id"]
+    EXPR_COUNTRY_CODE = expressions["country_code"]
+    EXPR_METADATA_CREATED = expressions["metadata_created"]
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
     reference_table = data_source_test_helper.ensure_test_table(reference_table_specification)
 
@@ -198,6 +182,12 @@ def test_column_level_column_expression_metric_checks_fail(data_source_test_help
 
 
 def test_check_level_column_expression_metric_checks_fail(data_source_test_helper: DataSourceTestHelper):
+    expressions = data_source_test_helper.column_expressions
+    EXPR_ID_VARCHAR = expressions["id_varchar"]
+    EXPR_AGE_STR_INTEGER = expressions["age_str_integer"]
+    EXPR_JSON_UNIQUE_ID = expressions["json_unique_id"]
+    EXPR_COUNTRY_CODE = expressions["country_code"]
+    EXPR_METADATA_CREATED = expressions["metadata_created"]
     # Test only a couple of check types, the override mechanism is universal.
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
@@ -260,6 +250,12 @@ def test_check_level_column_expression_metric_checks_fail(data_source_test_helpe
 
 
 def test_column_expression_clashing_metric(data_source_test_helper: DataSourceTestHelper):
+    expressions = data_source_test_helper.column_expressions
+    EXPR_ID_VARCHAR = expressions["id_varchar"]
+    EXPR_AGE_STR_INTEGER = expressions["age_str_integer"]
+    EXPR_JSON_UNIQUE_ID = expressions["json_unique_id"]
+    EXPR_COUNTRY_CODE = expressions["country_code"]
+    EXPR_METADATA_CREATED = expressions["metadata_created"]
     test_table = data_source_test_helper.ensure_test_table(test_table_specification)
 
     data_source_test_helper.enable_soda_cloud_mock(

--- a/soda-tests/tests/feature/test_column_expression.py
+++ b/soda-tests/tests/feature/test_column_expression.py
@@ -1,8 +1,30 @@
 from freezegun import freeze_time
 from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.mock_soda_cloud import MockResponse
+from helpers.test_fixtures import test_datasource
 from helpers.test_table import TestTableSpecification
 from soda_core.contracts.contract_verification import CheckOutcome
+
+# column_expression carries customer-supplied SQL, so these fixtures are inherently
+# dialect-flavoured. The values below are the Postgres/DuckDB spellings the file was written
+# with; a dialect that spells casts or JSON access differently overrides them rather than
+# skipping the file. Plain constants, not a dict, so the contract f-strings need no subscript.
+if test_datasource == "mysql":
+    # MySQL has no `::` cast operator, and its JSON extraction takes a path expression rather
+    # than a bare key. JSON_VALUE rather than `->>`: `->>` renders a JSON null as the literal
+    # text 'null', while JSON_VALUE yields SQL NULL like Postgres' `->>` does.
+    EXPR_ID_VARCHAR = "CAST(`id` AS CHAR)"
+    EXPR_AGE_STR_INTEGER = "CAST(`age_str` AS SIGNED)"
+    EXPR_JSON_UNIQUE_ID = "JSON_VALUE(json_col, '$.unique_id')"
+    EXPR_COUNTRY_CODE = "JSON_VALUE(country, '$.country_code')"
+    EXPR_METADATA_CREATED = "JSON_VALUE(metadata, '$.created')"
+else:
+    EXPR_ID_VARCHAR = '"id"::varchar'
+    EXPR_AGE_STR_INTEGER = '"age_str"::integer'
+    EXPR_JSON_UNIQUE_ID = "json_col::json->>'unique_id'"
+    EXPR_COUNTRY_CODE = "country::json->>'country_code'"
+    EXPR_METADATA_CREATED = "metadata::json->>'created'"
+
 
 test_table_specification = (
     TestTableSpecification.builder()
@@ -55,15 +77,15 @@ def test_column_level_column_expression_metric_checks_fail(data_source_test_help
             contract_yaml_str=f"""
                 variables:
                   id_col_expr:
-                    default: '"id"::varchar'
+                    default: '{EXPR_ID_VARCHAR}'
                   age_str_col_expr:
-                    default: '"age_str"::integer'
+                    default: '{EXPR_AGE_STR_INTEGER}'
                   json_col_expr:
-                    default: "json_col::json->>'unique_id'"
+                    default: "{EXPR_JSON_UNIQUE_ID}"
                   country_col_expr:
-                    default: "country::json->>'country_code'"
+                    default: "{EXPR_COUNTRY_CODE}"
                   metadata_col_expr:
-                    default: "metadata::json->>'created'"
+                    default: "{EXPR_METADATA_CREATED}"
                 columns:
                   - name: id
                     column_expression: '${{var.id_col_expr}}'
@@ -190,9 +212,9 @@ def test_check_level_column_expression_metric_checks_fail(data_source_test_helpe
         contract_yaml_str=f"""
             variables:
               id_col_expr:
-                default: '"id"::varchar'
+                default: '{EXPR_ID_VARCHAR}'
               age_str_col_expr:
-                default: '"age_str"::integer'
+                default: '{EXPR_AGE_STR_INTEGER}'
             columns:
               - name: id
                 column_expression: "CRASH_IF_USED"
@@ -251,7 +273,7 @@ def test_column_expression_clashing_metric(data_source_test_helper: DataSourceTe
         contract_yaml_str=f"""
             variables:
               id_col_expr:
-                default: '"id"::varchar'
+                default: '{EXPR_ID_VARCHAR}'
             columns:
               - name: id
                 checks:

--- a/soda-tests/tests/integration/test_session_timezone.py
+++ b/soda-tests/tests/integration/test_session_timezone.py
@@ -50,6 +50,11 @@ EXPECTED_SESSION_TIMEZONES: dict[str, _TzExpected] = {
     "dremio": timezone.utc,  # Dremio is UTC-only
     "db2": timezone.utc,  # Test instance is UTC; DB2 modules not always installed locally
     "db2z": timezone.utc,
+    # The compose instances pin default_time_zone to +00:00. The container clock is set away
+    # from UTC on purpose, so a regression that let MySQL's literal SYSTEM reach the shared
+    # parser — which resolves it to the *engine host's* zone — would show up here as a
+    # non-UTC value rather than passing silently.
+    "mysql": timezone.utc,
 }
 
 # For these adapters the session TZ follows the host running the test (no client-side override).

--- a/soda-tests/tests/integration/test_unbounded_text_column.py
+++ b/soda-tests/tests/integration/test_unbounded_text_column.py
@@ -26,7 +26,7 @@ from helpers.test_table import TestTableSpecification
 # diffs between record/replay, so always run against a real DB.
 pytestmark = pytest.mark.no_snapshot
 
-_SUPPORTED_DATASOURCES = {"postgres", "sqlserver"}
+_SUPPORTED_DATASOURCES = {"postgres", "sqlserver", "mysql"}
 _IS_SQLSERVER_FAMILY = test_datasource in {"sqlserver", "fabric", "synapse"}
 
 if test_datasource not in _SUPPORTED_DATASOURCES:

--- a/soda-tests/tests/unit/test_combined_hash_seam.py
+++ b/soda-tests/tests/unit/test_combined_hash_seam.py
@@ -1,0 +1,267 @@
+"""The COMBINED_HASH operand seam: its shape, and that `fold_equal_values` is opt-in.
+
+`COMBINED_HASH` builds the key that identifies a row — `__soda_row_id`, the diagnostics-warehouse
+keys, a duplicate check's failed-row groups. `fold_equal_values` asks for values the data source's
+own equality considers equal to hash alike, so a duplicate check's groups match the verdict it
+reported. Only a dialect on a case- or accent-insensitive source has anything to do about that, and
+it acts by overriding `_build_hash_operand`.
+
+Two things are pinned here. First the shape, because every dialect inherits it and a key that
+changes shape silently orphans every previously stored `__soda_row_id`. Second that the flag is
+inert in the base and in every shipped dialect: it was added for MySQL, and a dialect picking it up
+by accident would rewrite those keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+from soda_core.common.sql_ast import COLUMN, COMBINED_HASH
+
+
+@pytest.fixture
+def postgres_dialect():
+    # The shape is the base dialect's, but a bare SqlDialect() cannot render a CAST (it has no
+    # type-name map), so it is pinned through the dialect that adds the least on top.
+    module = pytest.importorskip("soda_postgres.common.data_sources.postgres_data_source")
+    return module.PostgresSqlDialect()
+
+
+def test_a_single_operand_is_hashed_without_a_separator(postgres_dialect):
+    # No CONCAT_WS around one operand: a one-column key must hash the value itself, so it stays
+    # comparable with a hash computed anywhere else over that column.
+    sql = postgres_dialect.build_expression_sql(COMBINED_HASH([COLUMN("id")]))
+
+    assert sql == """MD5(COALESCE("id"::varchar, '__SODA_NULL__'))"""
+
+
+def test_several_operands_are_joined_by_the_pipe_separator(postgres_dialect):
+    # The separator is what keeps ('a','bc') distinct from ('ab','c'); dropping it would collide
+    # two different rows onto one key.
+    sql = postgres_dialect.build_expression_sql(COMBINED_HASH([COLUMN("a"), COLUMN("b")]))
+
+    assert sql == (
+        """MD5(CONCAT_WS('||', COALESCE("a"::varchar, '__SODA_NULL__'), """
+        """COALESCE("b"::varchar, '__SODA_NULL__')))"""
+    )
+
+
+def test_a_null_operand_falls_back_to_the_sentinel(postgres_dialect):
+    # NULL must not swallow the whole CONCAT_WS-joined string, which is what an unguarded CAST
+    # would do on most engines.
+    sql = postgres_dialect.build_expression_sql(COMBINED_HASH([COLUMN("a")]))
+
+    assert postgres_dialect.get_soda_null_string_value() in sql
+
+
+# Every dialect class shipped in soda-core, including the two that are easy to miss because they
+# are not one-per-package: soda-trino, and the Hive variant inside soda-databricks.
+_DIALECT_CASES = [
+    ("postgres", "soda_postgres.common.data_sources.postgres_data_source", "PostgresSqlDialect"),
+    ("duckdb", "soda_duckdb.common.data_sources.duckdb_data_source", "DuckDBSqlDialect"),
+    ("sqlserver", "soda_sqlserver.common.data_sources.sqlserver_data_source", "SqlServerSqlDialect"),
+    ("snowflake", "soda_snowflake.common.data_sources.snowflake_data_source", "SnowflakeSqlDialect"),
+    ("bigquery", "soda_bigquery.common.data_sources.bigquery_data_source", "BigQuerySqlDialect"),
+    ("databricks", "soda_databricks.common.data_sources.databricks_data_source", "DatabricksSqlDialect"),
+    ("databricks_hive", "soda_databricks.common.data_sources.databricks_data_source", "DatabricksHiveSqlDialect"),
+    ("redshift", "soda_redshift.common.data_sources.redshift_data_source", "RedshiftSqlDialect"),
+    ("athena", "soda_athena.common.data_sources.athena_data_source", "AthenaSqlDialect"),
+    ("fabric", "soda_fabric.common.data_sources.fabric_data_source", "FabricSqlDialect"),
+    ("synapse", "soda_synapse.common.data_sources.synapse_data_source", "SynapseSqlDialect"),
+    ("sparkdf", "soda_sparkdf.common.data_sources.sparkdf_data_source", "SparkDataFrameSqlDialect"),
+    ("trino", "soda_trino.common.data_sources.trino_data_source", "TrinoSqlDialect"),
+]
+
+# The exact SQL each dialect renders for a one-column and a two-column key, as (one, two).
+#
+# A regression snapshot, not a style guide. `__soda_row_id` and every diagnostics-warehouse key is
+# one of these strings hashed, so a change here silently orphans previously stored identities: rows
+# written before and after would no longer join. Nothing else in the suite would notice, because the
+# SQL stays valid and self-consistent — the old and new hashes only disagree with each other.
+#
+# Captured from the rendering that predates the `fold_equal_values` flag, so these are literally the
+# pre-flag strings. Some carry pre-existing quirks — BigQuery triple-quotes the sentinel and the
+# separator, Redshift concatenates with `||` instead of CONCAT_WS — reproduced rather than corrected:
+# this file's job is to detect drift, not to fix it. Changing one deliberately means migrating every
+# stored key.
+_EXPECTED_SQL = {
+    "postgres": (
+        "MD5(COALESCE(\"a\"::varchar, '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(\"a\"::varchar, '__SODA_NULL__'), " "COALESCE(\"b\"::varchar, '__SODA_NULL__')))",
+    ),
+    "duckdb": (
+        "MD5(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'), "
+        "COALESCE(CAST(\"b\" AS varchar), '__SODA_NULL__')))",
+    ),
+    "sqlserver": (
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', COALESCE(CAST([a] AS varchar), '__SODA_NULL__')), 2)",
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', CONCAT_WS('||', COALESCE(CAST([a] AS varchar), "
+        "'__SODA_NULL__'), COALESCE(CAST([b] AS varchar), '__SODA_NULL__'))), 2)",
+    ),
+    "snowflake": (
+        "MD5(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'), "
+        "COALESCE(CAST(\"b\" AS varchar), '__SODA_NULL__')))",
+    ),
+    "bigquery": (
+        "to_hex(MD5(COALESCE(CAST(`a` AS string), '''__SODA_NULL__''')))",
+        "to_hex(MD5(CONCAT(COALESCE(CAST(`a` AS string), '''__SODA_NULL__'''), ''||'', "
+        "COALESCE(CAST(`b` AS string), '''__SODA_NULL__'''))))",
+    ),
+    "databricks": (
+        "MD5(COALESCE(CAST(`a` AS string), '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(CAST(`a` AS string), '__SODA_NULL__'), "
+        "COALESCE(CAST(`b` AS string), '__SODA_NULL__')))",
+    ),
+    "databricks_hive": (
+        "MD5(COALESCE(CAST(`a` AS string), '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(CAST(`a` AS string), '__SODA_NULL__'), "
+        "COALESCE(CAST(`b` AS string), '__SODA_NULL__')))",
+    ),
+    "redshift": (
+        "MD5(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'))",
+        "MD5(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__') || ''||'' || "
+        "COALESCE(CAST(\"b\" AS varchar), '__SODA_NULL__'))",
+    ),
+    "athena": (
+        "to_hex(md5(to_utf8(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'))))",
+        "to_hex(md5(to_utf8(CONCAT_WS('||', COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'), "
+        "COALESCE(CAST(\"b\" AS varchar), '__SODA_NULL__')))))",
+    ),
+    "fabric": (
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', COALESCE(CAST([a] AS varchar), '__SODA_NULL__')), 2)",
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', CONCAT_WS('||', COALESCE(CAST([a] AS varchar), "
+        "'__SODA_NULL__'), COALESCE(CAST([b] AS varchar), '__SODA_NULL__'))), 2)",
+    ),
+    "synapse": (
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', COALESCE(CAST([a] AS varchar), '__SODA_NULL__')), 2)",
+        "CONVERT(VARCHAR(32), HASHBYTES('MD5', CONCAT_WS('||', COALESCE(CAST([a] AS varchar), "
+        "'__SODA_NULL__'), COALESCE(CAST([b] AS varchar), '__SODA_NULL__'))), 2)",
+    ),
+    "sparkdf": (
+        "MD5(COALESCE(CAST(`a` AS string), '__SODA_NULL__'))",
+        "MD5(CONCAT_WS('||', COALESCE(CAST(`a` AS string), '__SODA_NULL__'), "
+        "COALESCE(CAST(`b` AS string), '__SODA_NULL__')))",
+    ),
+    "trino": (
+        "TO_HEX(MD5(TO_UTF8(COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'))))",
+        "TO_HEX(MD5(TO_UTF8(CONCAT_WS('||', COALESCE(CAST(\"a\" AS varchar), '__SODA_NULL__'), "
+        "COALESCE(CAST(\"b\" AS varchar), '__SODA_NULL__')))))",
+    ),
+}
+
+
+def _dialect(module_path: str, class_name: str):
+    module = pytest.importorskip(module_path)
+    return getattr(module, class_name)()
+
+
+@pytest.mark.parametrize("name, module_path, class_name", _DIALECT_CASES, ids=[c[0] for c in _DIALECT_CASES])
+def test_every_shipped_dialect_renders_the_pre_flag_sql(name, module_path, class_name):
+    """The regression guard that comparing a dialect against itself cannot give.
+
+    The same-dialect comparison below proves the flag is inert, but not that the shared builder
+    still renders what it used to — refactoring it would change every dialect together and keep
+    every such comparison green. These literals are the pre-flag output, so this is the assertion
+    that would catch it.
+    """
+    sql_dialect = _dialect(module_path, class_name)
+    expected_one, expected_two = _EXPECTED_SQL[name]
+
+    assert sql_dialect.build_expression_sql(COMBINED_HASH([COLUMN("a")])) == expected_one
+    assert sql_dialect.build_expression_sql(COMBINED_HASH([COLUMN("a"), COLUMN("b")])) == expected_two
+
+
+def test_every_shipped_dialect_is_pinned():
+    # A dialect added to _DIALECT_CASES without a snapshot would raise KeyError above, which reads
+    # as a broken test rather than a missing pin. Say which is missing instead.
+    assert {case[0] for case in _DIALECT_CASES} == set(_EXPECTED_SQL)
+
+
+@pytest.mark.parametrize("name, module_path, class_name", _DIALECT_CASES, ids=[c[0] for c in _DIALECT_CASES])
+@pytest.mark.parametrize("expressions", [[COLUMN("a")], [COLUMN("a"), COLUMN("b")]], ids=["one", "two"])
+def test_folding_is_inert_in_every_shipped_dialect(name, module_path, class_name, expressions):
+    """The other half: setting the flag must change nothing here.
+
+    The snapshot above would also pass if a dialect started honouring the flag, because it only
+    renders the default. This covers the opposite mistake — a dialect picking the flag up by
+    accident, which would rewrite the row identities of a source that has nothing to fold.
+    """
+    sql_dialect = _dialect(module_path, class_name)
+
+    assert sql_dialect.build_expression_sql(
+        COMBINED_HASH(expressions, fold_equal_values=True)
+    ) == sql_dialect.build_expression_sql(COMBINED_HASH(expressions))
+
+
+class TestTheMultiColumnDuplicateVerdictFolds:
+    """The verdict itself, which is the one place the flag decides PASS/FAIL rather than a sample.
+
+    A single-column duplicate check counts with `COUNT(DISTINCT(column))`, so the data source's own
+    text comparison decides — on a case- or accent-insensitive collation it folds. The multi-column
+    check has no such column to count; it counts distinct COMBINED_HASH values instead, so unless
+    the hash folds too the two check shapes answer differently about the same data, and the
+    failed-rows query (which hashes the same way) cannot return the rows the count reported.
+
+    Pinned at the metric because nothing downstream would notice: dropping the flag renders valid
+    SQL, every structural assertion holds, and on a byte-exact data source the SQL is unchanged, so
+    the whole suite stays green while a MySQL duplicate check silently changes its verdict.
+    """
+
+    def _sql_expression(self, column_expressions, check_filter=None):
+        from soda_core.contracts.impl.check_types.duplicate_check import MultiColumnDistinctCountMetricImpl
+
+        # Unbound against a stub: the real constructor needs a whole ContractImpl, and
+        # sql_expression reads only these two attributes.
+        metric = object.__new__(MultiColumnDistinctCountMetricImpl)
+        metric.column_expressions = column_expressions
+        metric.check_filter = check_filter
+        return MultiColumnDistinctCountMetricImpl.sql_expression(metric)
+
+    def _combined_hash(self, expression):
+        """The COMBINED_HASH inside COUNT(DISTINCT(...)), however deeply it is wrapped."""
+        from soda_core.common.sql_ast import COMBINED_HASH as HashNode
+
+        found = []
+        stack = [expression]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, HashNode):
+                found.append(node)
+            for attribute in vars(node).values() if hasattr(node, "__dict__") else []:
+                if isinstance(attribute, list):
+                    stack.extend(item for item in attribute if hasattr(item, "__dict__"))
+                elif hasattr(attribute, "__dict__"):
+                    stack.append(attribute)
+        assert len(found) == 1, f"expected exactly one COMBINED_HASH, found {len(found)}"
+        return found[0]
+
+    def test_the_unfiltered_verdict_folds(self):
+        expression = self._sql_expression([COLUMN("a"), COLUMN("b")])
+
+        assert self._combined_hash(expression).fold_equal_values is True
+
+    def test_the_filtered_verdict_folds_identically(self):
+        # The CASE_WHEN branch is a separate construction and would be easy to update alone; a
+        # check with a filter must not answer differently from one without.
+        expression = self._sql_expression([COLUMN("a"), COLUMN("b")], check_filter="a IS NOT NULL")
+
+        assert self._combined_hash(expression).fold_equal_values is True
+
+    def test_the_verdict_and_the_failed_rows_query_group_alike(self):
+        """Both sides of the seam, asserted together, on a dialect that honours the flag.
+
+        This is the property that matters: the count and the rows it explains must come from the
+        same grouping. soda-mysql is the only dialect that renders them differently, so it is the
+        only one where the two can disagree.
+        """
+        pytest.importorskip("soda_mysql")
+        from soda_mysql.common.data_sources.mysql_data_source import MysqlSqlDialect
+
+        sql_dialect = MysqlSqlDialect()
+        verdict_sql = sql_dialect.build_expression_sql(self._sql_expression([COLUMN("a"), COLUMN("b")]))
+
+        assert "WEIGHT_STRING" in verdict_sql, (
+            "the multi-column duplicate verdict must group the way the data source compares, or it "
+            "reports a count whose rows the failed-rows query cannot return"
+        )

--- a/soda-tests/tests/unit/test_combined_hash_seam.py
+++ b/soda-tests/tests/unit/test_combined_hash_seam.py
@@ -1,13 +1,13 @@
-"""The COMBINED_HASH operand seam: its shape, and that `fold_equal_values` is opt-in.
+"""The COMBINED_HASH operand seam: its shape, and that folding is opt-in.
 
 `COMBINED_HASH` builds the key that identifies a row — `__soda_row_id`, the diagnostics-warehouse
-keys, a duplicate check's failed-row groups. `fold_equal_values` asks for values the data source's
-own equality considers equal to hash alike, so a duplicate check's groups match the verdict it
-reported. Only a dialect on a case- or accent-insensitive source has anything to do about that, and
-it acts by overriding `_build_hash_operand`.
+keys, a duplicate check's failed-row groups. `comparison_mode="database-equality"` asks for values
+the data source's own equality considers equal to hash alike, so a duplicate check's groups match
+the verdict it reported. Only a dialect on a case- or accent-insensitive source has anything to do
+about that, and it acts by overriding `_build_hash_operand`.
 
 Two things are pinned here. First the shape, because every dialect inherits it and a key that
-changes shape silently orphans every previously stored `__soda_row_id`. Second that the flag is
+changes shape silently orphans every previously stored `__soda_row_id`. Second that the mode is
 inert in the base and in every shipped dialect: it was added for MySQL, and a dialect picking it up
 by accident would rewrite those keys.
 """
@@ -78,7 +78,7 @@ _DIALECT_CASES = [
 # written before and after would no longer join. Nothing else in the suite would notice, because the
 # SQL stays valid and self-consistent — the old and new hashes only disagree with each other.
 #
-# Captured from the rendering that predates the `fold_equal_values` flag, so these are literally the
+# Captured from the rendering that predates `comparison_mode`, so these are literally the
 # pre-flag strings. Some carry pre-existing quirks — BigQuery triple-quotes the sentinel and the
 # separator, Redshift concatenates with `||` instead of CONCAT_WS — reproduced rather than corrected:
 # this file's job is to detect drift, not to fix it. Changing one deliberately means migrating every
@@ -190,7 +190,7 @@ def test_folding_is_inert_in_every_shipped_dialect(name, module_path, class_name
     sql_dialect = _dialect(module_path, class_name)
 
     assert sql_dialect.build_expression_sql(
-        COMBINED_HASH(expressions, fold_equal_values=True)
+        COMBINED_HASH(expressions, comparison_mode="database-equality")
     ) == sql_dialect.build_expression_sql(COMBINED_HASH(expressions))
 
 
@@ -239,14 +239,14 @@ class TestTheMultiColumnDuplicateVerdictFolds:
     def test_the_unfiltered_verdict_folds(self):
         expression = self._sql_expression([COLUMN("a"), COLUMN("b")])
 
-        assert self._combined_hash(expression).fold_equal_values is True
+        assert self._combined_hash(expression).comparison_mode == "database-equality"
 
     def test_the_filtered_verdict_folds_identically(self):
         # The CASE_WHEN branch is a separate construction and would be easy to update alone; a
         # check with a filter must not answer differently from one without.
         expression = self._sql_expression([COLUMN("a"), COLUMN("b")], check_filter="a IS NOT NULL")
 
-        assert self._combined_hash(expression).fold_equal_values is True
+        assert self._combined_hash(expression).comparison_mode == "database-equality"
 
     def test_the_verdict_and_the_failed_rows_query_group_alike(self):
         """Both sides of the seam, asserted together, on a dialect that honours the flag.

--- a/soda-tests/tests/unit/test_invalid_reference_alias_quoting.py
+++ b/soda-tests/tests/unit/test_invalid_reference_alias_quoting.py
@@ -1,0 +1,128 @@
+"""The referencing alias in a valid_reference_data JOIN is quoted by the dialect.
+
+`InvalidReferenceCountQuery.query_join` rewrites a `column_expression` so the column it names is
+qualified with the join alias. It used to hardcode a double quote — `f'"{alias}".{column}'` — which
+is only correct for the dialects whose identifier quote character happens to be `"`.
+
+On BigQuery and Databricks a double-quoted identifier is a STRING LITERAL, so `"C".country` is a
+syntax error rather than a qualified column: any contract combining a `column_expression` with
+`valid_reference_data` could not run at all. On the SQL Server family the alias needs brackets.
+
+This is the coverage that was missing. The only existing test that reaches this branch is
+soda-tests/tests/feature/test_column_expression.py, and the feature suite runs on the postgres lane
+only — the one dialect whose output the change does NOT alter. So the fix shipped exercised on
+exactly zero of the dialects it affects.
+
+Note on where this runs: soda-tests/tests/unit is itself collected on the postgres lane only
+(soda-core's matrix) and on no soda-extensions lane, so these do not run "everywhere" either. What
+they do give is coverage that is independent of a live server and of which dialect the lane targets,
+so the bigquery/databricks/sqlserver rendering is asserted at all — which it previously was not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from soda_core.common.sql_ast import SqlExpressionStr
+from soda_core.contracts.impl.check_types.invalidity_check import InvalidReferenceCountQuery
+
+# One representative per quoting style, plus the dialects that share it.
+_DIALECT_CASES = [
+    ("postgres", "soda_postgres.common.data_sources.postgres_data_source", "PostgresSqlDialect", '"C"'),
+    ("bigquery", "soda_bigquery.common.data_sources.bigquery_data_source", "BigQuerySqlDialect", "`C`"),
+    ("databricks", "soda_databricks.common.data_sources.databricks_data_source", "DatabricksSqlDialect", "`C`"),
+    ("sqlserver", "soda_sqlserver.common.data_sources.sqlserver_data_source", "SqlServerSqlDialect", "[C]"),
+    ("duckdb", "soda_duckdb.common.data_sources.duckdb_data_source", "DuckDBSqlDialect", '"C"'),
+]
+
+
+def _dialect(module_path: str, class_name: str):
+    module = pytest.importorskip(module_path)
+    return getattr(module, class_name)()
+
+
+def _query_join_sql(sql_dialect, column_expression: str, column_name: str = "country") -> str:
+    """Drive the real query_join against a stub and return the rendered JOIN clause.
+
+    Unbound-method-against-a-stub, the pattern test_rows_diff_key_parts.py already uses: the real
+    class needs a whole ContractImpl to construct, and re-implementing the rewrite here would test
+    a copy rather than the code that ships.
+    """
+    stub = Mock()
+    stub.referencing_alias = "C"
+    stub.referenced_alias = "R"
+    stub._referenced_cte_name = "REF"
+    stub.data_source_impl.sql_dialect = sql_dialect
+    stub.metric_impl.column_impl.column_yaml.name = column_name
+    stub.metric_impl.column_expression = SqlExpressionStr(column_expression)
+    stub.metric_impl.missing_and_validity.valid_reference_data.column = "code"
+    # The two predicates are not what this test is about; make them render as something inert so
+    # the JOIN clause is what the assertion sees.
+    stub.metric_impl.missing_and_validity.is_missing_expr = lambda expr: SqlExpressionStr("1=0")
+    stub.metric_impl.missing_and_validity.is_invalid_expr = lambda expr: SqlExpressionStr("1=1")
+
+    clauses = InvalidReferenceCountQuery.query_join(stub)
+    # build_select_sql renders whole clauses (JOIN / WHERE); build_expression_sql only handles
+    # expression nodes and refuses a clause.
+    return sql_dialect.build_select_sql(clauses)
+
+
+class TestTheAliasIsQuotedByTheDialect:
+    @pytest.mark.parametrize(
+        "name, module_path, class_name, expected_alias",
+        _DIALECT_CASES,
+        ids=[case[0] for case in _DIALECT_CASES],
+    )
+    def test_the_alias_uses_the_dialects_own_quote_character(self, name, module_path, class_name, expected_alias):
+        sql = _query_join_sql(_dialect(module_path, class_name), "country::json->>'country_code'")
+
+        assert f"{expected_alias}.country" in sql, sql
+
+    @pytest.mark.parametrize(
+        "name, module_path, class_name, expected_alias",
+        _DIALECT_CASES,
+        ids=[case[0] for case in _DIALECT_CASES],
+    )
+    def test_a_double_quoted_alias_is_not_emitted_for_a_non_double_quote_dialect(
+        self, name, module_path, class_name, expected_alias
+    ):
+        """The regression itself: `"C".country` on a backtick or bracket dialect.
+
+        Asserted as an absence rather than only as a presence, because the previous
+        implementation emitted BOTH the right column and the wrong quoting.
+        """
+        sql = _query_join_sql(_dialect(module_path, class_name), "country::json->>'country_code'")
+
+        if expected_alias != '"C"':
+            assert '"C".' not in sql, sql
+
+    def test_the_word_boundary_rewrite_still_only_replaces_the_standalone_column(self):
+        # Guards the pre-existing behaviour the quoting change sits inside: `country_code` inside
+        # the JSON path must not be qualified, only the standalone `country`.
+        sql = _query_join_sql(_dialect(_DIALECT_CASES[1][1], _DIALECT_CASES[1][2]), "country::json->>'country_code'")
+
+        assert "`C`.country::json->>'country_code'" in sql, sql
+        assert "`C`.country_code" not in sql, sql
+
+    def test_a_plain_column_expression_is_left_to_the_ast(self):
+        # Only a SqlExpressionStr takes the rewrite path; a COLUMN is qualified by the AST's own
+        # .IN(alias), so the string substitution must not be involved at all.
+        sql_dialect = _dialect(_DIALECT_CASES[1][1], _DIALECT_CASES[1][2])
+        stub = Mock()
+        stub.referencing_alias = "C"
+        stub.referenced_alias = "R"
+        stub._referenced_cte_name = "REF"
+        stub.data_source_impl.sql_dialect = sql_dialect
+        stub.metric_impl.column_impl.column_yaml.name = "country"
+        from soda_core.common.sql_ast import COLUMN
+
+        stub.metric_impl.column_expression = COLUMN("country")
+        stub.metric_impl.missing_and_validity.valid_reference_data.column = "code"
+        stub.metric_impl.missing_and_validity.is_missing_expr = lambda expr: SqlExpressionStr("1=0")
+        stub.metric_impl.missing_and_validity.is_invalid_expr = lambda expr: SqlExpressionStr("1=1")
+
+        clauses = InvalidReferenceCountQuery.query_join(stub)
+        sql = sql_dialect.build_select_sql(clauses)
+
+        assert "`C`.`country`" in sql, sql

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -270,3 +270,33 @@ def test_supports_row_sampling_base_is_true():
     # The recon sampling fail-loud guard fires only when this is False; base SQL sources must
     # report True so a sampled recon on them is never flipped to NOT_EVALUATED.
     assert dialect().supports_row_sampling() is True
+
+
+# ---------------------------------------------------------------------------
+# returns_native_boolean_values()
+#
+# Whether the driver hands back a real bool for a canonically BOOLEAN column.
+# Consumers of query results branch on this instead of on a data source name;
+# answering False changes handling for that source only, leaving every other
+# source's data untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_returns_native_boolean_values_defaults_true():
+    assert dialect().returns_native_boolean_values() is True
+
+
+def test_a_dialect_can_declare_a_non_native_boolean_driver():
+    # SqlDialect.__init_subclass__ requires the sqlglot dialect name.
+    class IntBooleanDialect(SqlDialect, sqlglot_dialect="mysql"):
+        def returns_native_boolean_values(self) -> bool:
+            return False
+
+    assert IntBooleanDialect().returns_native_boolean_values() is False
+
+
+def test_it_is_a_method_not_a_property():
+    # Consistent with the supports_* family, so an override following that convention cannot
+    # silently shadow it with a property that is always truthy.
+    assert callable(SqlDialect.returns_native_boolean_values)
+    assert not isinstance(SqlDialect.__dict__["returns_native_boolean_values"], property)

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -270,33 +270,3 @@ def test_supports_row_sampling_base_is_true():
     # The recon sampling fail-loud guard fires only when this is False; base SQL sources must
     # report True so a sampled recon on them is never flipped to NOT_EVALUATED.
     assert dialect().supports_row_sampling() is True
-
-
-# ---------------------------------------------------------------------------
-# returns_native_boolean_values()
-#
-# Whether the driver hands back a real bool for a canonically BOOLEAN column.
-# Consumers of query results branch on this instead of on a data source name;
-# answering False changes handling for that source only, leaving every other
-# source's data untouched.
-# ---------------------------------------------------------------------------
-
-
-def test_returns_native_boolean_values_defaults_true():
-    assert dialect().returns_native_boolean_values() is True
-
-
-def test_a_dialect_can_declare_a_non_native_boolean_driver():
-    # SqlDialect.__init_subclass__ requires the sqlglot dialect name.
-    class IntBooleanDialect(SqlDialect, sqlglot_dialect="mysql"):
-        def returns_native_boolean_values(self) -> bool:
-            return False
-
-    assert IntBooleanDialect().returns_native_boolean_values() is False
-
-
-def test_it_is_a_method_not_a_property():
-    # Consistent with the supports_* family, so an override following that convention cannot
-    # silently shadow it with a property that is always truthy.
-    assert callable(SqlDialect.returns_native_boolean_values)
-    assert not isinstance(SqlDialect.__dict__["returns_native_boolean_values"], property)

--- a/soda-tests/tests/unit/test_sql_dialect_seams.py
+++ b/soda-tests/tests/unit/test_sql_dialect_seams.py
@@ -21,6 +21,7 @@ from datetime import datetime
 
 import pytest
 from soda_core.common.dataset_identifier import DatasetIdentifier
+from soda_core.common.metadata_types import SamplerType
 from soda_core.common.sql_ast import ALIAS, SqlExpressionStr
 from soda_core.common.sql_dialect import SqlDialect
 
@@ -270,3 +271,53 @@ def test_supports_row_sampling_base_is_true():
     # The recon sampling fail-loud guard fires only when this is False; base SQL sources must
     # report True so a sampled recon on them is never flipped to NOT_EVALUATED.
     assert dialect().supports_row_sampling() is True
+
+
+# ---------------------------------------------------------------------------
+# apply_sampling() warns when the dialect renders no sample clause
+#
+# sqlglot emits nothing for a target with no TABLESAMPLE and returns the
+# statement unchanged, so the caller silently receives a full scan. The warning
+# does not change what is returned — an unsamplable dialect still runs
+# unsampled — it only stops that being invisible.
+# ---------------------------------------------------------------------------
+
+
+def test_a_dialect_that_renders_a_sample_does_not_warn(caplog):
+    postgres = pytest.importorskip("soda_postgres.common.data_sources.postgres_data_source")
+    sql_dialect = postgres.PostgresSqlDialect()
+
+    with caplog.at_level("WARNING"):
+        sampled = sql_dialect.apply_sampling("SELECT COUNT(*) FROM t", 10, SamplerType.ABSOLUTE_LIMIT)
+
+    assert "TABLESAMPLE" in sampled.upper()
+    assert "renders no sample clause" not in caplog.text
+
+
+def test_a_dialect_that_renders_nothing_warns_and_returns_the_sql_unchanged(caplog):
+    redshift = pytest.importorskip("soda_redshift.common.data_sources.redshift_data_source")
+    sql_dialect = redshift.RedshiftSqlDialect()
+    sql = "SELECT COUNT(*) FROM t"
+
+    with caplog.at_level("WARNING"):
+        sampled = sql_dialect.apply_sampling(sql, 10, SamplerType.ABSOLUTE_LIMIT)
+
+    # Behaviour is unchanged: still the full-scan statement. sqlglot reformats regardless, so the
+    # check is that no sample clause was added, not that the string is byte-identical.
+    assert "TABLESAMPLE" not in sampled.upper()
+    assert "COUNT(*)" in sampled
+    assert "renders no sample clause" in caplog.text
+    assert "ABSOLUTE_LIMIT" in caplog.text
+
+
+def test_the_warning_is_not_gated_on_supports_sampler():
+    """The flag cannot be the gate: five dialects render a sample while declaring False.
+
+    Refusing on `supports_sampler` would disable sampling that works today, which is why
+    apply_sampling compares the rendered SQL instead.
+    """
+    postgres = pytest.importorskip("soda_postgres.common.data_sources.postgres_data_source")
+    sql_dialect = postgres.PostgresSqlDialect()
+
+    assert sql_dialect.supports_sampler(SamplerType.ABSOLUTE_LIMIT) is False
+    assert "TABLESAMPLE" in sql_dialect.apply_sampling("SELECT COUNT(*) FROM t", 10, SamplerType.ABSOLUTE_LIMIT).upper()


### PR DESCRIPTION
## Description

The soda-core half of MySQL support (`R-647`). The adapter itself lands in
[soda-extensions][ext-pr] — this PR is the shared-code seams it needs, plus two
fixes it surfaced. Five commits, each reviewable on its own.

### `COMBINED_HASH` can group values the data source considers equal

A duplicate check's verdict is computed by the data source: `COUNT(DISTINCT col)`
compares under the column's collation. On MySQL's default `utf8mb4_0900_ai_ci`
that folds case **and** accents, while `COMBINED_HASH` hashes bytes — so the
failed-rows query, which hashes the same way, could not return the rows the
verdict had counted. For a **multi-column** check the verdict *is* the hash, so
the two check shapes disagreed about the same data:

| check | verdict source | byte-exact hash |
| --- | --- | --- |
| one column | `COUNT(DISTINCT col)` — folds | sample can't be returned |
| two+ columns | `COUNT(DISTINCT <hash>)` | **verdict itself is wrong** |

New opt-in `fold_equal_values` flag, honoured by overriding the new per-operand
`_build_hash_operand` hook. The base ignores it. Row identity (`__soda_row_id`)
and the diagnostics-warehouse keys must stay byte-exact, so only the duplicate
path opts in.

**No other dialect changes.** I restored the pre-flag builder from `main` and
compared rendered SQL for 18 dialects across both repos × 5 operand shapes ×
both flag values: **175 identical, 5 differing — all 5 MySQL with the flag on.**

### `normalizes_own_text_ordering`

Reconciliation compensates for a case-insensitive peer by folding the other side
with `LOWER()`. That cannot reproduce an *accent*-insensitive order — `LOWER()`
drops case but keeps accents — so `café` sorts on the wrong side of `cafz` and a
cross-source `rows_diff` reports diffs that aren't there. A source answering
`True` folds its own keys instead. Defaults `False`; no existing source changes.

### `PicklableColumn` keeps a driver's 8th description field

PEP 249 fixes the first seven entries; a driver may append its own. MySQL puts
the charset id there, the only thing distinguishing `BINARY` from `CHAR` (each
pair shares one field-type code). Added with a default, so existing pickled
snapshots still load.

### Reference-check join alias is quoted by the dialect — independent fix

`InvalidReferenceCountQuery.query_join` hardcoded `f'"{alias}".{column}'`. On
BigQuery and Databricks a double-quoted identifier is a **string literal**, so
`"C".country` was a syntax error: any contract combining `column_expression`
with `valid_reference_data` could not run at all there. SQL Server needs
brackets. Unrelated to MySQL — worth reviewing (or reverting) on its own.

## Impact on downstream packages

soda-extensions consumes all four seams; its PR is stacked on this branch via
`SODA_CORE_BRANCH`. No behaviour change for any existing data source — the
byte-identity comparison above is the evidence for the hash, and the other three
are additive (new hook, new default-`False` property, defaulted tuple field).

## Tests

Two new unit files, both independent of a live server:

- `test_combined_hash_seam.py` — pins the **exact pre-flag SQL** for all 13
  dialects shipped here, including their pre-existing quirks (BigQuery
  triple-quotes the sentinel, Redshift concatenates with `||`), reproduced not
  corrected. A shared-builder change moves every dialect together, so the
  previous same-dialect comparison was blind to it: under a mutation swapping
  the NULL sentinel, the old style of assertion passes 26/26 while these fail 16.
  Also that the flag stays inert per dialect, and that the multi-column verdict
  asks for the fold.
- `test_invalid_reference_alias_quoting.py` — drives the real `query_join`
  across the four quoting styles. Previously zero coverage: the only test
  reaching that branch is the feature suite, which runs on the postgres lane —
  the one dialect whose output is unchanged.

| suite | result |
| --- | --- |
| `TEST_DATASOURCE=mysql` | 1502 passed, 35 skipped |
| `TEST_DATASOURCE=postgres` | 1510 passed, 27 skipped |
| `TEST_DATASOURCE=duckdb` | 1498 passed, 35 skipped |
| `TEST_DATASOURCE=sqlserver` (integration) | 172 passed, 16 skipped |

## Checklist

- [x] I added a test to verify the new functionality.
- [x] I verified this PR does not break [soda-extensions][1] — its suites run
      green against this branch locally (packages 775 passed; `all_data_sources`
      149/151 in both transfer modes; cross-source mysql↔postgres/sqlserver 16/16
      live). The extensions PR pins `SODA_CORE_BRANCH=r-647-mysql-support`.

[1]: https://github.com/sodadata/soda-extensions/actions/workflows/main.workflow.yaml
[ext-pr]: https://github.com/sodadata/soda-extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
