### PR TITLE
feat(review): add the de-review skill and an advisory Claude review workflow

### DIFF
--- a/.claude/skills/de-review/SKILL.md
+++ b/.claude/skills/de-review/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: de-review
+description: Review a PR against this repository's engine review conventions — the invariants that must hold, the checks that matter per kind of change, and the failure shapes agent-written PRs produce here. Use when asked to review a PR or branch, or to self-check before requesting human review.
+---
+
+# DE review
+
+The engine review for the v4 Python stack. It has a shape: a small set of things worth
+blocking on, a larger set of notes that ship with the approval, and findings that name a
+mechanism rather than a preference. Reproduce the shape, not just the checklist.
+
+Do not summarise the code. Prove things about it.
+
+## Public repositories
+
+`soda-core` is public and a review posted there is world-visible. When reviewing it:
+
+- Never name private repositories, internal packages, customers, or internal ticket IDs.
+- Say "downstream consumers" rather than enumerating them.
+- Every finding must be provable from that repository alone. If a concern depends on code
+  you cannot see, say so and stop there.
+- Do not introduce a reference to anything not already visible in the file under review.
+
+## How to run
+
+1. Get the diff and the PR description (`gh pr diff`, `gh pr view`). Review the claim, not
+   only the code — an unexplained hunk is itself a finding, and a PR body that promises
+   something the diff does not do is a finding too.
+2. Classify twice: by **nature** of the change and by **area** it touches. Run only the
+   lenses and passes that apply — a typo fix does not get an architectural review.
+3. Open changed files at the changed line. **The diff cannot tell you which class a hunk
+   lands in** — `*_data_source.py` holds both the `DataSourceImpl` and the `SqlDialect`,
+   and the hunk header shows the enclosing function, never the class.
+4. Deliver: verdict, findings, and an explicit list of what you did not check.
+
+## Lens by nature
+
+| Nature | What to prove |
+|---|---|
+| **Refactor** | Behavioural equivalence. Show the before/after of the critical path. Surface any behaviour change hiding inside the refactor. |
+| **Bug fix** | The fix addresses the root cause, not the symptom; a test exists that would have caught the original; the scope is tight. |
+| **New subsystem** | It sets a precedent worth copying. Judge it as a template, not only as functionality. |
+| **Prototype** | It demonstrates what it claims. Flag shortcuts that mislead — hardcoded values standing in for real complexity — and anything that would be dangerous if it shipped. |
+| **Dependency change** | The floor is real, not just what the lockfile resolved. CI installs the lock, so a wrong floor never fails here. |
+| **Mixed** | Split into groups and say which lens applies to which files. |
+
+## Passes by area
+
+### Dialect / SQL
+*`sql_dialect.py`, a `*_data_source.py`, anything building SQL.*
+
+- Every dialect that needs this overrides it, and the ones inheriting the base are still
+  correct. The base is the default for every warehouse nobody thought about.
+- Quoting and escaping go through the dialect seam, not the call site. A hard-coded `"` is
+  wrong for MySQL and SQL Server.
+- Warehouse types outside the mapping are handled explicitly. `convert_table_type_to_enum`
+  fails open — anything unrecognised silently becomes `TABLE`.
+- If rendered SQL changed, snapshots were re-recorded rather than the job retried.
+  Snapshot replay is keyed on the SQL text.
+- A CI lane actually exercises this warehouse.
+
+### Core seam
+*A base class or method that subclasses override.*
+
+- The change sits at the right altitude — base or dialect rather than copied into a leaf.
+  This is the most common substantive finding in these repos.
+- Every caller is identified. An override on a method with no caller changes nothing.
+- Downstream consumers cannot misread the result. Older readers ignore fields they do not
+  know, which can turn a stricter check into a silently weaker one.
+- Nothing here duplicates a sibling connector or a base implementation.
+
+### Check semantics
+*Check types, thresholds, outcomes, contract verification.*
+
+- Every field that makes two instances different is in `_get_id_properties()`. Identity
+  keys history: re-key a check and its results are orphaned.
+- The exit code is right — `1` checks failed (a success: the engine did its job), `3`
+  engine or parse error, `4` results not sent.
+- Nothing re-implements what `check_collections` already provides — the framework already
+  gates unmeasured metrics to NOT_EVALUATED and supplies diagnostic defaults.
+- The check cannot pass while reporting the wrong number.
+
+### CI / packaging
+*`.github/`, `pyproject.toml`, `uv.lock`, tbump.*
+
+- The test is collected by a lane, and it fails when the code under test is deleted.
+- The change makes a gap red, rather than only documenting it.
+
+### Outside contribution
+*Author is not a member.*
+
+- The base branch is one that can reach current users.
+- The claim holds for the warehouses named, and no wider.
+- No other open PR fixes the same bug at a different altitude.
+
+## Invariants
+
+Assert these hold; each has been broken before.
+
+- One metric, one Measurement.
+- A metric's identity contains every field that makes two metrics different.
+- A check type registers both halves — YAML parser and impl — through the same registry
+  the built-in check types use.
+- SQL is rendered by the dialect; quoting and escaping go through its seam.
+- Exit `1` is a success. The run fails when the engine could not do its job.
+- Unmeasured metrics give NOT_EVALUATED, never a computed default.
+- Installed means active: any package exposing a `soda.plugins.*` entry point is loaded,
+  and a plugin that fails to load is only a warning.
+- Warn once per cause, not once per row.
+- Snapshots are keyed on SQL text.
+
+## Failure shapes in agent-written PRs
+
+Weight these higher when the PR looks agent-authored.
+
+- Invents warehouse syntax that does not exist — check the function against vendor docs.
+- Copies the neighbouring connector instead of using the shared abstraction.
+- Overrides a plausible but wrong class; the diff cannot show you which one.
+- Patches one check type where the shared derivation was the right place.
+- Flips a capability flag wider than its justification, silently moving which tests run.
+- Matches the strings it expected; unlisted values fail open.
+- Writes tests that survive deleting the code under test, or mock away the thing under test.
+- Bloats READMEs and docstrings.
+- Leaves comments describing what the code used to do.
+
+## Verdict
+
+**Block only on what cannot be fixed after merge:** a warehouse nobody tested, a
+correctness defect, a configuration surface that reaches users, a change that breaks
+downstream consumers. Everything else — altitude, naming, structure, test shape — is a
+note that ships with an approval.
+
+Approve-with-notes is the norm and it is the right default.
+
+## Finding format
+
+For each finding:
+
+- **Claim** — what the code does.
+- **Evidence** — `path:line` plus the mechanism: the input that breaks it, the dialect it
+  is wrong for, the caller that would see the old shape. A finding that names a mechanism
+  gets fixed; a stated preference usually does not.
+- **Assumptions** — what must be true for your claim to hold.
+
+Mark each **blocking** or **note**, and say which are objective (it is wrong) versus
+judgment (I would do it differently).
+
+End with **what I did not check**: tests you could not run, warehouses you have no access
+to, behaviour you cannot determine statically. Never omit uncertainty to appear thorough —
+an honest gap is worth more than a confident guess. Treat an untested changed path as a
+risk, not an aside.
+
+Do not relay a tool's finding without triaging it yourself.

