### PR TITLE
fix(athena): convert tz timestamps in the driver, report unparseable freshness values truthfully

### DIFF
--- a/soda-athena/pyproject.toml
+++ b/soda-athena/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "soda-core==4.23.0",
     "PyAthena>=2.2.0,<4.0",
     "setuptools>=60",
+    # ZoneInfo needs an IANA database; slim images often ship without one.
+    "tzdata",
 ]
 
 [project.entry-points."soda.plugins.data_source.athena"]

--- a/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
+++ b/soda-athena/src/soda_athena/common/data_sources/athena_data_source_connection.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Literal, Optional, Union
+from zoneinfo import ZoneInfo
 
 import pyathena
 from pyathena.converter import DefaultTypeConverter
@@ -20,23 +22,71 @@ logger: logging.Logger = soda_logger
 DEFAULT_CATALOG = "awsdatacatalog"
 
 
+# A fraction longer than the 6 digits %f accepts, e.g. timestamp(9) renderings.
+_SUB_MICROSECOND_FRACTION_RE = re.compile(r"(.+ \d{2}:\d{2}:\d{2}\.\d{6})\d+$")
+_TZ_OFFSET_RE = re.compile(r"([+-])(\d{2}):(\d{2})(?::(\d{2}))?$")
+_TZ_UTC_NAMES = frozenset({"UTC", "GMT", "Z", "ZULU", "UT"})
+
+
 def _to_datetime_lenient(varchar_value: Optional[str]) -> Optional[datetime]:
-    """pyathena's default timestamp converter requires fractional seconds,
-    but Athena renders timestamp(0) values (e.g. second-precision literals
-    fed through date arithmetic) without them — which would fail the whole
-    fetch. Accept both forms."""
+    """pyathena's default timestamp converter requires fractional seconds of at
+    most 6 digits, but Athena renders timestamp(0) values (e.g. second-precision
+    literals fed through date arithmetic) without them and timestamp(7..9) values
+    with more — either would fail the whole fetch. Accept all forms; digits beyond
+    microseconds are truncated."""
     if varchar_value is None:
         return None
     try:
         return datetime.strptime(varchar_value, "%Y-%m-%d %H:%M:%S.%f")
     except ValueError:
-        return datetime.strptime(varchar_value, "%Y-%m-%d %H:%M:%S")
+        pass
+    sub_microsecond_match = _SUB_MICROSECOND_FRACTION_RE.match(varchar_value)
+    if sub_microsecond_match:
+        return datetime.strptime(sub_microsecond_match.group(1), "%Y-%m-%d %H:%M:%S.%f")
+    return datetime.strptime(varchar_value, "%Y-%m-%d %H:%M:%S")
+
+
+def _parse_time_zone(tz_value: str, full_value: str) -> tzinfo:
+    offset_match = _TZ_OFFSET_RE.fullmatch(tz_value)
+    if offset_match:
+        sign = 1 if offset_match.group(1) == "+" else -1
+        return timezone(
+            sign
+            * timedelta(
+                hours=int(offset_match.group(2)),
+                minutes=int(offset_match.group(3)),
+                seconds=int(offset_match.group(4) or 0),
+            )
+        )
+    # Resolve UTC without a tz database: Athena's session zone is always UTC, so
+    # this must work even on images without tzdata.
+    if tz_value.upper() in _TZ_UTC_NAMES:
+        return timezone.utc
+    try:
+        return ZoneInfo(tz_value)
+    except Exception:
+        raise ValueError(f"Unrecognized time zone '{tz_value}' in timestamp value '{full_value}'")
+
+
+def _to_datetime_with_tz_lenient(varchar_value: Optional[str]) -> Optional[datetime]:
+    """Convert 'timestamp with time zone' values (e.g. MAX over an Iceberg
+    timestamptz column), rendered like '2026-09-01 12:00:00.000 UTC'. pyathena
+    only maps this type since 3.9.0 — older versions hand the engine the raw
+    string — and its own converter requires fractional seconds and silently
+    drops offset-style zones ('+02:00'), producing naive datetimes."""
+    if varchar_value is None:
+        return None
+    datetime_value, separator, tz_value = varchar_value.rpartition(" ")
+    if not separator:
+        raise ValueError(f"No time zone in 'timestamp with time zone' value '{varchar_value}'")
+    return _to_datetime_lenient(datetime_value).replace(tzinfo=_parse_time_zone(tz_value, varchar_value))
 
 
 class LenientTypeConverter(DefaultTypeConverter):
     def __init__(self) -> None:
         super().__init__()
         self.mappings["timestamp"] = _to_datetime_lenient
