### PR TITLE
fix(bigquery): make time partition filters eligible for partition elimination

### DIFF
--- a/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
+++ b/soda-bigquery/src/soda_bigquery/common/data_sources/bigquery_data_source.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Optional
 
 from soda_bigquery.common.data_sources.bigquery_data_source_connection import (
@@ -269,14 +270,19 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         quantile_number: int = int(percentile_within_group.percentile * 1000)
         return f"APPROX_QUANTILES({expression_sql}, 1000)[{quantile_number}]"
 
-    # Singular unit names for TIMESTAMP_DIFF/TIMESTAMP_ADD. WEEK is deliberately
-    # absent: BigQuery's TIMESTAMP functions only accept MICROSECOND..DAY parts
-    # (WEEK is a DATE_DIFF/DATETIME_DIFF-only part), so weekly arithmetic
-    # renders day-denominated in both builders below.
+    # Singular unit names for DATETIME_ADD. WEEK is deliberately absent: weekly
+    # arithmetic renders day-denominated in both builders below, keeping
+    # cross-dialect bucket indexes identical.
     _TIME_BUCKET_UNIT_NAMES: dict = {
         "days": "DAY",
         "hours": "HOUR",
         "seconds": "SECOND",
+    }
+
+    _TIME_BUCKET_UNIT_MICROSECONDS: dict = {
+        "days": 86_400_000_000,
+        "hours": 3_600_000_000,
+        "seconds": 1_000_000,
     }
 
     def _build_time_delta_sql(self, time_delta: TIME_DELTA) -> str:
@@ -287,20 +293,21 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         unit, count = time_delta.unit, time_delta.count
         if unit == "weeks":
             unit, count = "days", count * 7
-        unit_name: str = self._TIME_BUCKET_UNIT_NAMES[unit]
-        sql: str = f"TIMESTAMP_DIFF({end_sql}, {start_sql}, {unit_name})"
-        if count != 1:
-            sql = f"CAST(FLOOR({sql} / {count}) AS INT)"
-        return sql
+        # Elapsed MICROSECONDs floor-divided by the unit size: DATETIME_DIFF at
+        # DAY/HOUR counts calendar-boundary crossings (a 2h span across midnight
+        # is 1 DAY), which would mis-bucket grids anchored off midnight.
+        unit_microseconds: int = self._TIME_BUCKET_UNIT_MICROSECONDS[unit] * count
+        sql: str = f"DATETIME_DIFF({end_sql}, {start_sql}, MICROSECOND)"
+        return f"CAST(FLOOR({sql} / {unit_microseconds}) AS INT)"
 
     def _build_add_interval_sql(self, add_interval: ADD_INTERVAL) -> str:
         timestamp_sql: str = self.build_expression_sql(add_interval.timestamp)
         count_sql: str = self.build_expression_sql(add_interval.count_expression)
         # Weekly intervals render as INTERVAL <count> * 7 DAY.
         if add_interval.unit == "weeks":
-            return f"TIMESTAMP_ADD({timestamp_sql}, INTERVAL {count_sql} * 7 DAY)"
+            return f"DATETIME_ADD({timestamp_sql}, INTERVAL {count_sql} * 7 DAY)"
         unit_name: str = self._TIME_BUCKET_UNIT_NAMES[add_interval.unit]
-        return f"TIMESTAMP_ADD({timestamp_sql}, INTERVAL {count_sql} {unit_name})"
+        return f"DATETIME_ADD({timestamp_sql}, INTERVAL {count_sql} {unit_name})"
 
     def supports_data_type_character_maximum_length(self) -> bool:
         return False
@@ -356,10 +363,28 @@ class BigQuerySqlDialect(SqlDialect, sqlglot_dialect="bigquery"):
         return f"timestamp('{datetime_in_iso8601}')"
 
     def sql_expr_timestamp_coerce(self, expr: str) -> str:
-        # BigQuery coerces bare string comparison literals to the column's type, and an
-        # ISO string with a UTC offset cannot cast to DATETIME. Wrapping the column makes
-        # both sides TIMESTAMP-typed.
-        return f"timestamp({expr})"
+        # CAST, not the timestamp() constructor: only CAST on the partitioning column is
+        # accepted for partition elimination (a function wrap full-scans, and tables with
+        # require_partition_filter reject the query outright). DATETIME as the target
+        # because the cast compiles for DATE, DATETIME and TIMESTAMP expressions alike,
+        # converting TIMESTAMP -> DATETIME at UTC; literal_datetime renders the matching
+        # offset-less UTC bounds.
+        return f"CAST({expr} AS DATETIME)"
+
+    def literal_datetime(self, dt: datetime) -> str:
+        # Offset-less UTC: an offset-carrying ISO string cannot coerce to a DATETIME
+        # column, nor to the coerce hook's CAST(... AS DATETIME). Stays untyped so it
+        # still coerces to TIMESTAMP columns (e.g. INFORMATION_SCHEMA.JOBS.end_time).
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return f"'{dt.isoformat()}'"
+
+    def literal_timestamp_typed(self, dt: datetime) -> str:
+        # Untyped: BigQuery coerces string literals inside DATETIME_DIFF/DATETIME_ADD
+        # (the anchor positions) AND against raw TIMESTAMP/DATETIME columns in
+        # user-authored custom metric SQL, where a typed DATETIME literal breaks the
+        # 'col BETWEEN ${soda.PARTITION_START_TIME} ...' pattern on TIMESTAMP columns.
+        return f"'{self._typed_timestamp_str(dt)}'"
 
     def sql_expr_timestamp_truncate_day(self, timestamp_literal: str) -> str:
         return f"date_trunc(timestamp({timestamp_literal}), day)"

--- a/soda-bigquery/tests/unit/test_bigquery_dialect.py
+++ b/soda-bigquery/tests/unit/test_bigquery_dialect.py
@@ -195,8 +195,36 @@ def test_get_large_numeric_cast_type_name_is_numeric():
     assert BigQuerySqlDialect().get_large_numeric_cast_type_name() == "NUMERIC"
 
 
-def test_sql_expr_timestamp_coerce_wraps_in_timestamp():
-    assert BigQuerySqlDialect().sql_expr_timestamp_coerce("`dt`") == "timestamp(`dt`)"
+def test_sql_expr_timestamp_coerce_wraps_in_pruning_safe_datetime_cast():
+    # timestamp(expr) is not accepted for partition elimination (tables with
+    # require_partition_filter reject the query); CAST(... AS DATETIME) is, and it
+    # compiles for DATE, DATETIME and TIMESTAMP expressions alike.
+    assert BigQuerySqlDialect().sql_expr_timestamp_coerce("`dt`") == "CAST(`dt` AS DATETIME)"
+
+
+def test_literal_datetime_aware_normalizes_to_utc_and_drops_offset():
+    # An offset-carrying ISO string cannot coerce to a DATETIME column, and the
+    # coerce hook makes the compared expression DATETIME-typed.
+    from datetime import datetime, timedelta, timezone
+
+    aware = datetime(2026, 8, 18, 2, 5, tzinfo=timezone(timedelta(hours=2)))
+    assert BigQuerySqlDialect().literal_datetime(aware) == "'2026-08-18T00:05:00'"
+
+
+def test_literal_datetime_naive_renders_unchanged():
+    from datetime import datetime
+
+    assert BigQuerySqlDialect().literal_datetime(datetime(2020, 6, 20)) == "'2020-06-20T00:00:00'"
+
+
+def test_literal_timestamp_typed_renders_untyped_string():
+    # Untyped on BigQuery: string literals coerce inside DATETIME_DIFF/DATETIME_ADD (the anchor
+    # positions) AND against raw TIMESTAMP/DATETIME columns in user-authored custom metric SQL,
+    # where a typed DATETIME literal breaks the 'col BETWEEN ${soda.PARTITION_START_TIME} ...'
+    # pattern on TIMESTAMP columns.
+    from datetime import datetime
+
+    assert BigQuerySqlDialect().literal_timestamp_typed(datetime(2020, 6, 20)) == "'2020-06-20 00:00:00'"
 
 
 # ---------------------------------------------------------------------------
@@ -227,13 +255,16 @@ def test_percentile_within_group_renders_approx_quantiles_q3():
 
 
 # ---------------------------------------------------------------------------
-# TIME_DELTA / ADD_INTERVAL — metric-monitoring time-bucket nodes:
-# TIMESTAMP_DIFF with singular unit names + CAST(FLOOR(../count) AS INT) when
-# count != 1; TIMESTAMP_ADD with an INTERVAL taking the count expression.
+# TIME_DELTA / ADD_INTERVAL — metric-monitoring time-bucket nodes.
+# DATETIME (not TIMESTAMP) arithmetic so the operands match the coerce hook's
+# CAST(... AS DATETIME). The delta measures elapsed MICROSECONDs floor-divided
+# by the unit size: DATETIME_DIFF at DAY/HOUR counts calendar-boundary
+# crossings (a 2h span across midnight is 1 DAY), which would mis-bucket grids
+# anchored off midnight.
 # ---------------------------------------------------------------------------
 
 
-def test_time_delta_renders_timestamp_diff_singular_unit():
+def test_time_delta_measures_elapsed_microseconds_per_day():
     from datetime import datetime
 
     from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
@@ -241,10 +272,10 @@ def test_time_delta_renders_timestamp_diff_singular_unit():
     sql = BigQuerySqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "days", 1)
     )