--- a/.claude/skills/de-review/SKILL.md
+++ b/.claude/skills/de-review/SKILL.md
@@ -26,12 +26,16 @@ Do not summarise the code. Prove things about it.
 1. Get the diff and the PR description (`gh pr diff`, `gh pr view`). Review the claim, not
    only the code — an unexplained hunk is itself a finding, and a PR body that promises
    something the diff does not do is a finding too.
-2. Classify twice: by **nature** of the change and by **area** it touches. Run only the
+2. Read the existing review threads before forming findings. A finding that already has a
+   thread, resolved or not, is not raised again; report which earlier findings now look
+   resolved instead.
+3. Classify twice: by **nature** of the change and by **area** it touches. Run only the
    lenses and passes that apply — a typo fix does not get an architectural review.
-3. Open changed files at the changed line. **The diff cannot tell you which class a hunk
+4. Open changed files at the changed line. **The diff cannot tell you which class a hunk
    lands in** — `*_data_source.py` holds both the `DataSourceImpl` and the `SqlDialect`,
    and the hunk header shows the enclosing function, never the class.
-4. Deliver: verdict, findings, and an explicit list of what you did not check.
+5. Deliver in the output format below: suggested verdict, findings, and an explicit list
+   of what you did not check.
 
 ## Lens by nature
 
@@ -86,6 +90,16 @@ Do not summarise the code. Prove things about it.
 - The test is collected by a lane, and it fails when the code under test is deleted.
 - The change makes a gap red, rather than only documenting it.
 