+        self.mappings["timestamp with time zone"] = _to_datetime_with_tz_lenient
 
 
 class AthenaConnectionProperties(DataSourceConnectionProperties, ABC):

--- a/soda-athena/tests/unit/test_athena_timestamp_converters.py
+++ b/soda-athena/tests/unit/test_athena_timestamp_converters.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the timestamp conversions in LenientTypeConverter.
+
+Athena renders query results as strings; pyathena converts them per result-column
+type name. Two gaps bit real scans:
+- 'timestamp with time zone' (e.g. Iceberg timestamptz columns) is only mapped by
+  pyathena >= 3.9.0 — older versions hand the raw string ('... UTC') to the engine.
+- pyathena's own tz converter requires fractional seconds and silently drops
+  offset-style zones ('+02:00'), yielding naive datetimes.
+LenientTypeConverter must produce correct (aware) datetimes for every form Athena
+renders, on any supported pyathena.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from soda_athena.common.data_sources.athena_data_source_connection import LenientTypeConverter
+
+
+@pytest.fixture
+def converter() -> LenientTypeConverter:
+    return LenientTypeConverter()
+
+
+def test_timestamp_with_fraction(converter):
+    assert converter.convert("timestamp", "2026-08-31 06:00:00.123") == datetime(2026, 8, 31, 6, 0, 0, 123000)
+
+
+def test_timestamp_without_fraction(converter):
+    assert converter.convert("timestamp", "2026-08-31 06:00:00") == datetime(2026, 8, 31, 6, 0, 0)
+
+
+def test_timestamp_nanosecond_fraction_is_truncated_to_microseconds(converter):
+    assert converter.convert("timestamp", "2026-08-31 06:00:00.123456789") == datetime(2026, 8, 31, 6, 0, 0, 123456)
+
+
+def test_timestamp_none(converter):
+    assert converter.convert("timestamp", None) is None
+
+
+def test_timestamp_tz_named_utc(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00.123 UTC")
+    assert value == datetime(2026, 8, 31, 6, 0, 0, 123000, tzinfo=timezone.utc)
+    assert value.utcoffset() == timedelta(0)
+
+
+def test_timestamp_tz_without_fraction(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00 UTC")
+    assert value == datetime(2026, 8, 31, 6, 0, 0, tzinfo=timezone.utc)
+
+
+def test_timestamp_tz_nanosecond_fraction(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00.123456789 UTC")
+    assert value == datetime(2026, 8, 31, 6, 0, 0, 123456, tzinfo=timezone.utc)
+
+
+def test_timestamp_tz_positive_offset_is_not_dropped(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00.000 +02:00")
+    assert value.utcoffset() == timedelta(hours=2)
+    assert value == datetime(2026, 8, 31, 4, 0, 0, tzinfo=timezone.utc)
+
+
+def test_timestamp_tz_negative_offset(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00.000 -05:30")
+    assert value.utcoffset() == -timedelta(hours=5, minutes=30)
+
+
+def test_timestamp_tz_region_zone(converter):
+    value = converter.convert("timestamp with time zone", "2026-08-31 06:00:00.000 Europe/Zurich")
+    # CEST in August
+    assert value.utcoffset() == timedelta(hours=2)
+
+
+def test_timestamp_tz_none(converter):
+    assert converter.convert("timestamp with time zone", None) is None
+
+
+def test_timestamp_tz_unknown_zone_raises_with_the_value(converter):
+    with pytest.raises(ValueError, match=r"No/Such_Zone.*2026-08-31 06:00:00\.000 No/Such_Zone"):
+        converter.convert("timestamp with time zone", "2026-08-31 06:00:00.000 No/Such_Zone")

--- a/soda-core/src/soda_core/contracts/impl/check_types/freshness_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/freshness_check.py
@@ -100,7 +100,13 @@ class FreshnessCheckImplBase(CheckImpl, ABC):
             if isinstance(max_timestamp, date):
                 max_timestamp = datetime.combine(max_timestamp, datetime.min.time())
             elif isinstance(max_timestamp, str):
-                max_timestamp = convert_str_to_datetime(max_timestamp)
+                converted_timestamp: Optional[datetime] = convert_str_to_datetime(max_timestamp)
+                if converted_timestamp is None:
+                    logger.error(
+                        f"Freshness column '{column_name}' returned value '{max_timestamp}' of data type '{type(max_timestamp).__name__}' which could not be parsed as a datetime."
+                    )
+                    return None
+                max_timestamp = converted_timestamp
 
         if not isinstance(max_timestamp, datetime):
             logger.error(

--- a/soda-tests/tests/unit/check_types/impl/test_freshness_check_impl.py
+++ b/soda-tests/tests/unit/check_types/impl/test_freshness_check_impl.py
@@ -158,3 +158,23 @@ def test_freshness_unit_day_fails():
     max_ts = _data_timestamp(check) - timedelta(days=10)
     result = _evaluate_freshness(contract_impl, check, max_ts)
     assert result.outcome == CheckOutcome.FAILED
+
+
+def test_freshness_unparseable_string_reports_the_received_value(caplog):
+    """A string the engine cannot parse (e.g. a tz-rendered timestamp handed over raw
+    by the driver) must be reported as itself — not as a received 'None', which reads
+    as if the database returned NULL."""
+    contract_impl, check = _build_freshness_check(_freshness_yaml())
+    result = _evaluate_freshness(contract_impl, check, max_ts="2026-09-01 12:00:00.000 UTC")
+    assert result.outcome == CheckOutcome.FAILED
+    assert "'2026-09-01 12:00:00.000 UTC'" in caplog.text
+    assert "could not be parsed" in caplog.text
+    assert "'None'" not in caplog.text
+
+
+def test_freshness_parseable_string_is_converted():
+    """ISO strings from drivers without native datetime conversion still evaluate."""
+    contract_impl, check = _build_freshness_check(_freshness_yaml(unit="hour", threshold=24))
+    max_ts = (_data_timestamp(check) - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+    result = _evaluate_freshness(contract_impl, check, max_ts)
+    assert result.outcome == CheckOutcome.PASSED

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2167,6 +2167,7 @@ dependencies = [
     { name = "pyathena" },
     { name = "setuptools" },
     { name = "soda-core" },
+    { name = "tzdata" },
 ]
 
 [package.metadata]
@@ -2174,6 +2175,7 @@ requires-dist = [
     { name = "pyathena", specifier = ">=2.2.0,<4.0" },
     { name = "setuptools", specifier = ">=60" },
     { name = "soda-core", editable = "soda-core" },
+    { name = "tzdata" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Freshness checks on Athena columns that are `timestamp with time zone` at query time (e.g. Iceberg `timestamptz`) failed with a misleading error:

```
Freshness column 'sys_update_time_utc' returned value 'None' of data type 'NoneType' which is not a datetime or datetime-compatible type.
```

The data was fine — the driver was handing the engine a raw string.

## Root cause

- `MAX()` over such a column has result type `timestamp with time zone`. pyathena only maps that type to a converter since **3.9.0**; on older versions (pinned at 2.25.2 in the contract launcher until v0.1.63) the value falls through to the default converter and reaches the engine as the raw string `'2026-09-01 12:00:00.000 UTC'`.
- The engine's `convert_str_to_datetime` can't parse the zone suffix and returns `None`, and the error message then printed the post-conversion `None` — reading as if the database returned NULL.
- The schema check passes throughout because Athena metadata types are normalized by truncating at the first `(` (`timestamp(6) with time zone` → `timestamp`), so nothing pointed at the type.

## Changes

1. **`LenientTypeConverter` now maps `timestamp with time zone` itself**, so the fix holds on any supported pyathena (`>=2.2.0,<4.0`): named zones, offset zones (pyathena's own converter drops these silently, producing naive datetimes), values with and without fractional seconds. Sub-microsecond fractions (`timestamp(7..9)`) are truncated instead of failing the whole fetch. An unrecognized zone raises a `ValueError` naming the value rather than guessing.
2. **The freshness check reports unparseable strings truthfully**: the error now names the actual received value (`... returned value '2026-09-01 12:00:00.000 UTC' of data type 'str' which could not be parsed as a datetime`) instead of claiming `'None'`/`'NoneType'`.
3. **`soda-athena` now declares `tzdata`**, so region-named zones resolve through `zoneinfo` on images that ship no system IANA database.

## Validation

- New unit tests for both (converter flavors incl. offsets/nanos/unknown zone; freshness message honesty). Full unit suite green (1405 passed).
- Validated against live Athena on pyathena **2.25.2** and **3.35.4**: every timestamp flavor now returns a correct timezone-aware datetime on both.

### 📣 Customer-facing release note

```customer-facing-release-note
Freshness checks on Athena timestamp-with-time-zone columns now evaluate correctly.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKHGpDcwQVq3UgxRfxpvfF