-    assert sql == "TIMESTAMP_DIFF((`ts`), '2020-06-20T00:00:00', DAY)"
+    assert sql == "CAST(FLOOR(DATETIME_DIFF((`ts`), '2020-06-20T00:00:00', MICROSECOND) / 86400000000) AS INT)"
 
 
-def test_time_delta_timestamp_diff_count_2_wraps_cast_floor():
+def test_time_delta_count_2_hours_divides_by_double_unit_size():
     from datetime import datetime
 
     from soda_core.common.sql_ast import LITERAL, TIME_DELTA, SqlExpressionStr
@@ -252,10 +283,10 @@ def test_time_delta_timestamp_diff_count_2_wraps_cast_floor():
     sql = BigQuerySqlDialect().build_expression_sql(
         TIME_DELTA(LITERAL(datetime(2020, 6, 20)), SqlExpressionStr("`ts`"), "hours", 2)
     )
-    assert sql == "CAST(FLOOR(TIMESTAMP_DIFF((`ts`), '2020-06-20T00:00:00', HOUR) / 2) AS INT)"
+    assert sql == "CAST(FLOOR(DATETIME_DIFF((`ts`), '2020-06-20T00:00:00', MICROSECOND) / 7200000000) AS INT)"
 
 
-def test_add_interval_renders_timestamp_add():
+def test_add_interval_renders_datetime_add():
     from datetime import datetime
 
     from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