+### Security surface
+*New inputs, credentials, anything that reaches a warehouse or a log.*
+
+- Values from a contract, a data source's own metadata, or user configuration reach SQL
+  as dialect-rendered literals and quoted identifiers, never through string formatting.
+- Credentials stay out of logs, error messages, and diagnostics. A connection failure
+  names the host and the user, never the secret.
+- Data leaving the engine (failed rows, samples, profiled values) is bounded and opt-in.
+  A new path that ships user data outward is a configuration surface that reaches users.
+
 ### Outside contribution
 *Author is not a member.*
 
@@ -130,6 +144,11 @@ correctness defect, a configuration surface that reaches users, a change that br
 downstream consumers. Everything else — altitude, naming, structure, test shape — is a
 note that ships with an approval.
 
+Ask it as a rollback question. Once merged and released, can the change be reverted
+without leaving something behind: re-keyed check identities with orphaned history, a
+payload shape a downstream consumer already stored, snapshots re-recorded against it?
+What a revert cannot undo is what blocks.
+
 Approve-with-notes is the norm and it is the right default.
 
 ## Finding format
@@ -151,3 +170,23 @@ an honest gap is worth more than a confident guess. Treat an untested changed pa
 risk, not an aside.
 
 Do not relay a tool's finding without triaging it yourself.
+
+## Output format
+
+One review per run, findings only. A finding that anchors to a changed line goes inline on
+that line; the rest go in the body. The body:
+
+```
+## DE review
+Suggested verdict: <approve with notes | block>, <one line naming what decides it>
+Earlier findings now resolved: <list, or none>
+
+### Blocking, not anchorable
+- <claim; evidence path:line and mechanism; assumptions>
+
+### What I did not check
+- <tests not run, warehouses without access, changed paths not exercised>
+```
+
+In CI the review is submitted with event COMMENT and a human sets the verdict. Locally the
+same body is the report.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,33 @@ Fixes #
 - [ ] Tests added or updated to cover the change
 - [ ] Documentation updated where relevant
 - [ ] PR title follows the conventional commit format (e.g. `fix(sqlserver): ...`)
+
+## Review checklist
+
+<!-- Keep the sections that apply to this change and delete the rest.
+     The full version, with the reasoning behind each line, is the `de-review`
+     skill: .claude/skills/de-review/SKILL.md -->
+
+**Dialect or SQL rendering**
+- [ ] Every dialect that needs this overrides it; the ones inheriting the base are still correct
+- [ ] Quoting and escaping go through the dialect seam, not the call site
+- [ ] Warehouse types outside the mapping are handled explicitly, not defaulted to `TABLE`
+- [ ] Rendered SQL changed → snapshots re-recorded, not the job retried
+- [ ] A CI lane actually exercises this warehouse
+
+**Core seam or base class**
+- [ ] The change sits at the right altitude — base or dialect, not copied into a leaf
+- [ ] Every caller is identified
+- [ ] Downstream consumers cannot misread the result
+- [ ] Nothing here duplicates a sibling connector or a base implementation
+
+**Check semantics and evaluation**
+- [ ] Every field that makes two instances different is in `_get_id_properties()`
+- [ ] The exit code is right: `1` checks failed, `3` engine error, `4` results not sent
+- [ ] Nothing re-implements what `check_collections` already provides
+- [ ] The check cannot pass while reporting the wrong number
+
+**CI, workflow, packaging**
+- [ ] The test is collected by a lane, and fails when the code under test is deleted
+- [ ] The dependency floor is real, not just what the lockfile resolved
+- [ ] The change makes a gap red, rather than only documenting it

--- a/.github/workflows/claude-de-review.yml
+++ b/.github/workflows/claude-de-review.yml
@@ -14,12 +14,14 @@ name: Claude DE Review
 #     IDs. Keep those rules when editing it.
 #
 #  2. Roughly half of the pull requests here come from forks, and GitHub does not
-#     expose secrets to `pull_request` runs from a fork — so the `agent-review`
-#     label silently does nothing on those. The `@claude-de` comment trigger is the
-#     path that works for fork PRs, because `issue_comment` runs in the base repo
-#     with secrets available. That comment is a deliberate maintainer action on
-#     untrusted code: this job only reads the diff and never executes repository
-#     code, and it must stay that way — do not add a build, install or test step.
+#     expose secrets to `pull_request` runs from a fork, so the label path is
+#     skipped for fork PRs (it would only fail red on the auth step). The
+#     `@claude-de` comment trigger is the path that works for fork PRs, because
+#     `issue_comment` runs in the base repo with secrets available. That comment
+#     is a deliberate maintainer action on untrusted code: this job only reads
+#     the diff and never executes repository code, and it must stay that way.
+#     Do not add a build, install or test step, and keep the tool allow-list
+#     below free of git, package, or test commands.
 
 on:
   pull_request:
