### PR TITLE
fix(failed_rows): coerce rows_tested_query result to an int row count

### DIFF
--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -418,6 +418,6 @@ class RowsTestedQuery(Query):
                 f"Could not read a row count from the rows tested query: expected a number, got "
                 f"{type(value).__name__} {value!r}. Use a query that returns a single count, for "
                 f"example 'SELECT COUNT(*) FROM (<your query>)'. Continuing without "
-                f"check_rows_tested.\n{self.sql}"
+                f"check_rows_tested.\nExecuted SQL:\n{self.sql}"
             )
             return None

--- a/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
+++ b/soda-core/src/soda_core/contracts/impl/check_types/failed_rows_check.py
@@ -391,6 +391,33 @@ class RowsTestedQuery(Query):
         if not query_result.rows:
             metric_value = None
         else:
-            metric_value = query_result.rows[0][0]
+            metric_value = self._to_row_count(query_result.rows[0][0])
         metric_impl: MetricImpl = self.metrics[0]
         return [Measurement(metric_id=metric_impl.id, value=metric_value, metric_name=metric_impl.type)]
+
+    def _to_row_count(self, value: any) -> Optional[int]:
+        """Coerce the first cell of the rows_tested_query result to an int row count.
+
+        This value reaches Soda Cloud as ``checkRowsTested``, which the API types as an
+        integer. A non-numeric value is rejected at JSON-parse time, which fails the whole
+        ``sodaCoreInsertScanResults`` body: every check result and every log line of that
+        scan is lost, not just this check's. Writing a rows_tested_query that selects rows
+        instead of a count is an easy mistake to make (SCS-1439), so reject the value here
+        and carry on with check_rows_tested unmeasured, exactly as for a query returning
+        NULL. The check itself still evaluates on failed_rows_count.
+
+        Note the metric never passes through ``convert_db_value``: RowsTestedQuery builds
+        its Measurement directly rather than going through the aggregation-metric path.
+        """
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            logger.error(
+                f"Could not read a row count from the rows tested query: expected a number, got "
+                f"{type(value).__name__} {value!r}. Use a query that returns a single count, for "
+                f"example 'SELECT COUNT(*) FROM (<your query>)'. Continuing without "
+                f"check_rows_tested.\n{self.sql}"
+            )
+            return None