@@ -263,13 +294,13 @@ def test_add_interval_renders_timestamp_add():
     sql = BigQuerySqlDialect().build_expression_sql(
         ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "days", SqlExpressionStr("(soda_partition__ + 1) * 1"))
     )
-    assert sql == "TIMESTAMP_ADD('2020-06-20T00:00:00', INTERVAL ((soda_partition__ + 1) * 1) DAY)"
+    assert sql == "DATETIME_ADD('2020-06-20T00:00:00', INTERVAL ((soda_partition__ + 1) * 1) DAY)"
 
 
 def test_add_interval_weeks_renders_as_days_times_seven():
-    # BigQuery TIMESTAMP functions accept only MICROSECOND..DAY parts (WEEK is a
-    # DATE_DIFF/DATETIME_DIFF-only part), so weekly intervals must be expressed
-    # as INTERVAL <count> * 7 DAY.
+    # Weekly arithmetic stays day-denominated (INTERVAL <count> * 7 DAY) even though
+    # DATETIME functions accept WEEK: the day form keeps the pinned cross-dialect
+    # bucket indexes identical.
     from datetime import datetime
 
     from soda_core.common.sql_ast import ADD_INTERVAL, LITERAL, SqlExpressionStr
@@ -277,7 +308,7 @@ def test_add_interval_weeks_renders_as_days_times_seven():
     sql = BigQuerySqlDialect().build_expression_sql(
         ADD_INTERVAL(LITERAL(datetime(2020, 6, 20)), "weeks", SqlExpressionStr("(soda_partition__ + 1) * 1"))
     )
-    assert sql == "TIMESTAMP_ADD('2020-06-20T00:00:00', INTERVAL ((soda_partition__ + 1) * 1) * 7 DAY)"
+    assert sql == "DATETIME_ADD('2020-06-20T00:00:00', INTERVAL ((soda_partition__ + 1) * 1) * 7 DAY)"
 
 
 # ---------------------------------------------------------------------------
@@ -367,9 +398,9 @@ def test_literal_string_none_returns_none():
 
 
 # ---------------------------------------------------------------------------
-# TIME_DELTA / ADD_INTERVAL — weekly arithmetic renders day-denominated:
-# BigQuery TIMESTAMP functions only accept MICROSECOND..DAY parts (WEEK is a
-# DATE_DIFF/DATETIME_DIFF-only part).
+# TIME_DELTA / ADD_INTERVAL — weekly arithmetic renders day-denominated
+# (INTERVAL <count> * 7 DAY / floor over 7·count days of microseconds),
+# keeping cross-dialect bucket indexes identical.
 # ---------------------------------------------------------------------------
 
 
