### PR TITLE
fix(cloud): report failed remote verification as ERROR instead of a passing UNKNOWN

### DIFF
--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -679,6 +679,45 @@ class SodaCloud:
             status=CheckCollectionStatus.UNKNOWN,
         )
 
+        # Capture from the first Cloud call, not from the poll onwards: the errors logged on
+        # the failure paths (permissions, upload, command, poll) have to land in
+        # ``log_records`` for ``get_errors()`` to report them.
+        logs: Logs = Logs()
+        try:
+            verification_result.status = self._verify_contract_on_runner(
+                verification_result=verification_result,
+                contract_yaml_str_original=contract_yaml_str_original,
+                contract_local_file_path=contract_local_file_path,
+                dataset_identifier=dataset_identifier,
+                variables=variables,
+                blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+                publish_results=publish_results,
+                verbose=verbose,
+            )
+        finally:
+            logs.close()
+            verification_result.log_records = logs.get_log_records()
+
+        return verification_result
+
+    def _verify_contract_on_runner(
+        self,
+        verification_result: ContractVerificationResult,
+        contract_yaml_str_original: str,
+        contract_local_file_path: Optional[str],
+        dataset_identifier: DatasetIdentifier,
+        variables: dict[str, str],
+        blocking_timeout_in_minutes: int,
+        publish_results: bool,
+        verbose: bool,
+    ) -> CheckCollectionStatus:
+        """Drive one remote verification and return its status.
+
+        Every path that ends without an outcome from Cloud returns ERROR: the result starts
+        out UNKNOWN, and UNKNOWN reads as a pass to ``has_errors``, ``is_failed`` and the CLI
+        exit code. ``sending_results_to_soda_cloud_failed`` is set on top of that only where
+        Cloud could not be reached or refused the request, which turns exit code 3 into 4.
+        """
         can_publish_and_verify, reason = self.can_publish_and_verify_contract(
             dataset_identifier.data_source_name, dataset_identifier.prefixes, dataset_identifier.dataset_name
         )
@@ -688,12 +727,13 @@ class SodaCloud:
                 verification_result.sending_results_to_soda_cloud_failed = True
             else:
                 logger.error(f"Skipping contract verification because of insufficient permissions: {reason}")
-            return verification_result
+            return CheckCollectionStatus.ERROR
 
         file_id: Optional[str] = self._upload_contract_yaml_file(contract_yaml_str_original)
         if not file_id:
-            logger.critical("Contract wasn't uploaded so skipping sending the results to Soda Cloud")
-            return []
+            logger.error("Contract wasn't uploaded, skipping remote contract verification")
+            verification_result.sending_results_to_soda_cloud_failed = True
+            return CheckCollectionStatus.ERROR
 
         verify_contract_command: dict = {
             "type": "sodaCoreVerifyContract" if publish_results else "sodaCoreTestContract",
@@ -709,36 +749,51 @@ class SodaCloud:
             "verbose": verbose,
             "variables": variables,
         }
