### PR TITLE
fix(databricks): enable Delta column mapping on tables Soda creates

### DIFF
--- a/soda-core/src/soda_core/common/sql_dialect.py
+++ b/soda-core/src/soda_core/common/sql_dialect.py
@@ -658,7 +658,15 @@ class SqlDialect:
             column_clauses.append(primary_key_clause)
 
         create_table_sql = create_table_sql + "(\n" + ",\n".join(column_clauses) + "\n)"
+        table_properties_sql: str = self._build_create_table_properties_sql()
+        if table_properties_sql:
+            create_table_sql = f"{create_table_sql} {table_properties_sql}"
         return create_table_sql + (";" if add_semicolon else "")
+
+    def _build_create_table_properties_sql(self) -> str:
+        """Dialect-specific table-level clauses, rendered after the column list in a CREATE TABLE
+        and before AS in a CTAS. Empty for every dialect that needs none."""
+        return ""
 
     def _create_table_with_primary_key_columns_not_null(
         self, create_table: CREATE_TABLE | CREATE_TABLE_IF_NOT_EXISTS
@@ -761,7 +769,11 @@ class SqlDialect:
         add_semicolon = self.apply_default_add_semicolon(add_semicolon)
         pre_parenthesis_sql: str = "(" if add_parenthesis else ""
         post_parenthesis_sql: str = ")" if add_parenthesis else ""
-        result_sql: str = f"CREATE TABLE {create_table_as_select.fully_qualified_table_name} AS "
+        table_properties_sql: str = self._build_create_table_properties_sql()
+        table_properties_prefix: str = f"{table_properties_sql} " if table_properties_sql else ""
+        result_sql: str = (
+            f"CREATE TABLE {create_table_as_select.fully_qualified_table_name} {table_properties_prefix}AS "
+        )
         result_sql += (
             f"{pre_parenthesis_sql}\n{self.build_select_sql(create_table_as_select.select_elements, add_semicolon=False)}{post_parenthesis_sql}"
             + (";" if add_semicolon else "")

--- a/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
+++ b/soda-databricks/src/soda_databricks/common/data_sources/databricks_data_source.py
@@ -98,6 +98,17 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
     # Databricks SQL rejects DROP TABLE ... CASCADE with PARSE_SYNTAX_ERROR
     # (CASCADE is valid on DROP SCHEMA only) — same as sparkdf/trino/athena.
     SUPPORTS_DROP_TABLE_CASCADE: bool = False
+    # Delta refuses to create a table whose column names contain one of " ,;{}()\n\t=" unless the
+    # table has column mapping enabled. Soda's diagnostics tables mirror source column names
+    # verbatim, so a dataset with a column like "First Name" made the whole failed-rows stage fail
+    # with DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES, even though the source table itself is
+    # readable (it has column mapping on). Every table Soda creates here declares it.
+    DELTA_TBLPROPERTIES: str = (
+        "TBLPROPERTIES ("
+        "'delta.columnMapping.mode' = 'name', "
+        "'delta.minReaderVersion' = '2', "
+        "'delta.minWriterVersion' = '5')"
+    )
 
     SODA_DATA_TYPE_SYNONYMS = (
         (SodaDataTypeName.TEXT, SodaDataTypeName.VARCHAR, SodaDataTypeName.CHAR),
@@ -409,6 +420,9 @@ class DatabricksSqlDialect(SqlDialect, sqlglot_dialect="databricks"):
 
     def _build_random_sql(self, random: RANDOM) -> str:
         return "RAND()"
+
+    def _build_create_table_properties_sql(self) -> str:
+        return self.DELTA_TBLPROPERTIES
 
 
 class DatabricksHiveSqlDialect(DatabricksSqlDialect, sqlglot_dialect="databricks"):

--- a/soda-databricks/tests/unit/test_databricks_dialect.py
+++ b/soda-databricks/tests/unit/test_databricks_dialect.py
@@ -1,7 +1,8 @@
 from datetime import date
 
 import pytest
-from soda_core.common.metadata_types import SodaDataTypeName
+from soda_core.common.metadata_types import SodaDataTypeName, SqlDataType
+from soda_core.common.sql_ast import CREATE_TABLE_AS_SELECT, CREATE_TABLE_COLUMN, CREATE_TABLE_IF_NOT_EXISTS
 from soda_core.common.sql_dialect import FROM, RANDOM, SELECT, STAR, SamplerType
 from soda_databricks.common.data_sources.databricks_data_source import DatabricksSqlDialect
 
@@ -196,3 +197,44 @@ def test_supports_percentile_within_group_is_true():
 
 def test_sql_expr_is_not_nan_renders_not_isnan():
     assert DatabricksSqlDialect().sql_expr_is_not_nan("`c`") == "NOT ISNAN(`c`)"
+
+
+def test_create_table_enables_delta_column_mapping():
+    """Delta rejects a column named "First Name" unless the table has column mapping enabled,
+    which is what broke the failed-rows stage for source datasets with spaces in column names."""
+    sql_dialect: DatabricksSqlDialect = DatabricksSqlDialect()
+
+    sql: str = sql_dialect.build_create_table_sql(
+        CREATE_TABLE_IF_NOT_EXISTS(
+            fully_qualified_table_name="`cat`.`sch`.`fr_x`",
+            columns=[CREATE_TABLE_COLUMN(name="First Name", type=SqlDataType(name="string"))],
+        )
+    )
+
+    assert sql == (
+        "CREATE TABLE IF NOT EXISTS `cat`.`sch`.`fr_x` (\n"
+        "\t`First Name` string\n"
+        ") TBLPROPERTIES ('delta.columnMapping.mode' = 'name', "
+        "'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5');"
+    )
+
+
+def test_create_table_as_select_enables_delta_column_mapping():
+    """TBLPROPERTIES has to land before AS, or Databricks fails to parse the statement."""
+    sql_dialect: DatabricksSqlDialect = DatabricksSqlDialect()
+
+    sql: str = sql_dialect.build_create_table_as_select_sql(
+        CREATE_TABLE_AS_SELECT(
+            fully_qualified_table_name="`cat`.`sch`.`fr_x`",
+            select_elements=[SELECT(STAR()), FROM("customers")],
+        )
+    )
+
+    assert sql == (
+        "CREATE TABLE `cat`.`sch`.`fr_x` TBLPROPERTIES ("
+        "'delta.columnMapping.mode' = 'name', "
+        "'delta.minReaderVersion' = '2', "
+        "'delta.minWriterVersion' = '5') AS (\n"
+        "SELECT *\n"
+        "FROM `customers`);"
+    )


### PR DESCRIPTION
Delta rejects `CREATE TABLE` when a column name contains one of ` ,;{}()\n\t=` unless the table has column mapping enabled. Our diagnostics tables mirror source column names verbatim, so the Linklaters dataset with columns like `First Name` fails the whole failed-rows stage with `DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES`. Their source table reads fine, it already has column mapping on. Quoting is not the issue, the SQL parses.

Reported here: https://sodadata.slack.com/archives/CAXRR8SS3/p1788538370535779

## Change

New `_build_create_table_properties_sql` hook on `SqlDialect`, rendered after the column list in `CREATE TABLE` and before `AS` in a CTAS. Both paths create diagnostics tables. Empty by default, Databricks returns the TBLPROPERTIES that turn column mapping on.

## Always, not only when needed

Every table we create on Databricks gets column mapping, so no dataset can slip through later.

The alternative was emitting the properties only when a column name actually contains a restricted character, to leave every other table on its current Delta protocol version. @Niels-b measured that on the CI workspace and the premise was wrong: a table created with no table properties at all is already reader 3 / writer 7, because that runtime represents Delta features as table features rather than the legacy monolithic versions. The `TBLPROPERTIES` here adds the columnMapping feature and bumps no protocol, so there is no older-client risk to be conservative about. His caveat stands, one workspace and one runtime, and the 3/7 default comes from DBR plus catalog defaults rather than a guarantee.

The `minReaderVersion` 2 / `minWriterVersion` 5 pair is a floor, not an exact value. It is a no-op on a table-features runtime and only does work on an older DBR where column mapping needs it declared. Keeping it as a defensive shim.

Two more, out of scope here:

- `DatabricksHiveSqlDialect` inherits the properties. On a hive_metastore warehouse that defaults to a non-Delta provider the `delta.*` properties would land on a non-Delta table. Neither of us has one to test against.
- `drop_column_supported` returns `False` with a note that it needs column mapping mode. New tables qualify once this lands.

## Tests

Unit tests for both SQL paths, full unit suite green.

Verified live on Databricks by @Niels-b in both DDL modes, `CREATE TABLE` and in-source-transfer CTAS, along with `INSERT`, `ALTER TABLE ADD COLUMN` with a restricted-character name, `CREATE VIEW` + select, and the metadata query returning every name intact. The regression test covering every DWH object family is sodadata/soda-extensions#605, which merges after this.

### 📣 Customer-facing release note

```customer-facing-release-note
Failed rows are now stored on Databricks for datasets whose column names contain spaces or other characters Delta restricts.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xsqPCEQpGnYcsnQD9sysw