@@ -33,7 +35,8 @@ jobs:
     # Comment "@claude-de" on the PR to run it. Restricted to org members so an
     # outside contributor cannot trigger a secret-bearing run on their own code.
     if: |
-      (github.event_name == 'pull_request' && github.event.label.name == 'agent-review') ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'agent-review' &&
+       github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@claude-de') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
@@ -63,18 +66,55 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Review this pull request following the de-review skill
-            (.claude/skills/de-review/SKILL.md). Read that file first, then apply it.
+            (.claude/skills/de-review/SKILL.md). Read that file first, then apply
+            it: its lenses and passes, its invariants, its finding format, and its
+            output format.
 
             This repository is PUBLIC and your review is world-visible. Obey the
-            "This repository is public" section of the skill without exception: no
+            "Public repositories" section of the skill without exception: no
             private repository or package names, no customers, no internal ticket
             IDs, and no findings that depend on code outside this repository.
 
-            Use `gh pr diff` and `gh pr view` for the diff and the PR description.
-            Open changed files at the changed line — the diff alone cannot tell you
-            which class a hunk lands in.
+            CI constraints:
+            - You can read the checkout and the PR; you cannot build, install, or
+              run anything. Every changed path you could not exercise is a gap:
+              list it under "what I did not check".
+            - A human decides the verdict. Phrase yours as a suggested verdict and
+              submit the review with event COMMENT, never APPROVE or
+              REQUEST_CHANGES.
 
-            Submit the result as a pull-request review with inline comments anchored
-            to lines in this PR's diff. Findings must be about the diff, not about
-            pre-existing code. If you have no blocking findings, approve and put the
-            notes in the review body.
+            Submit findings the way a human reviewer does: ONE pull-request review
+            with inline comments, never an issue comment.
+            1. Read earlier reviews first:
+               `gh api repos/${{ github.repository }}/pulls/<PR>/reviews` and
+               `gh api repos/${{ github.repository }}/pulls/<PR>/comments`. Do not
+               re-raise a finding that already has a thread, resolved or not; say
+               in the review body which earlier findings now look resolved.
+            2. `gh pr diff <PR>` and `gh pr view <PR>` for the diff and the
+               description. Open changed files at the changed line; the diff alone
+               cannot tell you which class a hunk lands in. Findings are about the
+               diff, not about pre-existing code.
+            3. Anchor each finding as an inline comment on the changed line it is
+               about (`path` + `line` from the diff, `side` "RIGHT"). Findings that
+               do not anchor to a diff line go in the review body.
+            4. The review body follows the skill's output format: it starts with
+               `## DE review`, then the suggested verdict, the earlier findings
+               that now look resolved, the blocking findings that could not be
+               anchored, and "what I did not check". Findings only; do not list
+               what the PR does well.
+            5. Write the payload to a JSON file and submit everything as one
+               review:
+               `gh api repos/${{ github.repository }}/pulls/<PR>/reviews --input review.json`
+               with shape
+               `{"event": "COMMENT", "body": "...", "comments": [{"path": "...", "line": N, "side": "RIGHT", "body": "..."}]}`.
+               If the API rejects the payload because a comment fails to anchor
+               (HTTP 422), move that finding into the body and submit again.
+            If the diff is clean, submit the review with a one-line body and no
+            inline comments.
+
+          # Bash is off by default in this action and it cannot submit reviews on
+          # its own, so the prompt's steps need these: Read/Glob/Grep read the
+          # checkout (SKILL.md is not in `gh pr diff` on PRs that don't touch it),
+          # Write composes the review JSON payload, `gh api` submits it. Nothing
+          # here executes repository code.
+          claude_args: '--allowed-tools "Read,Glob,Grep,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"'