@@ -382,7 +413,7 @@ def test_time_delta_weekly_buckets_render_day_denominated():
         TIME_DELTA(LITERAL(datetime(2020, 6, 1)), SqlExpressionStr("`ts`"), "weeks", 2)
     )
     assert "WEEK" not in sql
-    assert sql.endswith("DAY) / 14) AS INT)")
+    assert sql.endswith("MICROSECOND) / 1209600000000) AS INT)")
 
 
 def test_time_delta_single_week_still_floors_by_seven_days():
@@ -394,7 +425,7 @@ def test_time_delta_single_week_still_floors_by_seven_days():
         TIME_DELTA(LITERAL(datetime(2020, 6, 1)), SqlExpressionStr("`ts`"), "weeks", 1)
     )
     assert "WEEK" not in sql
-    assert sql.endswith("DAY) / 7) AS INT)")
+    assert sql.endswith("MICROSECOND) / 604800000000) AS INT)")
 
 
 def test_regex_like_pattern_goes_through_literal_string():


### PR DESCRIPTION
## Problem

The BigQuery dialect's `sql_expr_timestamp_coerce` hook wraps the partition expression in `timestamp(...)`. BigQuery only prunes partitions through a small set of functions on the partitioning column, and the `timestamp()` constructor is not one of them — the wrapped filter full-scans, and on tables with `require_partition_filter` the query is rejected with *"Cannot query over table ... without a filter over column(s) ... that can be used for partition elimination"*. This is the v4 port of the same defect fixed in v3 soda-library (sodadata/soda-library#790), where it was customer-reported. Two adjacent seams share the type problem: aware window bounds render with a UTC offset (which cannot coerce to a DATETIME column — the very reason the wrap existed), and the typed anchors/bucket arithmetic are TIMESTAMP-typed, so a DATETIME partition expression already fails inside `TIMESTAMP_DIFF`.

## Change

Compare everything in DATETIME. `sql_expr_timestamp_coerce` becomes `CAST(... AS DATETIME)` — the one conversion BigQuery accepts for partition elimination (verified against live BigQuery with dry-run byte estimates on a `require_partition_filter` table, nested casts included); it compiles for DATE, DATETIME and TIMESTAMP expressions alike and converts TIMESTAMP→DATETIME at UTC, preserving window semantics exactly.

Literals render **untyped**, offset-less, UTC: `literal_datetime` drops the offset (an offset-carrying string cannot coerce to DATETIME) and `literal_timestamp_typed` becomes an untyped string too — BigQuery coerces string literals inside `DATETIME_DIFF`/`DATETIME_ADD` and against raw TIMESTAMP or DATETIME columns alike, which keeps user-authored custom metric SQL (`col BETWEEN ${soda.PARTITION_START_TIME} ...` on TIMESTAMP columns) compiling unchanged; a typed `DATETIME` literal broke exactly that pattern in the v3 CI.

The time-bucket delta measures elapsed `MICROSECOND`s floor-divided by the unit size instead of `DATETIME_DIFF` at DAY/HOUR: those parts count *calendar-boundary crossings* (a 2-hour span across midnight counts as 1 DAY), which mis-buckets backfill grids anchored off midnight — confirmed with live constant queries and caught by the v3 2AM CI tests. The microsecond form matches the base dialect's `EXTRACT(EPOCH ...)` elapsed semantics; `ADD_INTERVAL` stays exact arithmetic on `DATETIME_ADD`.

**Pairs with** sodadata/soda-extensions#604, which routes the MM bulk builders through the coerce hook — with this change alone, an MM `TIME_DELTA` over a raw TIMESTAMP expression would stop compiling, so the two should land together.

## Testing

Dialect unit pins updated/added (coerce hook, offset stripping, untyped anchors, microsecond-based delta; written first and watched fail). SQL generated by the paired MM builders + this dialect validated against live BigQuery via dry runs: accepted on a `require_partition_filter` TIMESTAMP-partitioned table and pruned on DATE/TIMESTAMP partitions for regular scan, guard, freshness lookback, backfill CTE, and the profiling window filter with offset-carrying bounds. DIFF boundary-vs-elapsed semantics and untyped-string coercion confirmed with live constant queries. The v3 twin of this change passes the previously failing BigQuery CI suite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)