--- a/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
+++ b/soda-tests/tests/integration/test_failed_rows_rows_tested_query.py
@@ -281,6 +281,62 @@ def test_failed_rows_rows_tested_query_returns_null(data_source_test_helper: Dat
     assert "checkRowsTested" not in v4
 
 
+def test_failed_rows_rows_tested_query_returning_non_numeric_is_rejected(
+    data_source_test_helper: DataSourceTestHelper,
+):
+    """A rows_tested_query that returns rows instead of a count must not poison the upload.
+
+    SCS-1439: the first cell went onto the wire verbatim as checkRowsTested, which Soda
+    Cloud types as an integer, so a text value failed the JSON parse of the whole
+    sodaCoreInsertScanResults body. The scan lost every check result and every log line,
+    and the launcher exited 4. The value must be dropped here instead, with an error
+    naming the fix, and the rest of the payload must survive.
+    """
+    test_table = data_source_test_helper.ensure_test_table(test_table_specification)
+
+    end_quoted = data_source_test_helper.quote_column("end")
+    start_quoted = data_source_test_helper.quote_column("start")
+
+    data_source_test_helper.enable_soda_cloud_mock(
+        [
+            MockResponse(status_code=200, json_object={"fileId": "a81bc81b-dead-4e5d-abff-90865d1e13b1"}),
+        ]
+    )
+
+    data_source_test_helper.assert_contract_fail(
+        test_table=test_table,
+        contract_yaml_str=f"""
+            checks:
+              - failed_rows:
+                  query: |
+                    SELECT *
+                    FROM {test_table.qualified_name}
+                    WHERE ({end_quoted} - {start_quoted}) > 5
+                  rows_tested_query: |
+                    {data_source_test_helper.select_literal_query("'YARDI_EMEA_SCHRODERS'")}
+        """,
+    )
+
+    soda_core_insert_scan_results_command = data_source_test_helper.soda_cloud.requests[1].json
+    check_json: dict = soda_core_insert_scan_results_command["checks"][0]
+
+    # The text value is dropped, and the check still evaluates on failed_rows_count.
+    # failedRowsPercent is 0 because rows-tested is unknown, same as the NULL path above.
+    assert check_json["diagnostics"]["v4"] == {
+        "type": "failed_rows",
+        "failedRowsCount": 2,
+        "failedRowsPercent": 0,
+        "datasetRowsTested": 3,
+    }
+    assert check_json["outcome"] == "fail"
+
+    error_messages = [
+        log["message"] for log in soda_core_insert_scan_results_command["logs"] if log["level"] == "error"
+    ]
+    assert any("Could not read a row count from the rows tested query" in m for m in error_messages)
+    assert any("SELECT COUNT(*)" in m for m in error_messages)
+
+
 def test_failed_rows_rows_tested_query_does_not_leak_to_other_checks(
     data_source_test_helper: DataSourceTestHelper,
 ):


### PR DESCRIPTION
## What

A `failed_rows` check's `rows_tested_query` result is now coerced to an int before it becomes the `check_rows_tested` measurement. A value that is not a number is dropped, with an error naming the fix, and the check carries on unmeasured.

## Why

`RowsTestedQuery.execute()` took `query_result.rows[0][0]` verbatim. If the query returns rows rather than a count, that first cell can be anything, and it reached Soda Cloud as `checkRowsTested`. The API types that field as an integer, so a text value failed the JSON parse of the **whole** `sodaCoreInsertScanResults` body:

```
Status Code: 400
Message: 'Could not parse request from json body' | Response Code: 'invalid_request'
```

Because the rejection happens at body-parse time, the blast radius is the entire scan rather than the one bad check:

- no check results and no logs in the Soda Cloud UI
- failed-rows extraction skipped, `Skipping failed rows extraction: No soda cloud response available`
- launcher exits 4

And nothing in the engine output pointed at the field. The only clue was the printed summary table:

```
failed_rows_count:   9918
failed_rows_percent: 0
dataset_rows_tested: 463455012
check_rows_tested:   YARDI_EMEA_SCHRODERS     <-- a string
```

The value never passed through `convert_db_value`, because `RowsTestedQuery` builds its `Measurement` directly instead of going down the aggregation-metric path that applies it.

Found on a support ticket where the customer's `rows_tested_query` was missing its `select count(*) from ( ... )` wrapper, so it returned the query's rows and the first column was `SOURCEDB`.

## Behaviour change

A non-numeric `rows_tested_query` result used to kill the scan. It now logs a runtime error and leaves `check_rows_tested` unmeasured, which is the same shape the code already produces for a query returning NULL. `failedRowsPercent` is 0 and the check still evaluates on `failed_rows_count`. The scan reports one runtime error instead of vanishing.

`int()` truncation is deliberate: a row count is integral, and `Decimal`/`float` counts from a warehouse should land as ints.

## Test

`test_failed_rows_rows_tested_query_returning_non_numeric_is_rejected` pins the whole chain: the text value never reaches the wire, the rest of the diagnostics survive, the check still fails on its own count, and the error tells the user to wrap the query in `SELECT COUNT(*)`.

## Follow-ups, not in this PR

- Nothing stops a future non-numeric value from any other check type reaching a numeric field in `diagnostics.v4` and taking down a scan the same way. A wire-level type guard in `_build_v4_diagnostics_check_type_json_dict` would close that off, but it touches every check type and deserves its own review.
- `datasetRowsTested` is an `Integer` on the Cloud side. The customer that hit this is already at 463,809,660 rows, so a dataset past 2.1B rows produces the identical 400.

### 📣 Customer-facing release note

```customer-facing-release-note
A `rows_tested_query` returning a non-numeric value no longer fails the whole scan.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmhr4oTPpTjrsvFKC7FRvK