--- a/.github/workflows/claude-de-review.yml
+++ b/.github/workflows/claude-de-review.yml
@@ -1,0 +1,80 @@
+---
+name: Claude DE Review
+
+# Engine review pass for soda-core. Applies the de-review skill
+# (.claude/skills/de-review/SKILL.md) — the invariants, per-change-type checks and
+# agent failure shapes distilled from this repo's review history.
+#
+# Advisory: it does NOT gate merge. Same shape as sodadata/soda's claude-be-review.yml.
+#
+# THIS REPOSITORY IS PUBLIC. Two consequences:
+#
+#  1. The review output is world-visible. The skill carries explicit rules against
+#     naming private repositories, internal packages, customers or internal ticket
+#     IDs. Keep those rules when editing it.
+#
+#  2. Roughly half of the pull requests here come from forks, and GitHub does not
+#     expose secrets to `pull_request` runs from a fork — so the `agent-review`
+#     label silently does nothing on those. The `@claude-de` comment trigger is the
+#     path that works for fork PRs, because `issue_comment` runs in the base repo
+#     with secrets available. That comment is a deliberate maintainer action on
+#     untrusted code: this job only reads the diff and never executes repository
+#     code, and it must stay that way — do not add a build, install or test step.
+
+on:
+  pull_request:
+    # Works for branches on this repo. For fork PRs use the @claude-de comment.
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  de-review:
+    # Comment "@claude-de" on the PR to run it. Restricted to org members so an
+    # outside contributor cannot trigger a secret-bearing run on their own code.
+    if: |
+      (github.event_name == 'pull_request' && github.event.label.name == 'agent-review') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude-de') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          # This job never pushes; don't leave GITHUB_TOKEN in git config for a
+          # third-party action to read.
+          persist-credentials: false
+
+      - name: Run DE review
+        uses: anthropics/claude-code-action@ff9acae5886d41a99ed4ec14b7dc147d55834722 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Review this pull request following the de-review skill
+            (.claude/skills/de-review/SKILL.md). Read that file first, then apply it.
+
+            This repository is PUBLIC and your review is world-visible. Obey the
+            "This repository is public" section of the skill without exception: no
+            private repository or package names, no customers, no internal ticket
+            IDs, and no findings that depend on code outside this repository.
+
+            Use `gh pr diff` and `gh pr view` for the diff and the PR description.
+            Open changed files at the changed line — the diff alone cannot tell you
+            which class a hunk lands in.
+
+            Submit the result as a pull-request review with inline comments anchored
+            to lines in this PR's diff. Findings must be about the diff, not about
+            pre-existing code. If you have no blocking findings, approve and put the
+            notes in the review body.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 scripts/antlr*.jar
 .antlr
 agents/
-.claude/
+.claude/*
+!.claude/skills/
 .idea/
 .postgres/
 .db2/


### PR DESCRIPTION
Captures the engine review conventions as a skill the team and CI share — the invariants that must hold, the checks that matter per kind of change, and the failure shapes agent-written PRs produce here. Distilled from this repository's own review history.

Adds:

- `.claude/skills/de-review/SKILL.md` — usable locally as `/de-review`
- `.github/workflows/claude-de-review.yml` — advisory, **does not gate merge**
- a review checklist in the PR template
- a `.gitignore` negation so `.claude/skills/` is tracked while local settings stay ignored

Same shape as the review workflows already running in `sodadata/soda`: label-triggered with `agent-review`, `@claude-de` to re-run, action pinned to the same SHA.

## This repository is public

Two consequences, both handled:

**The review output is world-visible.** The skill carries explicit rules against naming private repositories, internal packages, customers or ticket IDs, and requires every finding to be provable from this repository alone. The workflow prompt repeats them. The generator that produces this file fails the build if a private reference appears in it.

**Fork PRs do not get secrets.** GitHub does not pass secrets to `pull_request` runs from a fork, so the `agent-review` label silently does nothing on roughly half the PRs here — which are exactly the outside contributions this is most useful for. The `@claude-de` comment path covers those, because `issue_comment` runs in the base repo. It is gated to `OWNER`/`MEMBER`/`COLLABORATOR` so an outside contributor cannot trigger a secret-bearing run on their own code, and the job reads the diff only. **It must never gain a build, install or test step.**

Net effect: on fork PRs the review is a deliberate maintainer action rather than automatic. Worth agreeing that is the trade we want.

## Before this does anything

`CLAUDE_CODE_OAUTH_TOKEN` needs to be reachable from this repository. `sodadata/soda` has it; this repo does not have it as a repo secret, and I cannot see whether the org secret's visibility covers us.

An `agent-review` label is also needed.

## Source of truth

The skill is generated. Its source lives in soda-punch and is synced with `just de-review-sync` — edit it there, not here. See sodadata/soda-punch#30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CLHBhYAG2CeRten4xSyEv