-        response: Response = self._execute_command(
+        response: Optional[Response] = self._execute_command(
             command_json_dict=verify_contract_command, request_log_name="verify_contract"
         )
-        response_json: dict = response.json()
-        scan_id: str = response_json.get("scanId")
-
-        if response.status_code != 200:
+        if response is None or response.status_code != 200:
             logger.error("Remote contract verification failed.")
             verification_result.sending_results_to_soda_cloud_failed = True
-            return verification_result
+            return CheckCollectionStatus.ERROR
 
+        response_json: Optional[dict] = _parse_json_dict(response)
+        scan_id: Optional[str] = response_json.get("scanId") if response_json else None
         if not scan_id:
-            logger.warning("Did not receive a Scan ID from Soda Cloud")
-            return verification_result
+            logger.error("Did not receive a Scan ID from Soda Cloud")
+            return CheckCollectionStatus.ERROR
+        verification_result.scan_id = scan_id
 
         scan_is_finished, contract_dataset_cloud_url, scan_status = self._poll_remote_scan_finished(
             scan_id=scan_id, blocking_timeout_in_minutes=blocking_timeout_in_minutes
         )
 
-        verification_result.status = _map_remote_scan_status_to_contract_verification_status(scan_status)
+        self._replay_remote_scan_logs(scan_id)
 
+        if contract_dataset_cloud_url:
+            logger.info(f"See contract dataset on Soda Cloud: {contract_dataset_cloud_url}")
+
+        if not scan_is_finished:
+            logger.error(f"Max retries exceeded. " f"Contract verification did not finish yet.")
+            verification_result.sending_results_to_soda_cloud_failed = True
+            return CheckCollectionStatus.ERROR
+
+        status: CheckCollectionStatus = _map_remote_scan_status_to_contract_verification_status(scan_status)
+        if status is CheckCollectionStatus.ERROR and scan_status is not RemoteScanStatus.COMPLETED_WITH_ERRORS:
+            # canceled, timedOut, failed: the scan ended without evaluating the checks, and the
+            # scan logs Cloud has for it are usually empty, so say what happened here.
+            logger.error(f"Remote contract verification ended in state '{scan_status.value_}' without check results")
+        return status
+
+    def _replay_remote_scan_logs(self, scan_id: str) -> None:
+        """Fetch the scan's logs from Soda Cloud and re-emit them locally, so they reach the
+        console and the active ``Logs`` capture (the verification result's ``log_records``)."""
         logger.debug(f"Asking Soda Cloud the logs of scan {scan_id}")
         logs_response: Response = self._get_scan_logs(scan_id=scan_id)
         logger.debug(f"Soda Cloud responded with {json.dumps(dict(logs_response.headers))}\n{logs_response.text}")
 
-        # Start capturing logs here
-        logs: Logs = Logs()
-
-        response_json: dict = logs_response.json()
-        soda_cloud_log_dicts: list[dict] = response_json.get("content")
+        response_json: Optional[dict] = _parse_json_dict(logs_response)
+        soda_cloud_log_dicts: Optional[list[dict]] = response_json.get("content") if response_json else None
         # TODO implement extra page loading if there are more pages of scan logs....
         # response body: {
         #   "content": [...],
@@ -798,18 +853,6 @@ class SodaCloud:
             logger.debug(f"No logs in Soda Cloud response")
         else:
             logger.debug(f"Expected dict for logs, but was {type(soda_cloud_log_dicts).__name__}")
-
-        if not scan_is_finished:
-            logger.error(f"Max retries exceeded. " f"Contract verification did not finish yet.")
-            verification_result.sending_results_to_soda_cloud_failed = True
-
-        if contract_dataset_cloud_url:
-            logger.info(f"See contract dataset on Soda Cloud: {contract_dataset_cloud_url}")
-
-        logs.close()
-        verification_result.log_records = logs.get_log_records()
-
-        return verification_result
 
     def fetch_contract_for_dataset(self, dataset_identifier: str) -> Optional[str]:
         """Fetch the contract contents for the given dataset identifier.
@@ -2154,18 +2197,29 @@ def _build_threshold_conditions(threshold: Threshold, check_result: CheckResult)
 
 
 def _map_remote_scan_status_to_contract_verification_status(
-    scan_status: RemoteScanStatus,
+    scan_status: Optional[RemoteScanStatus],
 ) -> CheckCollectionStatus:
     if scan_status == RemoteScanStatus.COMPLETED:
         return CheckCollectionStatus.PASSED
     elif scan_status == RemoteScanStatus.COMPLETED_WITH_WARNINGS:
         return CheckCollectionStatus.WARNED
-    elif scan_status in (RemoteScanStatus.COMPLETED_WITH_FAILURES, RemoteScanStatus.FAILED):
+    elif scan_status == RemoteScanStatus.COMPLETED_WITH_FAILURES:
         return CheckCollectionStatus.FAILED
-    elif scan_status in (RemoteScanStatus.COMPLETED_WITH_ERRORS,):
-        return CheckCollectionStatus.ERROR
-    else:
-        return CheckCollectionStatus.UNKNOWN
+    # completedWithErrors: the engine errored. failed: the scan itself failed, which is also
+    # how a runner reports an engine that errored before producing results. canceled and
+    # timedOut: Cloud ended the scan without an outcome. None of these evaluated the checks,
+    # so none may read as a pass, nor ``failed`` as check failures.
+    return CheckCollectionStatus.ERROR
+
+
+def _parse_json_dict(response: Response) -> Optional[dict]:
+    """The response body as a dict, or None when it is not JSON or not an object."""
+    try:
+        body = response.json()
+    except ValueError:
+        logger.debug(f"Soda Cloud response is not JSON: {response.text[:200]}")
+        return None
+    return body if isinstance(body, dict) else None
 
 
 # def _build_diagnostics_column_data_type_mismatches(

--- a/soda-core/src/soda_core/common/soda_cloud.py
+++ b/soda-core/src/soda_core/common/soda_cloud.py
@@ -83,6 +83,10 @@ class RemoteScanStatus(Enum):
         raise ValueError(f"Unknown RemoteScanStatus value: {value}")
 
 
+# Seconds between two status polls when Soda Cloud does not suggest a next poll time.
+_DEFAULT_POLL_INTERVAL_SECONDS: float = 5
+
+
 class MigrationStatus(Enum):
     CREATED = "created"
     GENERATING_CONTRACTS = "generatingContracts"
@@ -623,7 +627,7 @@ class SodaCloud:
         response: Response = self._execute_query(
             query_json_dict=dataset_responsibilities_query, request_log_name="can_manage_contracts"
         )
-        if not response.status_code == 200:  # TODO: should this also not be a critical issue causing the scan to fail?
+        if response is None or response.status_code != 200:
             return False, None
         response_json: dict = response.json()
         if not isinstance(response_json, dict):
@@ -694,6 +698,12 @@ class SodaCloud:
                 publish_results=publish_results,
                 verbose=verbose,
             )
+        except Exception as e:
+            # Caught inside the capture window: the traceback joins the records logged
+            # before it, and the result keeps its dataset identity instead of being
+            # replaced by a bare placeholder further up.
+            logger.error(f"Remote contract verification failed: {e}", exc_info=True)
+            verification_result.status = CheckCollectionStatus.ERROR
         finally:
             logs.close()
             verification_result.log_records = logs.get_log_records()
@@ -768,21 +778,26 @@ class SodaCloud:
             scan_id=scan_id, blocking_timeout_in_minutes=blocking_timeout_in_minutes
         )
 
-        self._replay_remote_scan_logs(scan_id)
+        try:
+            self._replay_remote_scan_logs(scan_id)
+        except Exception as e:
+            # The replay is informational. A hiccup fetching the logs must not turn the
+            # outcome Cloud already reported into an error.
+            logger.warning(f"Could not fetch the logs of scan {scan_id} from Soda Cloud: {e}")
 
         if contract_dataset_cloud_url:
             logger.info(f"See contract dataset on Soda Cloud: {contract_dataset_cloud_url}")
 
         if not scan_is_finished:
-            logger.error(f"Max retries exceeded. " f"Contract verification did not finish yet.")
+            logger.error("Max retries exceeded. Contract verification did not finish yet.")
             verification_result.sending_results_to_soda_cloud_failed = True
             return CheckCollectionStatus.ERROR
 
         status: CheckCollectionStatus = _map_remote_scan_status_to_contract_verification_status(scan_status)
-        if status is CheckCollectionStatus.ERROR and scan_status is not RemoteScanStatus.COMPLETED_WITH_ERRORS:
-            # canceled, timedOut, failed: the scan ended without evaluating the checks, and the
-            # scan logs Cloud has for it are usually empty, so say what happened here.
-            logger.error(f"Remote contract verification ended in state '{scan_status.value_}' without check results")
+        if status is CheckCollectionStatus.ERROR:
+            # Say what happened here as well: for canceled, timedOut and failed the scan logs
+            # Cloud has are usually empty, and get_errors() must never be empty on ERROR.
+            logger.error(f"Remote contract verification ended in state '{scan_status.value_}'")
         return status
 
     def _replay_remote_scan_logs(self, scan_id: str) -> None:
@@ -1247,27 +1262,41 @@ class SodaCloud:
             logger.debug(
                 f"Asking Soda Cloud if scan {scan_id} is already completed. Attempt {attempt}. Max wait: {max_wait}"
             )
-            response = self._get_scan_status(scan_id)
-            logger.debug(f"Soda Cloud responded with {json.dumps(dict(response.headers))}\n{response.text}")
+            try:
+                response = self._get_scan_status(scan_id)
+                logger.debug(f"Soda Cloud responded with {json.dumps(dict(response.headers))}\n{response.text}")
+            except Exception as e:
+                logger.warning(f"Failed to poll the status of scan {scan_id}, retrying: {e}")
+                sleep(_DEFAULT_POLL_INTERVAL_SECONDS)
+                continue
             if not response:
-                logger.error(f"Failed to poll remote scan status. " f"Response: {response}")
+                logger.warning(f"Failed to poll the status of scan {scan_id}, retrying. Response: {response}")
+                sleep(_DEFAULT_POLL_INTERVAL_SECONDS)
                 continue
 
-            response_body_dict: Optional[dict] = response.json() if response else None
+            response_body_dict: Optional[dict] = _parse_json_dict(response)
             contract_dataset_cloud_url: Optional[str] = (
                 response_body_dict.get("contractDatasetCloudUrl") if response_body_dict else None
             )
 
-            if "state" not in response_body_dict:
-                continue
-            scan_state = RemoteScanStatus.from_value(response_body_dict["state"])
+            state_value: Optional[str] = response_body_dict.get("state") if response_body_dict else None
+            scan_state: Optional[RemoteScanStatus] = None
+            if state_value is None:
+                logger.warning(f"Status response for scan {scan_id} carries no state, retrying")
+            else:
+                try:
+                    scan_state = RemoteScanStatus.from_value(state_value)
+                except ValueError:
+                    # A state this client does not know is treated as not final: keep polling
+                    # until Cloud reports one it does know, or the deadline passes.
+                    logger.warning(f"Scan {scan_id} has unknown state '{state_value}', treating it as not final")
 
-            logger.info(f"Scan {scan_id} has state '{scan_state.value_}'")
+            if scan_state is not None:
+                logger.info(f"Scan {scan_id} has state '{scan_state.value_}'")
+                if scan_state.is_final_state:
+                    return True, contract_dataset_cloud_url, scan_state
 
-            if scan_state.is_final_state:
-                return True, contract_dataset_cloud_url, scan_state
-
-            time_to_wait_in_seconds: float = 5
+            time_to_wait_in_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS
             next_poll_time_str = response.headers.get("X-Soda-Next-Poll-Time")
             if next_poll_time_str:
                 logger.debug(

--- a/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
+++ b/soda-core/src/soda_core/contracts/impl/contract_verification_impl.py
@@ -448,8 +448,12 @@ class ContractVerificationSessionImpl:
                         contract_verification_result.log_records or []
                     )
                 contract_verification_results.append(contract_verification_result)
-            except:
+            except Exception as exc:
                 logger.error(msg=f"Could not verify contract {contract_yaml_source}", exc_info=True)
+                # Same per-item isolation as the local path: keep an ERROR placeholder for the
+                # item. Dropping it left the session without a result, and an empty session
+                # reads as a pass.
+                contract_verification_results.append(ContractImpl.build_error_result(contract_yaml_source, exc))
         return contract_verification_results
 
     @classmethod

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -9,6 +9,8 @@ from helpers.data_source_test_helper import DataSourceTestHelper
 from helpers.dict_helpers import assert_dict, matcher_string_contains
 from helpers.mock_soda_cloud import MockHttpMethod, MockRequest, MockResponse, MockSodaCloud
 from helpers.test_table import TestTableSpecification
+from soda_core.cli.exit_codes import ExitCode
+from soda_core.cli.handlers.contract import interpret_contract_verification_result
 from soda_core.common.data_source_impl import DataSourceImpl
 from soda_core.common.dataset_identifier import DatasetIdentifier
 from soda_core.common.datetime_conversions import convert_datetime_to_str
@@ -32,6 +34,8 @@ from soda_core.contracts.contract_verification import (
     CheckOutcome,
     CheckResult,
     ContractVerificationResult,
+    ContractVerificationSessionResult,
+    ContractVerificationStatus,
     PostProcessingStage,
     PostProcessingStageState,
     ScanTokenUsage,
@@ -40,6 +44,7 @@ from soda_core.contracts.impl.contract_verification_impl import (
     ContractImpl,
     ContractVerificationHandler,
     ContractVerificationHandlerRegistry,
+    ContractVerificationSessionImpl,
 )
 from soda_core.contracts.impl.contract_yaml import ContractYaml
 from soda_core.contracts.impl.diagnostics_warehouse_files import DiagnosticsWarehouseFiles
@@ -642,7 +647,9 @@ def test_verify_contract_on_runner_permission_check():
     assert res.check_collection.dataset_prefix == ["some", "schema"]
     assert res.check_results == []
     assert res.measurements == []
-    assert res.log_records is None
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.has_errors
+    assert any("insufficient permissions" in error for error in res.get_errors())
 
 
 def test_verify_contract_on_agent_permission_check_deprecated():
@@ -682,7 +689,9 @@ def test_verify_contract_on_agent_permission_check_deprecated():
     assert res.contract.dataset_prefix == ["some", "schema"]
     assert res.check_results == []
     assert res.measurements == []
-    assert res.log_records is None
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.has_errors
+    assert any("insufficient permissions" in error for error in res.get_errors())
 
 
 @mock.patch("requests.post")
@@ -1118,3 +1127,185 @@ def test_execute_dataset_query_non_json_error_body_raises_soda_cloud_exception_n
 def test_execute_dataset_query_non_json_200_body_returns_empty_dict():
     soda_cloud = _soda_cloud_with_query_response(_query_response(200, json_raises=True))
     assert soda_cloud.execute_dataset_query("sodaCoreGetSomething", "postgres_ds/public/orders", "get_something") == {}
+
+
+# ---- verify_contract_on_runner: every path without an outcome from Cloud must be ERROR ----
+
+_RUNNER_CONTRACT_YAML = """
+dataset: test/some/schema/CUSTOMERS
+columns:
+- name: id
+"""
+
+
+def _runner_allowed() -> MockResponse:
+    return MockResponse(status_code=200, json_object={"allowed": True})
+
+
+def _runner_uploaded() -> MockResponse:
+    return MockResponse(method=MockHttpMethod.POST, status_code=200, json_object={"fileId": "fffileid"})
+
+
+def _runner_scan_created() -> MockResponse:
+    return MockResponse(method=MockHttpMethod.POST, status_code=200, json_object={"scanId": "ssscanid"})
+
+
+def _runner_scan_state(state: str) -> MockResponse:
+    return MockResponse(
+        method=MockHttpMethod.GET,
+        status_code=200,
+        json_object={
+            "scanId": "ssscanid",
+            "state": state,
+            "contractDatasetCloudUrl": "https://the-contract-dataset-url",
+        },
+    )
+
+
+def _runner_scan_logs() -> MockResponse:
+    return MockResponse(
+        method=MockHttpMethod.GET,
+        status_code=200,
+        json_object={
+            "content": [],
+            "totalElements": 0,
+            "totalPages": 1,
+            "number": 0,
+            "size": 0,
+            "last": True,
+            "first": True,
+        },
+    )
+
+
+def _verify_on_runner(
+    responses: list[MockResponse], blocking_timeout_in_minutes: int = 60
+) -> ContractVerificationResult:
+    return MockSodaCloud(responses).verify_contract_on_runner(
+        ContractYaml.parse(ContractYamlSource.from_str(_RUNNER_CONTRACT_YAML)),
+        variables={},
+        blocking_timeout_in_minutes=blocking_timeout_in_minutes,
+        publish_results=False,
+        verbose=False,
+    )
+
+
+def _exit_code(result: ContractVerificationResult) -> ExitCode:
+    return interpret_contract_verification_result(ContractVerificationSessionResult([result]))
+
+
+def test_verify_contract_on_runner_permission_query_failed():
+    res = _verify_on_runner([MockResponse(status_code=500, json_object={})])
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.has_errors
+    assert res.sending_results_to_soda_cloud_failed is True
+    assert _exit_code(res) == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+def test_verify_contract_on_runner_upload_failed_returns_error_result():
+    res = _verify_on_runner(
+        [_runner_allowed(), MockResponse(method=MockHttpMethod.POST, status_code=500, json_object={})]
+    )
+
+    assert isinstance(res, ContractVerificationResult)
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.sending_results_to_soda_cloud_failed is True
+    assert _exit_code(res) == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+def test_verify_contract_on_runner_verify_command_failed():
+    res = _verify_on_runner(
+        [
+            _runner_allowed(),
+            _runner_uploaded(),
+            MockResponse(method=MockHttpMethod.POST, status_code=500, json_object={}),
+        ]
+    )
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.sending_results_to_soda_cloud_failed is True
+    assert _exit_code(res) == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+def test_verify_contract_on_runner_without_scan_id():
+    res = _verify_on_runner(
+        [
+            _runner_allowed(),
+            _runner_uploaded(),
+            MockResponse(method=MockHttpMethod.POST, status_code=200, json_object={}),
+        ]
+    )
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.has_errors
+    assert res.sending_results_to_soda_cloud_failed is False
+    assert any("Scan ID" in error for error in res.get_errors())
+    assert _exit_code(res) == ExitCode.LOG_ERRORS
+
+
+def test_verify_contract_on_runner_poll_timeout():
+    res = _verify_on_runner(
+        [_runner_allowed(), _runner_uploaded(), _runner_scan_created(), _runner_scan_logs()],
+        blocking_timeout_in_minutes=0,
+    )
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.sending_results_to_soda_cloud_failed is True
+    assert any("did not finish" in error for error in res.get_errors())
+    assert _exit_code(res) == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+@pytest.mark.parametrize(
+    "state, expected_status, expected_exit_code",
+    [
+        ("completed", ContractVerificationStatus.PASSED, ExitCode.OK),
+        ("completedWithWarnings", ContractVerificationStatus.WARNED, ExitCode.CHECK_WARNINGS),
+        ("completedWithFailures", ContractVerificationStatus.FAILED, ExitCode.CHECK_FAILURES),
+        ("completedWithErrors", ContractVerificationStatus.ERROR, ExitCode.LOG_ERRORS),
+        ("failed", ContractVerificationStatus.ERROR, ExitCode.LOG_ERRORS),
+        ("canceled", ContractVerificationStatus.ERROR, ExitCode.LOG_ERRORS),
+        ("timedOut", ContractVerificationStatus.ERROR, ExitCode.LOG_ERRORS),
+    ],
+)
+def test_verify_contract_on_runner_final_state(state, expected_status, expected_exit_code):
+    res = _verify_on_runner(
+        [
+            _runner_allowed(),
+            _runner_uploaded(),
+            _runner_scan_created(),
+            _runner_scan_state(state),
+            _runner_scan_logs(),
+        ]
+    )
+
+    assert res.status is expected_status
+    assert res.scan_id == "ssscanid"
+    assert res.sending_results_to_soda_cloud_failed is False
+    assert _exit_code(res) == expected_exit_code
+    if state in ("failed", "canceled", "timedOut"):
+        assert any(f"'{state}'" in error for error in res.get_errors())
+
+
+def test_execute_on_runner_isolates_exceptions_as_error_results(monkeypatch):
+    mock_cloud = MockSodaCloud([])
+
+    def raise_boom(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mock_cloud, "verify_contract_on_runner", raise_boom)
+
+    results = ContractVerificationSessionImpl._execute_on_runner(
+        contract_yaml_sources=[ContractYamlSource.from_str(_RUNNER_CONTRACT_YAML)],
+        variables={},
+        soda_cloud_impl=mock_cloud,
+        soda_cloud_use_runner_blocking_timeout_in_minutes=60,
+        soda_cloud_publish_results=False,
+        soda_cloud_verbose=False,
+    )
+
+    assert len(results) == 1
+    assert results[0].status is ContractVerificationStatus.ERROR
+    assert isinstance(results[0].error, RuntimeError)
+    assert any("boom" in error for error in results[0].get_errors())
+    assert _exit_code(results[0]) == ExitCode.LOG_ERRORS

--- a/soda-tests/tests/unit/test_soda_cloud.py
+++ b/soda-tests/tests/unit/test_soda_cloud.py
@@ -1178,16 +1178,20 @@ def _runner_scan_logs() -> MockResponse:
     )
 
 
-def _verify_on_runner(
-    responses: list[MockResponse], blocking_timeout_in_minutes: int = 60
-) -> ContractVerificationResult:
-    return MockSodaCloud(responses).verify_contract_on_runner(
+def _verify_on_runner_with(cloud: MockSodaCloud, blocking_timeout_in_minutes: int = 60) -> ContractVerificationResult:
+    return cloud.verify_contract_on_runner(
         ContractYaml.parse(ContractYamlSource.from_str(_RUNNER_CONTRACT_YAML)),
         variables={},
         blocking_timeout_in_minutes=blocking_timeout_in_minutes,
         publish_results=False,
         verbose=False,
     )
+
+
+def _verify_on_runner(
+    responses: list[MockResponse], blocking_timeout_in_minutes: int = 60
+) -> ContractVerificationResult:
+    return _verify_on_runner_with(MockSodaCloud(responses), blocking_timeout_in_minutes)
 
 
 def _exit_code(result: ContractVerificationResult) -> ExitCode:
@@ -1283,7 +1287,7 @@ def test_verify_contract_on_runner_final_state(state, expected_status, expected_
     assert res.scan_id == "ssscanid"
     assert res.sending_results_to_soda_cloud_failed is False
     assert _exit_code(res) == expected_exit_code
-    if state in ("failed", "canceled", "timedOut"):
+    if expected_status is ContractVerificationStatus.ERROR:
         assert any(f"'{state}'" in error for error in res.get_errors())
 
 
@@ -1309,3 +1313,100 @@ def test_execute_on_runner_isolates_exceptions_as_error_results(monkeypatch):
     assert isinstance(results[0].error, RuntimeError)
     assert any("boom" in error for error in results[0].get_errors())
     assert _exit_code(results[0]) == ExitCode.LOG_ERRORS
+
+
+def test_verify_contract_on_runner_permission_query_unreachable(monkeypatch):
+    mock_cloud = MockSodaCloud([])
+
+    def raise_connection_error(*args, **kwargs):
+        raise ConnectionError("cloud down")
+
+    monkeypatch.setattr(mock_cloud, "_http_post", raise_connection_error)
+
+    res = _verify_on_runner_with(mock_cloud)
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.sending_results_to_soda_cloud_failed is True
+    assert _exit_code(res) == ExitCode.RESULTS_NOT_SENT_TO_CLOUD
+
+
+def test_verify_contract_on_runner_keeps_result_when_the_path_raises(monkeypatch):
+    mock_cloud = MockSodaCloud([_runner_allowed(), _runner_uploaded(), _runner_scan_created()])
+
+    def raise_boom(**kwargs):
+        raise RuntimeError("boom while polling")
+
+    monkeypatch.setattr(mock_cloud, "_poll_remote_scan_finished", raise_boom)
+
+    res = _verify_on_runner_with(mock_cloud)
+
+    assert res.status is ContractVerificationStatus.ERROR
+    assert res.check_collection.dataset_name == "CUSTOMERS"
+    assert res.scan_id == "ssscanid"
+    assert any("boom while polling" in error for error in res.get_errors())
+    assert _exit_code(res) == ExitCode.LOG_ERRORS
+
+
+def test_verify_contract_on_runner_survives_log_fetch_failure(monkeypatch):
+    mock_cloud = MockSodaCloud(
+        [_runner_allowed(), _runner_uploaded(), _runner_scan_created(), _runner_scan_state("completed")]
+    )
+
+    def raise_connection_error(**kwargs):
+        raise ConnectionError("logs endpoint down")
+
+    monkeypatch.setattr(mock_cloud, "_get_scan_logs", raise_connection_error)
+
+    res = _verify_on_runner_with(mock_cloud)
+
+    assert res.status is ContractVerificationStatus.PASSED
+    assert not res.has_errors
+    assert any("logs endpoint down" in warning for warning in res.get_warnings())
+    assert _exit_code(res) == ExitCode.OK
+
+
+def test_verify_contract_on_runner_keeps_polling_through_unknown_state(monkeypatch):
+    monkeypatch.setattr("soda_core.common.soda_cloud.sleep", lambda seconds: None)
+
+    res = _verify_on_runner(
+        [
+            _runner_allowed(),
+            _runner_uploaded(),
+            _runner_scan_created(),
+            _runner_scan_state("started"),
+            _runner_scan_state("completed"),
+            _runner_scan_logs(),
+        ]
+    )
+
+    assert res.status is ContractVerificationStatus.PASSED
+    assert any("unknown state 'started'" in warning for warning in res.get_warnings())
+
+
+def test_verify_contract_on_runner_keeps_polling_through_status_request_failure(monkeypatch):
+    monkeypatch.setattr("soda_core.common.soda_cloud.sleep", lambda seconds: None)
+    mock_cloud = MockSodaCloud(
+        [
+            _runner_allowed(),
+            _runner_uploaded(),
+            _runner_scan_created(),
+            _runner_scan_state("completed"),
+            _runner_scan_logs(),
+        ]
+    )
+    original_get_scan_status = mock_cloud._get_scan_status
+    calls = {"count": 0}
+
+    def flaky_get_scan_status(scan_id):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ConnectionError("connection reset by peer")
+        return original_get_scan_status(scan_id)
+
+    monkeypatch.setattr(mock_cloud, "_get_scan_status", flaky_get_scan_status)
+
+    res = _verify_on_runner_with(mock_cloud)
+
+    assert res.status is ContractVerificationStatus.PASSED
+    assert calls["count"] == 2
+    assert any("retrying" in warning for warning in res.get_warnings())


### PR DESCRIPTION
## Description

Reported internally on 2026-09-02: when a contract is verified on a Runner with `--use-runner` and something goes wrong, the result says everything is fine. `has_errors`, `is_failed` and `get_errors()` come back false, and the CLI exits 0.

Root cause. `verify_contract_on_runner` leaves the result's status at its initial `UNKNOWN` on every path that ends without an outcome from Cloud, and `has_errors` is `status is ERROR`. The remote-state mapper knows four of Cloud's seven final states, so `canceled` and `timedOut` fell through to `UNKNOWN`, and `failed` mapped to check failures. The local error logs never reached `log_records` either, because capture only started after polling. On top of that, the runner loop in the session wrapped the call in a bare `except:` that dropped the item, so an exception left an empty session, which also reads as a pass.

What a CI caller saw before, and sees now. Exit codes via `interpret_contract_verification_result`:

| condition | before | after |
|---|---|---|
| insufficient permissions | 0 | 3 |
| 200 without a scan id | 0 | 3 |
| Cloud state `canceled` or `timedOut` | 0 | 3 |
| exception on the path | 0, empty session | 3, result kept with its logs |
| Cloud state `failed` | 1, read as check failures | 3 |
| contract upload failed | AttributeError, the method returned `[]` | 4 |
| permission query or verify command could not be sent | AttributeError on `None`, or 0 | 4 |
| permission query or verify command non-200, client poll timeout | 4, no errors on the result | 4, errors on the result |

Changes:

- Every path without an outcome returns `ERROR`. The send flag stays where Cloud could not be reached or refused the request, so those still exit 4.
- `canceled`, `timedOut` and `failed` map to `ERROR` and log why. `failed` no longer reads as check failures. It is also how a runner reports an engine that errored before producing results.
- `Logs()` capture starts before the first Cloud call, so `get_errors()` reports the failure. Every ERROR-mapped state logs a line, so `get_errors()` is never empty on exit 3.
- A failed upload returns a result instead of `[]`.
- An exception on the path is caught inside the capture window: the result keeps its dataset identity, scan id and the records logged before the raise. `_execute_on_runner` keeps an ERROR placeholder for parse and construct failures, the way the local path does.
- The log replay is guarded. A hiccup fetching logs does not change the outcome Cloud already reported.
- The status poll survives a transient request failure, an unknown state string, and a body without a state. All three are treated as not final and polling continues with the usual wait.
- A permission query that could not be sent takes the send-flag branch instead of raising on `None`.
- Non-JSON bodies from the command, status and logs endpoints no longer raise.

The existing `test_verify_contract_on_runner_permission_check` pinned the silent behaviour by asserting `log_records is None`. It now asserts the error. New tests cover each path and the exit code it maps to.

Unchanged on purpose: the client-side poll timeout keeps exit 4.

Docs: sodadata/docs#1045 adds the exit-code table to the core CLI reference.

## Checklist

- [x] Tests added or updated to cover the change
- [x] Documentation updated where relevant
- [x] PR title follows the conventional commit format

## Review checklist

**Check semantics and evaluation**
- [x] The exit code is right: `1` checks failed, `3` engine error, `4` results not sent

**Core seam or base class**
- [x] Every caller is identified: `ContractImpl.verify_on_runner` is the only call site, reached from `_execute_on_runner`, plus the deprecated `verify_contract_on_agent` and `verify_on_agent` aliases
- [x] Downstream consumers cannot misread the result

### 📣 Customer-facing release note

```customer-facing-release-note
Verifying a contract on a runner now reports an error when the scan cannot complete.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChwRG6RQYKhsg5QFJhtdCN
